### PR TITLE
Convert snackbar to MCT popup

### DIFF
--- a/src/SSW.Rewards/Controls/Snackbar.xaml
+++ b/src/SSW.Rewards/Controls/Snackbar.xaml
@@ -1,71 +1,72 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="SSW.Rewards.Mobile.Controls.Snackbar">
-  <ContentView.Content>
-        <Border StrokeShape="RoundRectangle 3"
-                StrokeThickness="0"
+<mct:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+           xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+           xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+           x:Class="SSW.Rewards.Mobile.Controls.Snackbar"
+           VerticalOptions="End">
+  
+    <Border StrokeShape="RoundRectangle 3"
+            StrokeThickness="0"
+            WidthRequest="300"
+            x:Name="GridBackground"
+            Opacity="0"
+            TranslationY="50">
+        <Grid x:Name="MainLayout"
+                HorizontalOptions="CenterAndExpand"
+                Margin="5"
+                Padding="5"
                 WidthRequest="300"
-                x:Name="GridBackground"
-                Opacity="0"
-                TranslationY="50">
-            <Grid x:Name="MainLayout"
-                  HorizontalOptions="CenterAndExpand"
-                  Margin="5"
-                  Padding="5"
-                  WidthRequest="300"
-                  ColumnDefinitions="50, *, Auto">
+                ColumnDefinitions="50, *, Auto">
 
-                <!-- Glyph Icon-->
-                <Label Grid.Column="0"
-                       Grid.ColumnSpan="2"
-                       x:Name="GlyphIconLabel"
-                       FontSize="30"
-                       FontFamily="FluentIcons"
-                       HeightRequest="40"
-                       WidthRequest="40"
-                       Margin="10,0"
-                       HorizontalOptions="Start"
-                       VerticalOptions="Center"
-                       VerticalTextAlignment="Center"
-                       HorizontalTextAlignment="Center">
-                    <Label.Clip>
-                        <EllipseGeometry Center="20,20"
-                                     RadiusX="20"
-                                     RadiusY="20"/>
-                    </Label.Clip>
-                </Label>
+            <!-- Glyph Icon-->
+            <Label Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    x:Name="GlyphIconLabel"
+                    FontSize="30"
+                    FontFamily="FluentIcons"
+                    HeightRequest="40"
+                    WidthRequest="40"
+                    Margin="10,0"
+                    HorizontalOptions="Start"
+                    VerticalOptions="Center"
+                    VerticalTextAlignment="Center"
+                    HorizontalTextAlignment="Center">
+                <Label.Clip>
+                    <EllipseGeometry Center="20,20"
+                                    RadiusX="20"
+                                    RadiusY="20"/>
+                </Label.Clip>
+            </Label>
 
-                <!-- Main message or action-->
-                <Label Grid.Column="1" 
-                       Margin="10,0"
-                       FontSize="Small"
-                       VerticalOptions="Center"
-                       HorizontalOptions="Center"
-                       BackgroundColor="Transparent"
-                       TextColor="White"
-                       x:Name="MessageLabel"/>
+            <!-- Main message or action-->
+            <Label Grid.Column="1" 
+                    Margin="10,0"
+                    FontSize="Small"
+                    VerticalOptions="Center"
+                    HorizontalOptions="Center"
+                    BackgroundColor="Transparent"
+                    TextColor="White"
+                    x:Name="MessageLabel"/>
 
-                <!-- End icon-->
-                <Label Grid.Column="2"
-                       TextColor="White"
-                       Text="&#xf293;"
-                       FontFamily="FluentIcons"
-                       HorizontalOptions="Center"
-                       VerticalOptions="Center"
-                       HorizontalTextAlignment="Center"
-                       x:Name="TickLabel"/>
+            <!-- End icon-->
+            <Label Grid.Column="2"
+                    TextColor="White"
+                    Text="&#xf293;"
+                    FontFamily="FluentIcons"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    x:Name="TickLabel"/>
 
-                <!--End points coint-->
-                <Label Grid.Column="1"
-                       Grid.ColumnSpan="2"
-                       x:Name="PointsLabel"
-                       FontSize="11"
-                       HorizontalOptions="End"
-                       VerticalOptions="Center"
-                       Margin="0,0,10,0"
-                       TextColor="White"/>
-            </Grid>
-        </Border>
-  </ContentView.Content>
-</ContentView>
+            <!--End points coint-->
+            <Label Grid.Column="1"
+                    Grid.ColumnSpan="2"
+                    x:Name="PointsLabel"
+                    FontSize="11"
+                    HorizontalOptions="End"
+                    VerticalOptions="Center"
+                    Margin="0,0,10,0"
+                    TextColor="White"/>
+        </Grid>
+    </Border>
+</mct:Popup>

--- a/src/SSW.Rewards/Controls/Snackbar.xaml
+++ b/src/SSW.Rewards/Controls/Snackbar.xaml
@@ -3,70 +3,69 @@
            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
            xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
            x:Class="SSW.Rewards.Mobile.Controls.Snackbar"
-           VerticalOptions="End">
+           VerticalOptions="End"
+           Color="Transparent">
   
     <Border StrokeShape="RoundRectangle 3"
             StrokeThickness="0"
             WidthRequest="300"
-            x:Name="GridBackground"
-            Opacity="0"
-            TranslationY="50">
+            x:Name="GridBackground">
         <Grid x:Name="MainLayout"
-                HorizontalOptions="CenterAndExpand"
-                Margin="5"
-                Padding="5"
-                WidthRequest="300"
-                ColumnDefinitions="50, *, Auto">
+              HorizontalOptions="CenterAndExpand"
+              Margin="5"
+              Padding="5"
+              WidthRequest="300"
+              ColumnDefinitions="50, *, Auto">
 
             <!-- Glyph Icon-->
             <Label Grid.Column="0"
-                    Grid.ColumnSpan="2"
-                    x:Name="GlyphIconLabel"
-                    FontSize="30"
-                    FontFamily="FluentIcons"
-                    HeightRequest="40"
-                    WidthRequest="40"
-                    Margin="10,0"
-                    HorizontalOptions="Start"
-                    VerticalOptions="Center"
-                    VerticalTextAlignment="Center"
-                    HorizontalTextAlignment="Center">
+                   Grid.ColumnSpan="2"
+                   x:Name="GlyphIconLabel"
+                   FontSize="30"
+                   FontFamily="FluentIcons"
+                   HeightRequest="40"
+                   WidthRequest="40"
+                   Margin="10,0"
+                   HorizontalOptions="Start"
+                   VerticalOptions="Center"
+                   VerticalTextAlignment="Center"
+                   HorizontalTextAlignment="Center">
                 <Label.Clip>
                     <EllipseGeometry Center="20,20"
-                                    RadiusX="20"
-                                    RadiusY="20"/>
+                                     RadiusX="20"
+                                     RadiusY="20"/>
                 </Label.Clip>
             </Label>
 
             <!-- Main message or action-->
             <Label Grid.Column="1" 
-                    Margin="10,0"
-                    FontSize="Small"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    BackgroundColor="Transparent"
-                    TextColor="White"
-                    x:Name="MessageLabel"/>
+                   Margin="10,0"
+                   FontSize="Small"
+                   VerticalOptions="Center"
+                   HorizontalOptions="Center"
+                   BackgroundColor="Transparent"
+                   TextColor="White"
+                   x:Name="MessageLabel"/>
 
             <!-- End icon-->
             <Label Grid.Column="2"
-                    TextColor="White"
-                    Text="&#xf293;"
-                    FontFamily="FluentIcons"
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    HorizontalTextAlignment="Center"
-                    x:Name="TickLabel"/>
+                   TextColor="White"
+                   Text="&#xf293;"
+                   FontFamily="FluentIcons"
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center"
+                   HorizontalTextAlignment="Center"
+                   x:Name="TickLabel"/>
 
             <!--End points coint-->
             <Label Grid.Column="1"
-                    Grid.ColumnSpan="2"
-                    x:Name="PointsLabel"
-                    FontSize="11"
-                    HorizontalOptions="End"
-                    VerticalOptions="Center"
-                    Margin="0,0,10,0"
-                    TextColor="White"/>
+                   Grid.ColumnSpan="2"
+                   x:Name="PointsLabel"
+                   FontSize="11"
+                   HorizontalOptions="End"
+                   VerticalOptions="Center"
+                   Margin="0,0,10,0"
+                   TextColor="White"/>
         </Grid>
     </Border>
 </mct:Popup>

--- a/src/SSW.Rewards/Controls/Snackbar.xaml.cs
+++ b/src/SSW.Rewards/Controls/Snackbar.xaml.cs
@@ -14,6 +14,8 @@ namespace SSW.Rewards.Mobile.Controls
             ShowPoints = false
         };
 
+        private bool _isDismissed = false;
+
         public Snackbar(SnackbarOptions? options = null)
         {
             InitializeComponent();
@@ -57,6 +59,24 @@ namespace SSW.Rewards.Mobile.Controls
             TickLabel.IsVisible = !options.ShowPoints && options.ActionCompleted;
             PointsLabel.IsVisible = options.ShowPoints;
             PointsLabel.Text = string.Format("⭐ {0:n0}", options.Points);
+
+            _ = SetDismissTimer();
+        }
+
+        private async Task SetDismissTimer()
+        {
+            await Task.Delay(5000);
+
+            if (!_isDismissed)
+            {
+                this.Close();
+            }
+        }
+
+        protected override Task OnDismissedByTappingOutsideOfPopup()
+        {
+            _isDismissed = true;
+            return base.OnDismissedByTappingOutsideOfPopup();
         }
     }
 

--- a/src/SSW.Rewards/Controls/Snackbar.xaml.cs
+++ b/src/SSW.Rewards/Controls/Snackbar.xaml.cs
@@ -1,14 +1,9 @@
-﻿namespace SSW.Rewards.Mobile.Controls
-{
-    public partial class Snackbar : ContentView
-    {
-        public static readonly BindableProperty OptionsProperty = BindableProperty.Create(nameof(Options), typeof(SnackbarOptions), typeof(Snackbar), DefaultOptions, propertyChanged: OptionsChanged);
-        public SnackbarOptions Options
-        {
-            get => (SnackbarOptions)GetValue(OptionsProperty);
-            set => SetValue(OptionsProperty, value);
-        }
+﻿using CommunityToolkit.Maui.Views;
 
+namespace SSW.Rewards.Mobile.Controls
+{
+    public partial class Snackbar : Popup
+    {
         private static SnackbarOptions DefaultOptions = new SnackbarOptions
         {
             ActionCompleted = true,
@@ -19,65 +14,49 @@
             ShowPoints = false
         };
 
-        public Snackbar()
+        public Snackbar(SnackbarOptions? options = null)
         {
             InitializeComponent();
+
+            SetOptions(options);
         }
 
-        private static void OptionsChanged(BindableObject bindable, object oldVal, object newVal)
+        private void SetOptions(SnackbarOptions options)
         {
-            var snack = (Snackbar)bindable;
-
-            var opt = (SnackbarOptions)newVal;
-
-            if (opt.ActionCompleted)
+            if (options == null)
             {
-                snack.GridBackground.BackgroundColor = Color.FromArgb("cc4141");
-                snack.GlyphIconLabel.BackgroundColor = Colors.White;
-                snack.GlyphIconLabel.TextColor = Color.FromArgb("cc4141");
+                options = DefaultOptions;
+            }
+
+            if (options.ActionCompleted)
+            {
+                GridBackground.BackgroundColor = Color.FromArgb("cc4141");
+                GlyphIconLabel.BackgroundColor = Colors.White;
+                GlyphIconLabel.TextColor = Color.FromArgb("cc4141");
             }
             else
             {
-                snack.GridBackground.BackgroundColor = Color.FromArgb("717171");
-                snack.GlyphIconLabel.TextColor = Colors.White;
-                snack.GlyphIconLabel.BackgroundColor = Color.FromArgb("414141");
+                GridBackground.BackgroundColor = Color.FromArgb("717171");
+                GlyphIconLabel.TextColor = Colors.White;
+                GlyphIconLabel.BackgroundColor = Color.FromArgb("414141");
             }
-            
 
-            snack.GlyphIconLabel.Text = opt.Glyph;
-            
-            if (opt.GlyphIsBrand)
+
+            GlyphIconLabel.Text = options.Glyph;
+
+            if (options.GlyphIsBrand)
             {
-                snack.GlyphIconLabel.FontFamily = "FA6Brands";
+                GlyphIconLabel.FontFamily = "FA6Brands";
             }
             else
             {
-                snack.GlyphIconLabel.FontFamily = "FluentIcons";
+                GlyphIconLabel.FontFamily = "FluentIcons";
             }
 
-            snack.MessageLabel.Text = opt.Message;
-            snack.TickLabel.IsVisible = !opt.ShowPoints && opt.ActionCompleted;
-            snack.PointsLabel.IsVisible = opt.ShowPoints;
-            snack.PointsLabel.Text = string.Format("⭐ {0:n0}", opt.Points);
-        }
-
-        private bool _isShowing = false;
-
-        public async Task ShowSnackbar()
-        {
-            if (!_isShowing)
-            {
-                _isShowing = true;
-                GridBackground.InputTransparent = false;
-                GridBackground.FadeTo(1, 750);
-                GridBackground.TranslateTo(0, 0, 750);
-
-                await Task.Delay(5000);
-                GridBackground.FadeTo(0, 750);
-                GridBackground.TranslateTo(0, 50, 750);
-                GridBackground.InputTransparent = true;
-                _isShowing = false;
-            }
+            MessageLabel.Text = options.Message;
+            TickLabel.IsVisible = !options.ShowPoints && options.ActionCompleted;
+            PointsLabel.IsVisible = options.ShowPoints;
+            PointsLabel.Text = string.Format("⭐ {0:n0}", options.Points);
         }
     }
 
@@ -94,10 +73,5 @@
         public int Points { get; set; }
 
         public bool ShowPoints { get; set; }
-    }
-
-    public class ShowSnackbarEventArgs : EventArgs
-    {
-        public SnackbarOptions Options { get; set; }
     }
 }

--- a/src/SSW.Rewards/GlobalUsings.cs
+++ b/src/SSW.Rewards/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using SSW.Rewards.Services;
+﻿global using SSW.Rewards.Mobile.Services;
 global using SSW.Rewards.Mobile.ViewModels;
 global using SSW.Rewards.Mobile;
 global using SSW.Rewards.Models;

--- a/src/SSW.Rewards/MauiProgram.cs
+++ b/src/SSW.Rewards/MauiProgram.cs
@@ -1,16 +1,15 @@
-﻿using System.Reflection;
-using IBrowser = IdentityModel.OidcClient.Browser.IBrowser;
-using CommunityToolkit.Maui;
-using Mopups.Hosting;
-using SkiaSharp.Views.Maui.Controls.Hosting;
-using ZXing.Net.Maui.Controls;
-using SSW.Rewards.Mobile.Controls;
+﻿using CommunityToolkit.Maui;
 using FFImageLoading.Maui;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Mopups.Hosting;
+using SkiaSharp.Views.Maui.Controls.Hosting;
+using SSW.Rewards.Mobile.Controls;
+using System.Reflection;
+using ZXing.Net.Maui.Controls;
+using IBrowser = IdentityModel.OidcClient.Browser.IBrowser;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 namespace SSW.Rewards.Mobile;
@@ -59,6 +58,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IBrowser, AuthBrowser>();
         builder.Services.AddSingleton<AuthHandler>();
         builder.Services.AddSingleton(options);
+        builder.Services.AddSingleton<ISnackbarService, SnackBarService>();
 
         builder.Services.AddSingleton<FlyoutHeader>();
         builder.Services.AddSingleton<FlyoutHeaderViewModel>();

--- a/src/SSW.Rewards/Pages/PeoplePage.xaml
+++ b/src/SSW.Rewards/Pages/PeoplePage.xaml
@@ -246,15 +246,6 @@
                                Grid.ColumnSpan="3"
                                Grid.RowSpan="4"
                                IsVisible="{Binding IsRunning}"/>
-
-            <controls:Snackbar Grid.Row="0"
-                               Grid.RowSpan="4"
-                               Grid.Column="0"
-                               Grid.ColumnSpan="3"
-                               Options="{Binding SnackOptions}"
-                               InputTransparent="True"
-                               VerticalOptions="End" 
-                               x:Name="PeoplePageSnackbar"/>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/SSW.Rewards/Pages/PeoplePage.xaml.cs
+++ b/src/SSW.Rewards/Pages/PeoplePage.xaml.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Maui.Controls;
-using SSW.Rewards.Mobile.Controls;
-
-namespace SSW.Rewards.Mobile.Pages;
+﻿namespace SSW.Rewards.Mobile.Pages;
 
 public partial class PeoplePage : ContentPage
 {
@@ -21,7 +18,6 @@ public partial class PeoplePage : ContentPage
 
         _viewModel.PageInView = true;
         _viewModel.ScrollToRequested += ScrollToIndex;
-        _viewModel.ShowSnackbar += ShowSnackbar;
         await _viewModel.Initialise();
     }
 
@@ -30,17 +26,10 @@ public partial class PeoplePage : ContentPage
         base.OnDisappearing();
         _viewModel.PageInView = false;
         _viewModel.ScrollToRequested -= ScrollToIndex;
-        _viewModel.ShowSnackbar -= ShowSnackbar;
     }
 
     private void ScrollToIndex(object sender, ScrollToEventArgs e)
     {
         PicCarousel.ScrollTo(e.Index, -1, e.Position, e.Animate);
-    }
-
-    private async void ShowSnackbar(object sender, ShowSnackbarEventArgs e)
-    {
-        PeoplePageSnackbar.Options = e.Options;
-        await PeoplePageSnackbar.ShowSnackbar();
     }
 }

--- a/src/SSW.Rewards/Pages/ProfilePage.xaml
+++ b/src/SSW.Rewards/Pages/ProfilePage.xaml
@@ -74,12 +74,5 @@
                            Color="{StaticResource primary}"
                            IsVisible="{Binding IsLoading}"/>
 
-        <controls:Snackbar Grid.Row="0"
-                           Grid.RowSpan="4"
-                           Options="{Binding SnackOptions}"
-                           InputTransparent="True"
-                           VerticalOptions="End" 
-                           x:Name="ProfilePageSnackbar"/>
-
     </Grid>
 </ContentPage>

--- a/src/SSW.Rewards/Pages/ProfilePage.xaml.cs
+++ b/src/SSW.Rewards/Pages/ProfilePage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using SSW.Rewards.Mobile.Controls;
-
-namespace SSW.Rewards.Mobile.Pages;
+﻿namespace SSW.Rewards.Mobile.Pages;
 
 public partial class ProfilePage : ContentPage
 {
@@ -21,11 +19,11 @@ public partial class ProfilePage : ContentPage
         _isMe = true;
     }
 
-    public ProfilePage(IRewardService rewardsService, IUserService userService, LeaderViewModel leader)
+    public ProfilePage(IRewardService rewardsService, IUserService userService, ISnackbarService snackbarService, LeaderViewModel leader)
     {
         InitializeComponent();
-        // HACK: Need to find a better way to handle these two differnt constructors
-        viewModel = new ProfileViewModel(rewardsService, userService, leader);
+        // HACK: Need to find a better way to handle these two different constructors
+        viewModel = new ProfileViewModel(rewardsService, userService, snackbarService, leader);
         viewModel.Navigation = Navigation;
         BindingContext = viewModel;
 
@@ -43,20 +41,12 @@ public partial class ProfilePage : ContentPage
         {
             await viewModel.Initialise(_isMe);
         }
-        viewModel.ShowSnackbar += ShowSnackbar;
         _initialised = true;
-    }
-
-    private async void ShowSnackbar(object sender, ShowSnackbarEventArgs e)
-    {
-        ProfilePageSnackbar.Options = e.Options;
-        await ProfilePageSnackbar.ShowSnackbar();
     }
 
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
-        //viewModel.ShowSnackbar -= ShowSnackbar;
         viewModel.OnDisappearing();
     }
 }

--- a/src/SSW.Rewards/Pages/QuizDetailsPage.xaml
+++ b/src/SSW.Rewards/Pages/QuizDetailsPage.xaml
@@ -2,7 +2,6 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:converters="clr-namespace:SSW.Rewards.Mobile.Converters"
-             xmlns:controls="clr-namespace:SSW.Rewards.Mobile.Controls"
              xmlns:lottie="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
              xmlns:viewModels="clr-namespace:SSW.Rewards.Mobile.ViewModels"
              xmlns:rewards="clr-namespace:SSW.Rewards"
@@ -192,7 +191,7 @@
                                InputTransparent="True"/>
                     </Frame>
 
-                    <FlexLayout WidthRequest="400"
+                <FlexLayout WidthRequest="400"
                                 Direction="Row"
                                 JustifyContent="SpaceEvenly"
                                 HorizontalOptions="Center"
@@ -200,9 +199,9 @@
                                 Grid.Row="4"
                                 IsVisible="{Binding TestPassed, Converter={StaticResource InverseBool}}"
                                 BindableLayout.ItemsSource="{Binding Results}">
-                        <BindableLayout.ItemTemplate>
-                            <DataTemplate x:DataType="rewards:QuestionResultDto">
-                                <Grid>
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="rewards:QuestionResultDto">
+                            <Grid>
 
                                 <lottie:SKLottieView Source="pass.json"
                                                           IsAnimationEnabled="True"
@@ -217,17 +216,11 @@
                                                           IsVisible="{Binding Correct, Converter={StaticResource InverseBool}}"/>
 
                             </Grid>
-                            </DataTemplate>
-                        </BindableLayout.ItemTemplate>
-                    </FlexLayout>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </FlexLayout>
 
-                    <controls:Snackbar Grid.Row="0"
-                                       Grid.RowSpan="5"
-                                       InputTransparent="True"
-                                       VerticalOptions="End" 
-                                       x:Name="QuizResultsPageSnackbar"/>
-                    
-                </Grid>
             </Grid>
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/SSW.Rewards/Pages/QuizDetailsPage.xaml.cs
+++ b/src/SSW.Rewards/Pages/QuizDetailsPage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using SSW.Rewards.Mobile.Controls;
-
-namespace SSW.Rewards.Mobile.Pages;
+﻿namespace SSW.Rewards.Mobile.Pages;
 
 [QueryProperty(nameof(QuizId), nameof(QuizId))]
 [QueryProperty(nameof(QuizIcon), nameof(QuizIcon))]
@@ -27,7 +25,6 @@ public partial class QuizDetailsPage : ContentPage
 
         await _viewModel.Initialise(quizId, QuizIcon);
         _viewModel.OnNextQuestionRequested += ScrollToIndex;
-        _viewModel.ShowSnackbar += ShowSnackbar;
     }
 
     private void ScrollToIndex(object sender, int index)
@@ -39,12 +36,6 @@ public partial class QuizDetailsPage : ContentPage
     {
         base.OnDisappearing();
         _viewModel.OnNextQuestionRequested -= ScrollToIndex;
-    }
-
-    private async void ShowSnackbar(object sender, ShowSnackbarEventArgs e)
-    {
-        QuizResultsPageSnackbar.Options = e.Options;
-        await QuizResultsPageSnackbar.ShowSnackbar();
     }
 
     protected override void OnSizeAllocated(double width, double height)

--- a/src/SSW.Rewards/SSW.Rewards.Mobile.csproj
+++ b/src/SSW.Rewards/SSW.Rewards.Mobile.csproj
@@ -68,7 +68,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="5.2.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="6.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="Goldie.MauiPlugins.PageResolver" Version="1.1.1" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />

--- a/src/SSW.Rewards/Services/ApiBaseService.cs
+++ b/src/SSW.Rewards/Services/ApiBaseService.cs
@@ -1,14 +1,14 @@
 ﻿using SSW.Rewards.Mobile.Helpers;
 
-namespace SSW.Rewards.Services;
+namespace SSW.Rewards.Mobile.Services;
 
-public class BaseService
+public class ApiBaseService
 {
     protected static HttpClient AuthenticatedClient;
 
     protected readonly string BaseUrl;
 
-    public BaseService(IHttpClientFactory clientFactory, ApiOptions options)
+    public ApiBaseService(IHttpClientFactory clientFactory, ApiOptions options)
     {
         if (AuthenticatedClient is null) AuthenticatedClient = clientFactory.CreateClient(AuthHandler.AuthenticatedClient);
         BaseUrl = options.BaseUrl;

--- a/src/SSW.Rewards/Services/DevService.cs
+++ b/src/SSW.Rewards/Services/DevService.cs
@@ -1,6 +1,6 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
-public class DevService : BaseService, IDevService
+public class DevService : ApiBaseService, IDevService
 {
     private StaffClient _staffClient;
 

--- a/src/SSW.Rewards/Services/IDevService.cs
+++ b/src/SSW.Rewards/Services/IDevService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IDevService
 {

--- a/src/SSW.Rewards/Services/IDeviceInstallationService.cs
+++ b/src/SSW.Rewards/Services/IDeviceInstallationService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IDeviceInstallationService
 {

--- a/src/SSW.Rewards/Services/ILeaderService.cs
+++ b/src/SSW.Rewards/Services/ILeaderService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface ILeaderService
 {

--- a/src/SSW.Rewards/Services/INotificationActionService.cs
+++ b/src/SSW.Rewards/Services/INotificationActionService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 /// <summary>Centralize the handling of notification actions</summary>
 public interface INotificationActionService

--- a/src/SSW.Rewards/Services/INotificationRegistrationService.cs
+++ b/src/SSW.Rewards/Services/INotificationRegistrationService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 /// <summary>Handles the interaction between the client and backend service.</summary>
 public interface INotificationRegistrationService

--- a/src/SSW.Rewards/Services/IPushNotificationActionService.cs
+++ b/src/SSW.Rewards/Services/IPushNotificationActionService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IPushNotificationActionService : INotificationActionService
 {

--- a/src/SSW.Rewards/Services/IQuizService.cs
+++ b/src/SSW.Rewards/Services/IQuizService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IQuizService
 {

--- a/src/SSW.Rewards/Services/IRewardService.cs
+++ b/src/SSW.Rewards/Services/IRewardService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IRewardService
 {

--- a/src/SSW.Rewards/Services/IScannerService.cs
+++ b/src/SSW.Rewards/Services/IScannerService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IScannerService
 {

--- a/src/SSW.Rewards/Services/ISnackbarService.cs
+++ b/src/SSW.Rewards/Services/ISnackbarService.cs
@@ -1,0 +1,8 @@
+﻿using SSW.Rewards.Mobile.Controls;
+
+namespace SSW.Rewards.Mobile.Services;
+
+public interface ISnackbarService
+{
+    Task ShowSnackbar(SnackbarOptions options);
+}

--- a/src/SSW.Rewards/Services/IUserService.cs
+++ b/src/SSW.Rewards/Services/IUserService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public interface IUserService
 {

--- a/src/SSW.Rewards/Services/LeaderService.cs
+++ b/src/SSW.Rewards/Services/LeaderService.cs
@@ -1,6 +1,6 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
-public class LeaderService : BaseService, ILeaderService
+public class LeaderService : ApiBaseService, ILeaderService
 {
     private LeaderboardClient _leaderBoardClient;
 

--- a/src/SSW.Rewards/Services/PushNotificationActionService.cs
+++ b/src/SSW.Rewards/Services/PushNotificationActionService.cs
@@ -1,4 +1,4 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
 public class PushNotificationActionService : IPushNotificationActionService
 {

--- a/src/SSW.Rewards/Services/QuizService.cs
+++ b/src/SSW.Rewards/Services/QuizService.cs
@@ -1,6 +1,6 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
-public class QuizService : BaseService, IQuizService
+public class QuizService : ApiBaseService, IQuizService
 {
     private QuizzesClient _quizClient;
 

--- a/src/SSW.Rewards/Services/RewardService.cs
+++ b/src/SSW.Rewards/Services/RewardService.cs
@@ -1,6 +1,6 @@
-﻿namespace SSW.Rewards.Services;
+﻿namespace SSW.Rewards.Mobile.Services;
 
-public class RewardService : BaseService, IRewardService
+public class RewardService : ApiBaseService, IRewardService
 {
     private RewardClient _rewardClient;
 

--- a/src/SSW.Rewards/Services/ScannerService.cs
+++ b/src/SSW.Rewards/Services/ScannerService.cs
@@ -1,9 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.Messaging;
 using SSW.Rewards.Mobile.Messages;
 
-namespace SSW.Rewards.Services;
+namespace SSW.Rewards.Mobile.Services;
 
-public class ScannerService : BaseService, IScannerService
+public class ScannerService : ApiBaseService, IScannerService
 {
     private AchievementClient _achievementClient { get; set; }
     private RewardClient _rewardClient { get; set; }

--- a/src/SSW.Rewards/Services/SnackBarService.cs
+++ b/src/SSW.Rewards/Services/SnackBarService.cs
@@ -1,0 +1,18 @@
+﻿using CommunityToolkit.Maui.Views;
+using SSW.Rewards.Mobile.Controls;
+
+namespace SSW.Rewards.Mobile.Services;
+
+public class SnackBarService : ISnackbarService
+{
+    public async Task ShowSnackbar(SnackbarOptions options)
+    {
+        var snack = new Snackbar(options);
+
+        await App.Current.MainPage.ShowPopupAsync(snack);
+
+        await Task.Delay(5000);
+
+        snack.Close();
+    }
+}

--- a/src/SSW.Rewards/Services/SnackBarService.cs
+++ b/src/SSW.Rewards/Services/SnackBarService.cs
@@ -10,9 +10,5 @@ public class SnackBarService : ISnackbarService
         var snack = new Snackbar(options);
 
         await App.Current.MainPage.ShowPopupAsync(snack);
-
-        await Task.Delay(5000);
-
-        snack.Close();
     }
 }

--- a/src/SSW.Rewards/Services/UserService.cs
+++ b/src/SSW.Rewards/Services/UserService.cs
@@ -5,9 +5,9 @@ using SSW.Rewards.Mobile.Messages;
 using System.IdentityModel.Tokens.Jwt;
 using IBrowser = IdentityModel.OidcClient.Browser.IBrowser;
 
-namespace SSW.Rewards.Services;
+namespace SSW.Rewards.Mobile.Services;
 
-public class UserService : BaseService, IUserService
+public class UserService : ApiBaseService, IUserService
 {
     private UserClient _userClient { get; set; }
 

--- a/src/SSW.Rewards/ViewModels/PeoplePageViewModel.cs
+++ b/src/SSW.Rewards/ViewModels/PeoplePageViewModel.cs
@@ -3,12 +3,14 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using SSW.Rewards.Mobile.Messages;
+using CommunityToolkit.Maui.Views;
 
 namespace SSW.Rewards.Mobile.ViewModels;
 
 public class DevProfilesViewModel : BaseViewModel, IRecipient<PointsAwardedMessage>
 {
     private IDevService _devService;
+    private readonly ISnackbarService _snackbarService;
 
     public ICommand OnCardSwiped => new Command(SetDevDetails);
     public ICommand StaffQRCommand => new Command(ShowScannedMessage);
@@ -21,8 +23,6 @@ public class DevProfilesViewModel : BaseViewModel, IRecipient<PointsAwardedMessa
     public ICommand SearchTextCommand => new Command<string>(SearchTextHandler);
 
     public EventHandler<ScrollToEventArgs> ScrollToRequested;
-
-    public EventHandler<ShowSnackbarEventArgs> ShowSnackbar;
 
     public bool IsRunning { get; set; }
 
@@ -63,11 +63,12 @@ public class DevProfilesViewModel : BaseViewModel, IRecipient<PointsAwardedMessa
 
     public string[] OnSwipedUpdatePropertyList { get; set; }
 
-    public DevProfilesViewModel(IDevService devService)
+    public DevProfilesViewModel(IDevService devService, ISnackbarService snackbarService)
     {
         IsRunning = true;
         TwitterEnabled = true;
         _devService = devService;
+        _snackbarService = snackbarService;
         SnackOptions = new SnackbarOptions
         {
             Glyph = "\uf636",
@@ -241,7 +242,7 @@ public class DevProfilesViewModel : BaseViewModel, IRecipient<PointsAwardedMessa
         await Launcher.OpenAsync(new Uri(_peopleUri));
     }
 
-    private void ShowScannedMessage()
+    private async void ShowScannedMessage()
     {
         var options = new SnackbarOptions
         {
@@ -252,9 +253,7 @@ public class DevProfilesViewModel : BaseViewModel, IRecipient<PointsAwardedMessa
             Glyph = "\uf636"
         };
 
-        var args = new ShowSnackbarEventArgs { Options = options };
-
-        ShowSnackbar.Invoke(this, args);
+        await _snackbarService.ShowSnackbar(options);
     }
 
     public async void Receive(PointsAwardedMessage message)

--- a/src/SSW.Rewards/ViewModels/ProfileViewModel.cs
+++ b/src/SSW.Rewards/ViewModels/ProfileViewModel.cs
@@ -16,6 +16,7 @@ public class ProfileViewModel : BaseViewModel,
 {
     private readonly IRewardService _rewardsService;
     private IUserService _userService;
+    private readonly ISnackbarService _snackbarService;
 
     public string ProfilePic { get; set; }
     public string Name { get; set; }
@@ -48,9 +49,7 @@ public class ProfileViewModel : BaseViewModel,
 
     private bool _loadingProfileSections;
 
-    public EventHandler<ShowSnackbarEventArgs> ShowSnackbar;
-
-    public ProfileViewModel(IRewardService rewardsService, IUserService userService)
+    public ProfileViewModel(IRewardService rewardsService, IUserService userService, ISnackbarService snackbarService)
     {
         WeakReferenceMessenger.Default.RegisterAll(this);
 
@@ -58,7 +57,7 @@ public class ProfileViewModel : BaseViewModel,
         RaisePropertyChanged("IsLoading");
         _rewardsService = rewardsService;
         _userService = userService;
-
+        _snackbarService = snackbarService;
         SnackOptions = new SnackbarOptions
         {
             ActionCompleted = true,
@@ -70,7 +69,7 @@ public class ProfileViewModel : BaseViewModel,
         };
     }
 
-    public ProfileViewModel(IRewardService rewardsService, IUserService userService, LeaderViewModel vm)
+    public ProfileViewModel(IRewardService rewardsService, IUserService userService, ISnackbarService snackbarService, LeaderViewModel vm)
     {
         IsLoading = true;
         RaisePropertyChanged("IsLoading");
@@ -80,6 +79,7 @@ public class ProfileViewModel : BaseViewModel,
         Points = vm.TotalPoints;
         _userService = userService;
         _rewardsService = rewardsService;
+        _snackbarService = snackbarService;
         Balance = vm.Balance;
         ShowBalance = false;
         ShowPopButton = true;
@@ -350,9 +350,7 @@ public class ProfileViewModel : BaseViewModel,
 
         options.Message = $"{GetMessage(message.Value.Achievement)}";
 
-        var args = new ShowSnackbarEventArgs { Options = options };
-
-        ShowSnackbar.Invoke(this, args);
+        await _snackbarService.ShowSnackbar(options);
 
         if (result)
         {
@@ -362,7 +360,7 @@ public class ProfileViewModel : BaseViewModel,
         IsBusy = false;
     }
 
-    private void ShowAchievementSnackbar(ProfileAchievement achievement)
+    private async void ShowAchievementSnackbar(ProfileAchievement achievement)
     {
         // TODO: set Glyph when given values
         var options = new SnackbarOptions
@@ -374,9 +372,7 @@ public class ProfileViewModel : BaseViewModel,
             Glyph = (string)typeof(Icon).GetField(achievement.AchievementIcon.ToString()).GetValue(null)
         };
 
-        var args = new ShowSnackbarEventArgs { Options = options };
-
-        ShowSnackbar.Invoke(this, args);
+        await _snackbarService.ShowSnackbar(options);
     }
 
     public string GetMessage(Achievement achievement, bool IsActivity = false)

--- a/src/SSW.Rewards/ViewModels/QuizDetailsViewModel.cs
+++ b/src/SSW.Rewards/ViewModels/QuizDetailsViewModel.cs
@@ -9,6 +9,7 @@ namespace SSW.Rewards.Mobile.ViewModels
     public class QuizDetailsViewModel : BaseViewModel
     {
         private readonly IQuizService _quizService;
+        private readonly ISnackbarService _snackbarService;
         private int _quizId;
 
         public ObservableCollection<QuizQuestionViewModel> Questions { get; set; } = new ObservableCollection<QuizQuestionViewModel>();
@@ -45,15 +46,14 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         public EventHandler<int> OnNextQuestionRequested;
 
-        public EventHandler<ShowSnackbarEventArgs> ShowSnackbar;
-
         public QuizQuestionViewModel CurrentQuestion { get; set; }
 
         private string _quizIcon;
 
-        public QuizDetailsViewModel(IQuizService quizService)
+        public QuizDetailsViewModel(IQuizService quizService, ISnackbarService snackbarService)
         {
             _quizService = quizService;
+            _snackbarService = snackbarService;
         }
 
         public async Task Initialise(int quizId, string icon)
@@ -161,9 +161,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                     ShowPoints = true
                 };
 
-                var args = new ShowSnackbarEventArgs { Options = SnackOptions };
-
-                ShowSnackbar.Invoke(this, args);
+                await _snackbarService.ShowSnackbar(SnackOptions);
                 
                 WeakReferenceMessenger.Default.Send(new PointsAwardedMessage());
             }


### PR DESCRIPTION
This PR switches out the proprietary logic for displaying a snackbar and uses the MAUI CommunityToolkit popup instead.

Fixes #452 
Fixes #449 
Fixes #440 

<img width="397" alt="image" src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/19944129/982b70d6-f1c5-454b-81bf-78501be1fe57">

**Figure: Snackbar working on Android**

![image](https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/19944129/8a47cbf8-71e2-431e-b9a1-fe16d9cc49c6)
**Figure: Snackbar working on iOS**