### PR TITLE
Fix unregister notifications

### DIFF
--- a/src/SSW.Rewards/Pages/ProfilePages/MyProfilePage.xaml.cs
+++ b/src/SSW.Rewards/Pages/ProfilePages/MyProfilePage.xaml.cs
@@ -23,6 +23,8 @@ public partial class MyProfilePage : ContentPage
             await viewModel.Initialise();
 
         _initialised = true;
+
+        viewModel.OnAppearing();
     }
 
     protected override void OnDisappearing()

--- a/src/SSW.Rewards/Pages/ProfilePages/OthersProfilePage.xaml.cs
+++ b/src/SSW.Rewards/Pages/ProfilePages/OthersProfilePage.xaml.cs
@@ -25,6 +25,8 @@ public partial class OthersProfilePage : ContentPage
             await viewModel.Initialise();
 
         _initialised = true;
+
+        viewModel.OnAppearing();
     }
 
     protected override void OnDisappearing()

--- a/src/SSW.Rewards/Platforms/iOS/Info.plist
+++ b/src/SSW.Rewards/Platforms/iOS/Info.plist
@@ -26,7 +26,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scan QR codes to earn points</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.2.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/src/SSW.Rewards/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
+++ b/src/SSW.Rewards/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
@@ -47,8 +47,6 @@ public abstract class ProfileViewModelBase : BaseViewModel, IRecipient<Achieveme
 
     public ProfileViewModelBase(IRewardService rewardsService, IUserService userService, ISnackbarService snackbarService)
     {
-        WeakReferenceMessenger.Default.RegisterAll(this);
-
         IsLoading = true;
         RaisePropertyChanged("IsLoading");
         _rewardsService = rewardsService;
@@ -65,6 +63,11 @@ public abstract class ProfileViewModelBase : BaseViewModel, IRecipient<Achieveme
             Points = 1000,
             ShowPoints = true
         };
+    }
+
+    public void OnAppearing()
+    {
+        WeakReferenceMessenger.Default.RegisterAll(this);
     }
 
     public void Receive(AchievementTappedMessage message)


### PR DESCRIPTION
Minor bug in latest version - in the profile ViewModels, Ondisappearing deregisters WeakReferenceMessenger recipients. This means that after you navigate away from your own profile, you can't tap achievements anymore.

Kept this but moved the registration from ctor to OnAppearing.