### PR TITLE
🐛 Mobile - Log in auth fixes

### DIFF
--- a/src/MobileUI/Services/IAuthenticationService.cs
+++ b/src/MobileUI/Services/IAuthenticationService.cs
@@ -51,10 +51,17 @@ public class AuthenticationService : IAuthenticationService
         {
             var oidcClient = new OidcClient(_options);
 
-            var result = await oidcClient.LoginAsync(new LoginRequest());
+            var result = await oidcClient.LoginAsync(new LoginRequest()
+            {
+                FrontChannelExtraParameters = HasCachedAccount ? null : new Parameters
+                {
+                    { "prompt", "login" }
+                }
+            });
 
             if (result.IsError)
             {
+                SignOut();
                 return ApiStatus.Error;
             }
 
@@ -70,6 +77,7 @@ public class AuthenticationService : IAuthenticationService
         }
         catch (Exception ex)
         {
+            SignOut();
             return ApiStatus.Error;
         }
     }

--- a/src/MobileUI/ViewModels/LoginPageViewModel.cs
+++ b/src/MobileUI/ViewModels/LoginPageViewModel.cs
@@ -41,6 +41,7 @@ public partial class LoginPageViewModel : BaseViewModel
         }
         catch (Exception exception)
         {
+            await WaitForWindowClose();
             status = ApiStatus.LoginFailure;
             //Crashes.TrackError(exception);
             await App.Current.MainPage.DisplayAlert("Login Failure", exception.Message, "OK");
@@ -53,18 +54,29 @@ public partial class LoginPageViewModel : BaseViewModel
                 await OnAfterLogin();
                 break;
             case ApiStatus.Unavailable:
+                await WaitForWindowClose();
                 await App.Current.MainPage.DisplayAlert("Service Unavailable", "Looks like the SSW.Rewards service is not currently available. Please try again later.", "OK");
                 break;
             case ApiStatus.LoginFailure:
+                await WaitForWindowClose();
                 await App.Current.MainPage.DisplayAlert("Login Failure", "There seems to have been a problem logging you in. Please try again.", "OK");
                 break;
             default:
+                await WaitForWindowClose();
                 await App.Current.MainPage.DisplayAlert("Unexpected Error", "Something went wrong there, please try again later.", "OK");
                 break;
         }
 
         LoginButtonEnabled = enablebuttonAfterLogin;
         IsRunning = false;
+    }
+    
+    private async static Task WaitForWindowClose()
+    {
+        if (DeviceInfo.Platform == DevicePlatform.iOS)
+        {
+            await Task.Delay(1000);
+        }
     }
 
     public async Task Refresh()

--- a/src/MobileUI/ViewModels/LoginPageViewModel.cs
+++ b/src/MobileUI/ViewModels/LoginPageViewModel.cs
@@ -72,6 +72,8 @@ public partial class LoginPageViewModel : BaseViewModel
     
     private async static Task WaitForWindowClose()
     {
+        // TECH DEBT: Workaround for iOS since calling DisplayAlert while a Safari web view is in
+        // the process of closing causes the alert to never appear and the await call never returns.
         if (DeviceInfo.Platform == DevicePlatform.iOS)
         {
             await Task.Delay(1000);


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#544

> 2. What was changed?

1. Fixes a bug where alerts for log in issues are never displayed on iOS as they occur during the closing animation for the Safari web view and both never display the alert and never resolve the await call. This just adds a delay for iOS but there's probably a better solution here that I'm unaware of.
2. Fixes an issue where a user can be caught in a perpetual log in loop where either the log in spinner continues indefinitely or hitting the log in button results in the web view window opening then immediately closing and never allowing the user to attempt logging in again. This change just clears credentials upon an error then prompts for login on next execution.

> 3. Did you do pair or mob programming?

No

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->