### PR TITLE
Fix ios tabbar overlay

### DIFF
--- a/src/SSW.Rewards/Pages/ProfilePage.xaml
+++ b/src/SSW.Rewards/Pages/ProfilePage.xaml
@@ -29,7 +29,12 @@
                                          Achievements="{StaticResource AchievementsTemplate}"
                                          RecentActivity="{StaticResource ActivityTemplate}" />
     </ContentPage.Resources>
-    
+
+    <!-- TECH DEBT: The following workaround adds an extra row on iOS.
+                    This is necessary due to a bug in .NET MAUI Preview that 
+                    causes part of the page to be hidden behind the tab bar.
+                    See: https://github.com/dotnet/maui/issues/17817
+    -->
     <Grid RowDefinitions="{OnPlatform 'Auto,Auto,*,10', iOS='Auto,Auto,*,10,80'}"
           RowSpacing="6"
           Padding="20,20,20,5">

--- a/src/SSW.Rewards/Pages/ProfilePage.xaml
+++ b/src/SSW.Rewards/Pages/ProfilePage.xaml
@@ -30,7 +30,7 @@
                                          RecentActivity="{StaticResource ActivityTemplate}" />
     </ContentPage.Resources>
     
-    <Grid RowDefinitions="Auto,Auto,*,10"
+    <Grid RowDefinitions="{OnPlatform 'Auto,Auto,*,10', iOS='Auto,Auto,*,10,80'}"
           RowSpacing="6"
           Padding="20,20,20,5">
 


### PR DESCRIPTION
## Reason for change:

In testing the most recent build, two issues were identified on iOS only. The tab bar hides the `IndicatorView` and the last row of achievements.

The issue occurs due to a bug in .NET MAUI (see: https://github.com/dotnet/maui/issues/17817); this provides a workaround.

Fixes #453 
Fixes #454 