### PR TITLE
Move SQL administrators to separate resource

### DIFF
--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -16,7 +16,7 @@ param databaseProperties object = {
   maxSizeBytes: 2 * 1073741824 // 2GB
 }
 
-param now string 
+param now string
 
 var sqlserverName = 'sql-${projectName}-${environment}'
 var databaseName = 'db-${projectName}-${environment}'
@@ -29,15 +29,18 @@ resource sqlServer 'Microsoft.Sql/servers@2021-02-01-preview' = {
   properties: {
     administratorLogin: sqlAdministratorLogin
     administratorLoginPassword: sqlAdministratorLoginPassword
-    administrators: {
-      administratorType: 'ActiveDirectory'
-      login: sqlAdministratorsLoginName
-      sid: sqlAdministratorsObjectId
-      tenantId: tenant().tenantId
-      principalType: 'Group'
-      azureADOnlyAuthentication: false
-    }
     version: '12.0'
+  }
+}
+
+resource sqlServerAdmins 'Microsoft.Sql/servers/administrators@2022-05-01-preview' = {
+  name: 'ActiveDirectory'
+  parent: sqlServer
+  properties: {
+    administratorType: 'ActiveDirectory'
+    login: sqlAdministratorsLoginName
+    sid: sqlAdministratorsObjectId
+    tenantId: tenant().tenantId
   }
 }
 
@@ -60,7 +63,7 @@ resource allowAllWindowsAzureIps 'Microsoft.Sql/servers/firewallRules@2021-02-01
 
 module connectionStringSecret 'create-secrets.bicep' = {
   name: 'connectionStringSecret-${now}'
-  params:{
+  params: {
     keyVaultName: keyVaultName
     secretName: 'SqlConnectionString'
     secretValue: 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Initial Catalog=${databaseName};Persist Security Info=False;User ID=${sqlAdministratorLogin};Password=${sqlAdministratorLoginPassword};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Fixes #585 

> 2. What was changed?

✏️ The SQL server administrators were moved out of direct assignment within the SQL Server resource in the bicep template, and added as their own resource with the SQL server set as the parent.

> 3. Did you do pair or mob programming?

✏️ N/A
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->