### PR TITLE
Made bio in People profiles fixed height

### DIFF
--- a/src/SSW.Rewards/Pages/PeoplePage.xaml
+++ b/src/SSW.Rewards/Pages/PeoplePage.xaml
@@ -15,7 +15,7 @@
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Content>
-        <Grid RowDefinitions="65, 2.5*, 12*, 3*"
+        <Grid RowDefinitions="65, 2.5*, 12*, 150"
               ColumnDefinitions="*, 5*, *"
               ColumnSpacing="6">
 

--- a/src/SSW.Rewards/Platforms/iOS/Info.plist
+++ b/src/SSW.Rewards/Platforms/iOS/Info.plist
@@ -26,7 +26,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scan QR codes to earn points</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.2.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
## Reason for change

Prior to adding the search bar, all rows on the People page were proportional. Since adding the search bar, which is fixed height, the proportional rows will adjust according to each other but also the fixed height row.

This allows the bio row to grow and shrink depending on the size of its content (in this case dictated by the length of the bio).

Making this row also fixed height resolves the issue.

Fixes #458 