### PR TITLE
Bumped iOS version, fixed icon scaling

### DIFF
--- a/src/SSW.Rewards/Platforms/iOS/Info.plist
+++ b/src/SSW.Rewards/Platforms/iOS/Info.plist
@@ -26,7 +26,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scan QR codes to earn points</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>5</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.2.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/src/SSW.Rewards/SSW.Rewards.Mobile.csproj
+++ b/src/SSW.Rewards/SSW.Rewards.Mobile.csproj
@@ -43,7 +43,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\icon_dark.png" Color="#f5f5f5" BaseSize="1024,1024" ForegroundScale="0.67" />
+		<MauiIcon Include="Resources\AppIcon\icon_dark.png" Color="#f5f5f5" BaseSize="1024,1024" />
 
 		<!-- Splash Screen -->
 		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#29282d" BaseSize="228,128" />

--- a/src/SSW.Rewards/SSW.Rewards.sln
+++ b/src/SSW.Rewards/SSW.Rewards.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SSW.Rewards.Mobile", "SSW.Rewards.Mobile.csproj", "{01CBA69A-B367-4B56-B298-164A98E74C90}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{01CBA69A-B367-4B56-B298-164A98E74C90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01CBA69A-B367-4B56-B298-164A98E74C90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01CBA69A-B367-4B56-B298-164A98E74C90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01CBA69A-B367-4B56-B298-164A98E74C90}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B50CB2A5-BF6F-4814-97F3-23EA59C6B97C}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Reason for change
Two major issues identified with the last version sent to TestFlight:

* Incorrect icon scaling
* App crashes at startup
