### PR TITLE
V2 layout and cleaned up unused code

### DIFF
--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -17,95 +17,11 @@
     <ContentPage.Content>
         <Grid Margin="30,5"
               RowSpacing="6"
-              RowDefinitions="80, 55, 40, 35, *">
-
-            <Grid Grid.Row="0"
-                  RowSpacing="6"
-                  RowDefinitions="3*, 2*"
-                  ColumnDefinitions="80, *, 50">
-
-                <ImageButton Grid.Row="0"
-                             Grid.RowSpan="2"
-                             Source="{Binding ProfilePic}"
-                             WidthRequest="74"
-                             HeightRequest="74"
-                             CornerRadius="37"
-                             Command="{Binding GoToMyProfileCommand}"
-                             VerticalOptions="Center"
-                             HorizontalOptions="Center"
-                             Aspect="AspectFill">
-                </ImageButton>
-
-                <HorizontalStackLayout Grid.Column="1"
-                             Padding="10,5,0,0"
-                             VerticalOptions="End">
-
-                    <Label Text="{Binding MyRank, StringFormat='&#35;{0}'}"
-                           FontSize="Title"
-                           TextColor="White"/>
-
-                    <Label Text="{Binding TotalLeaders, StringFormat=' of {0}'}"
-                           FontSize="Title"
-                           TextColor="{StaticResource MutedText}"/>
-
-                </HorizontalStackLayout>
-
-                <HorizontalStackLayout Grid.Column="1"
-                             Grid.Row="1"
-                             Padding="10,0,5,0"
-                             VerticalOptions="Start"
-                             Spacing="10">
-
-                    <Label Text="{Binding MyBalance, StringFormat='⭐ {0:n0}'}"
-                           TextColor="{StaticResource primary}"/>
-
-                    <Label Text="{Binding MyPoints, StringFormat='⭐ {0:n0}'}"
-                           TextColor="{StaticResource HighlightedText}"/>
-
-                </HorizontalStackLayout>
-
-                <Border
-                    Grid.Row="0"
-                    Grid.RowSpan="2"
-                    Grid.Column="2"
-                    BackgroundColor="{StaticResource primary}"
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    StrokeShape="Ellipse"
-                    StrokeThickness="0">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ScrollToMeCommand}"/>
-                    </Border.GestureRecognizers>
-                    <Label
-                        FontFamily="FluentIcons"
-                        FontSize="30"
-                        Margin="5"
-                        Text="&#xf151;"
-                        TextColor="White"/>
-                </Border>
-                
-            </Grid>
-
-            <controls:Search
-                Grid.Row="1"
-                VerticalOptions="Center"
-                BackgroundColor="{StaticResource TabBarBackground}"
-                TextColor="White"
-                Command="{Binding SearchTextCommand}"
-                ClearSearch="{Binding ClearSearch, Mode=TwoWay}"/>
-            <!--TODO: Why OneWayToSource doesn't work here?-->
-
-            <Label Grid.Row="2"
-                   Text="Leaderboard"
-                   TextColor="White"
-                   FontSize="Title"
-                   HorizontalOptions="Center"
-                   VerticalOptions="Center"
-                   HorizontalTextAlignment="Center"/>
+              RowDefinitions="1*, 7*, 8*">
 
             <controls:SegmentedControl
                 Segments="{Binding Periods}"
-                Grid.Row="3"
+                Grid.Row="0"
                 SelectedSegment="{Binding SelectedPeriod, Mode=OneWayToSource}">
                 <controls:SegmentedControl.Behaviors>
                     <mct:EventToCommandBehavior EventName="SelectionChanged"
@@ -114,13 +30,13 @@
             </controls:SegmentedControl>
 
             <RefreshView
-                Grid.Row="4"
+                Grid.Row="2"
                 Command="{Binding RefreshCommand}"
                 IsRefreshing="{Binding IsRefreshing}">
-                <ContentView> <!--TODO: MAUI, remove when the issue is fixed on iOS https://github.com/dotnet/maui/issues/11363-->
+                <ContentView>
+                    <!--TODO: MAUI, remove when the issue is fixed on iOS https://github.com/dotnet/maui/issues/11363-->
                     <CollectionView
                         ItemsSource="{Binding SearchResults}"
-                        Scrolled="CollectionView_Scrolled"
                         x:Name="LeadersCollection"
                         Margin="0,10">
                         <CollectionView.ItemTemplate>
@@ -180,7 +96,7 @@
                                            InputTransparent="True"/>
 
                                     <!--TODO: MAUI, without a wrapping layout the label will be trancated on Android if the points have more than 4 digits-->
-                                    <Grid Grid.Column="3"> 
+                                    <Grid Grid.Column="3">
                                         <Label 
                                             Text="{Binding DisplayPoints, StringFormat='{0:N0} ⭐'}"
                                             TextColor="White"
@@ -196,53 +112,6 @@
                     </CollectionView>
                 </ContentView>
             </RefreshView>
-
-            <VerticalStackLayout
-                Grid.Row="0"
-                Grid.RowSpan="5"
-                HorizontalOptions="End"
-                VerticalOptions="End"
-                Margin="0,0,-20,10"
-                IsVisible="False"
-                Spacing="6"
-                x:Name="ScrollButtons">
-                
-                <Border
-                    BackgroundColor="{StaticResource primary}"
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    StrokeThickness="0"
-                    StrokeShape="Ellipse">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ScrollToTopCommand}"/>
-                    </Border.GestureRecognizers>
-                    <Label
-                        FontFamily="FluentIcons"
-                        FontSize="30"
-                        Margin="{OnPlatform iOS=2, Android=10}"
-                        Padding="{OnPlatform iOS=10, Android=0}"
-                        Text="&#xf1a5;"
-                        TextColor="White"/>
-                </Border>
-
-                <Border
-                    BackgroundColor="{StaticResource primary}"
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    StrokeThickness="0"
-                    StrokeShape="Ellipse">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ScrollToEndCommand}"/>
-                    </Border.GestureRecognizers>
-                    <Label
-                        FontFamily="FluentIcons"
-                        FontSize="30"
-                        Margin="{OnPlatform iOS=2, Android=10}"
-                        Padding="{OnPlatform iOS=10, Android=0}"
-                        Text="&#xf151;"
-                        TextColor="White"/>
-                </Border>
-            </VerticalStackLayout>
 
             <ActivityIndicator Grid.Row="0"
                                Grid.RowSpan="5"

--- a/src/MobileUI/Pages/LeaderboardPage.xaml.cs
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Maui.Controls;
-using SSW.Rewards.Mobile.Controls;
-
-namespace SSW.Rewards.Mobile.Pages;
+﻿namespace SSW.Rewards.Mobile.Pages;
 
 public partial class LeaderboardPage : ContentPage
 {
@@ -22,60 +19,8 @@ public partial class LeaderboardPage : ContentPage
         _viewModel.ScrollTo += ScrollTo;
     }
 
-    // TODO:    This method has been hacked a little and removed from teh CheckedChanged handler
-    //          of the RadioButtons, as well as the Radio_Tapped method added below. This is to
-    //          workaround a bug in .NET MAUI. see: https://github.com/dotnet/maui/issues/6938.
-    //          We can remove this when this issue gets resolved.
-    //private void FilterChanged(string value)
-    //{
-    //    //if (e.Value)
-    //    //{
-    //    //    var radio = (RadioButton)sender;
-
-    //    //    switch (radio. as string)
-    //    //    {
-    //    //        case "This Month":
-    //    //            _viewModel.SortLeaders("month");
-    //    //            break;
-    //    //        case "This Year":
-    //    //            _viewModel.SortLeaders("year");
-    //    //            break;
-    //    //        default:
-    //    //            _viewModel.SortLeaders("all");
-    //    //            break;
-    //    //    }
-    //    //}
-
-    //    switch (value)
-    //    {
-    //        case "This Month":
-    //            _viewModel.SortLeaders("month");
-    //            break;
-    //        case "This Year":
-    //            _viewModel.SortLeaders("year");
-    //            break;
-    //        default:
-    //            _viewModel.SortLeaders("all");
-    //            break;
-    //    }
-    //}
-
     private void ScrollTo(int i)
     {
         LeadersCollection.ScrollTo(i, position: ScrollToPosition.Center);
-    }
-
-    private void CollectionView_Scrolled(object sender, ItemsViewScrolledEventArgs e)
-    {
-        if (e.FirstVisibleItemIndex > 1)
-        {
-            // show the scrolling controls
-            ScrollButtons.IsVisible = true;
-        }
-        else
-        {
-            // hide the scrolling controls
-            ScrollButtons.IsVisible = false;
-        }
     }
 }

--- a/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
+++ b/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
@@ -33,12 +33,7 @@ public partial class LeaderBoardViewModel : BaseViewModel, IRecipient<PointsAwar
     
     public ICommand LeaderTapped => new Command<LeaderViewModel>(async (x) => await HandleLeaderTapped(x));
     public ICommand OnRefreshCommand { get; set; }
-    public ICommand ScrollToTopCommand => new Command(ScrollToFirstCard);
-    public ICommand ScrollToEndCommand => new Command(ScrollToLastCard);
-    public ICommand ScrollToMeCommand => new Command(ScrollToMyCard);
     public ICommand RefreshCommand => new Command(async () => await RefreshLeaderboard());
-    public ICommand SearchTextCommand => new Command<string>(SearchTextHandler);
-    public IAsyncRelayCommand GoToMyProfileCommand => new AsyncRelayCommand(() => Shell.Current.GoToAsync("//main"));
 
     public ObservableCollection<LeaderViewModel> Leaders { get; set; }
 
@@ -205,24 +200,6 @@ public partial class LeaderBoardViewModel : BaseViewModel, IRecipient<PointsAwar
         IsRefreshing = false;
     }
 
-    private void ScrollToMyCard()
-    {
-        var myCard = SearchResults.FirstOrDefault(l => l.IsMe);
-        var myIndex = SearchResults.IndexOf(myCard);
-
-        ScrollTo.Invoke(myIndex);
-    }
-
-    private void ScrollToFirstCard()
-    {
-        ScrollTo.Invoke(0);
-    }
-
-    private void ScrollToLastCard()
-    {
-        ScrollTo.Invoke(SearchResults.Count() - 1);
-    }
-
     private async Task HandleLeaderTapped(LeaderViewModel leader)
     {
         if (leader.IsMe)
@@ -242,20 +219,5 @@ public partial class LeaderBoardViewModel : BaseViewModel, IRecipient<PointsAwar
         {
             MyRank = mySummary.Rank;
         }
-    }
-
-    private void SearchTextHandler(string searchBarText)
-    {
-        // UserStoppedTypingBehavior fires the command on a threadPool thread
-        // as internally it uses .ContinueWith
-        App.Current.MainPage.Dispatcher.Dispatch(() =>
-        {
-            if (searchBarText != null)
-            {
-                var filtered = Leaders.Where(l => l.Name.ToLower().Contains(searchBarText.ToLower()));
-                //SearchResults = new ObservableCollection<LeaderViewModel>(filtered);
-                FilterAndSortLeaders(filtered, CurrentPeriod, true);
-            }
-        });
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Updates the Leaderboard page to the layout defined in #558 

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/19944129/bbfac71d-7016-408a-a022-5e7e12709f0c" width="300">

> 2. What was changed?

✏️ 
* Header section removed
* Search removed
* Scroll buttons removed
* Row definitions updated
* Unused code removed

> 3. Did you do pair or mob programming?

✏️ N/A
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->