### PR TITLE
Lc quizgpt backend

### DIFF
--- a/src/Application/Common/Interfaces/IQuizGPTService.cs
+++ b/src/Application/Common/Interfaces/IQuizGPTService.cs
@@ -1,0 +1,9 @@
+﻿using SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+using SSW.Rewards.Shared.DTOs.Quizzes;
+
+namespace SSW.Rewards.Application.Common.Interfaces;
+
+public interface IQuizGPTService
+{
+    Task<QuizGPTResponseDto> ValidateAnswer(QuizGPTRequestDto model, CancellationToken ct);
+}

--- a/src/Application/Quizzes/Commands/BeginQuiz/BeginQuizCommand.cs
+++ b/src/Application/Quizzes/Commands/BeginQuiz/BeginQuizCommand.cs
@@ -1,0 +1,46 @@
+﻿using SSW.Rewards.Application.Common.Exceptions;
+
+namespace SSW.Rewards.Application.Quizzes.Commands.BeginQuiz;
+
+public class BeginQuizCommand : IRequest<int>
+{
+    public int QuizId { get; set; }
+}
+
+public sealed class Handler : IRequestHandler<BeginQuizCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserService _userService;
+
+    public Handler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUserService,
+        IUserService userService
+        )
+    {
+        _context            = context;
+        _currentUserService = currentUserService;
+        _userService        = userService;
+    }
+
+    public async Task<int> Handle(BeginQuizCommand request, CancellationToken cancellationToken)
+    {
+        // make sure the quiz exists
+        var quiz = await _context.Quizzes.FindAsync(request.QuizId);
+        if (quiz == null)
+            throw new NotFoundException(nameof(Quiz), request.QuizId);
+
+        // create a new submission
+        int userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+        var submission = new CompletedQuiz
+        {
+            QuizId = request.QuizId,
+            UserId = userId
+        };
+        await _context.CompletedQuizzes.AddAsync(submission, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return submission.Id;
+    }
+}

--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTRequestDto.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTRequestDto.cs
@@ -1,0 +1,7 @@
+﻿namespace SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+
+public class QuizGPTRequestDto
+{
+    public string QuestionText { get; set; } = "";
+    public string AnswerText { get; set; } = "";
+}

--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTResponseDto.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTResponseDto.cs
@@ -1,0 +1,9 @@
+﻿namespace SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+public class QuizGPTResponseDto
+{
+    public string QuestionText { get; set; } = string.Empty;
+    public string AnswerText { get; set; } = string.Empty;
+    public bool Correct { get; set; }
+    public string Explanation { get; set; } = string.Empty;
+    public int Confidence { get; set; }
+}

--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTResponseDto.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTResponseDto.cs
@@ -1,9 +1,20 @@
-﻿namespace SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+﻿using System.Text.Json.Serialization;
+
+namespace SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
 public class QuizGPTResponseDto
 {
-    public string QuestionText { get; set; } = string.Empty;
-    public string AnswerText { get; set; } = string.Empty;
+    [JsonPropertyName("question")]
+    public string Question { get; set; } = string.Empty;
+
+    [JsonPropertyName("answer")]
+    public string Answer { get; set; } = string.Empty;
+
+    [JsonPropertyName("correct")]
     public bool Correct { get; set; }
+
+    [JsonPropertyName("explanation")]
     public string Explanation { get; set; } = string.Empty;
+
+    [JsonPropertyName("confidence")]
     public int Confidence { get; set; }
 }

--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/SubmitAnswerCommand.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/SubmitAnswerCommand.cs
@@ -1,0 +1,85 @@
+﻿using SSW.Rewards.Application.Common.Exceptions;
+
+namespace SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+
+public class SubmitAnswerCommand : IRequest<Unit>
+{
+    public int SubmissionId { get; set; }
+    public int QuestionId { get; set; }
+    public string AnswerText { get; set; } = "";
+}
+
+public sealed class Handler : IRequestHandler<SubmitAnswerCommand, Unit>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserService _userService;
+    private readonly IQuizGPTService _quizGptService;
+
+    public Handler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUserService,
+        IUserService userService,
+        IQuizGPTService quizGptService
+        )
+    {
+        _context            = context;
+        _currentUserService = currentUserService;
+        _userService        = userService;
+        _quizGptService     = quizGptService;
+    }
+
+    public async Task<Unit> Handle(SubmitAnswerCommand request, CancellationToken cancellationToken)
+    {
+        // make sure there isn't already an answer to this question (for this submission)
+        await CheckForDuplicate(request, cancellationToken);
+        
+        // get the question text
+        string questionText = await GetQuestionText(request.QuestionId);
+        
+        // run the answer through GPT
+        QuizGPTRequestDto payload = new QuizGPTRequestDto
+        {
+            QuestionText    = questionText,
+            AnswerText      = request.AnswerText
+        };
+
+        QuizGPTResponseDto result = await _quizGptService.ValidateAnswer(payload, cancellationToken);
+        
+        // write the answer to the database
+        SubmittedQuizAnswer answer = new SubmittedQuizAnswer
+        {
+            QuizQuestionId  = request.QuestionId,
+            AnswerText      = request.AnswerText,
+            Correct         = result.Correct,
+            GPTConfidence   = result.Confidence,
+            GPTExplanation  = result.Explanation
+        };
+        await _context.SubmittedAnswers.AddAsync(answer, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+        
+        return Unit.Value;
+    }
+
+    private async Task<string> GetQuestionText(int questionId)
+    {
+        QuizQuestion? dbQuestion = await _context.QuizQuestions
+                                            .Where(q => q.Id == questionId)
+                                            .FirstOrDefaultAsync();
+        if (dbQuestion == null)
+            throw new NotFoundException(nameof(QuizQuestion), questionId);
+        string questionText = dbQuestion.Text ?? throw new ArgumentNullException(nameof(dbQuestion.Text));
+        return questionText;
+    }
+
+    private async Task CheckForDuplicate(SubmitAnswerCommand request, CancellationToken cancellationToken)
+    {
+        bool alreadyAnswered = await _context.SubmittedAnswers
+                                            .Where(a =>
+                                                    a.SubmissionId == request.SubmissionId
+                                                &&  a.QuizQuestionId == request.QuestionId)
+                                            .AnyAsync(cancellationToken);
+        if (alreadyAnswered)
+            throw new ArgumentException($"Question with id {request.QuestionId} has already been submitted for submission with id {request.SubmissionId}");
+    }
+}

--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/SubmitAnswerCommandValidator.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/SubmitAnswerCommandValidator.cs
@@ -1,0 +1,55 @@
+﻿namespace SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+
+public class SubmitAnswerCommandValidator : AbstractValidator<SubmitAnswerCommand>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserService _userService;
+
+    public SubmitAnswerCommandValidator(IApplicationDbContext context, ICurrentUserService currentUserService, IUserService userService)
+    {
+        _context            = context;
+        _currentUserService = currentUserService;
+        _userService        = userService;
+
+        RuleFor(c => c)
+            .NotNull();
+        RuleFor(c => c.AnswerText)
+            .NotEmpty()
+            .WithMessage("Missing answer text");
+        RuleFor(c => c.QuestionId)
+            .GreaterThan(0)
+            .WithMessage("Missing question id");
+        RuleFor(c => c.SubmissionId)
+            .GreaterThan(0)
+            .WithMessage("Missing submission id");
+        RuleFor(c => c)
+            .MustAsync(SubmissionExists)
+            .WithMessage("No submission with that id found for the current user");
+        RuleFor(c => c)
+            .MustAsync(BeUnanswered)
+            .WithMessage("Question has already been attempted for this submission");
+    }
+
+    private async Task<bool> BeUnanswered(SubmitAnswerCommand command, CancellationToken cancellationToken)
+    {
+        int userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+        
+        bool alreadyAnswered = await _context.SubmittedAnswers
+            .Where(a =>
+                        a.SubmissionId == command.SubmissionId
+                    &&  a.Submission.UserId == userId
+                    &&  a.QuizQuestionId == command.QuestionId)
+            .AnyAsync(cancellationToken);
+        return !alreadyAnswered;
+    }
+
+    private async Task<bool> SubmissionExists(SubmitAnswerCommand command, CancellationToken cancellationToken)
+    {
+        int userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+        bool submissionExists = await _context.CompletedQuizzes
+            .Where(s => s.Id == command.SubmissionId && s.UserId == userId)
+            .AnyAsync(cancellationToken);
+        return submissionExists;
+    }
+}

--- a/src/Application/Quizzes/Queries/CheckQuizCompletion/CheckQuizCompletionQuery.cs
+++ b/src/Application/Quizzes/Queries/CheckQuizCompletion/CheckQuizCompletionQuery.cs
@@ -1,0 +1,47 @@
+﻿namespace SSW.Rewards.Application.Quizzes.Queries.CheckQuizCompletion;
+
+public class CheckQuizCompletionQuery : IRequest<bool>
+{
+    public int SubmissionId { get; set; }
+}
+
+public sealed class Handler : IRequestHandler<CheckQuizCompletionQuery, bool>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserService _userService;
+    public Handler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUserService,
+        IUserService userService)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _userService = userService;
+    }
+
+    public async Task<bool> Handle(CheckQuizCompletionQuery request, CancellationToken cancellationToken)
+    {
+        int userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+
+        // Ugly query because we need all this data to figure stuff out
+        var dbQuiz = await _context.CompletedQuizzes
+            .Include(q => q.Quiz)
+                .ThenInclude(qu => qu.Questions)
+            .Include(q => q.Answers)
+                .ThenInclude(a => a.QuizQuestion)
+            .Where(q =>
+                    q.UserId == userId
+                && q.Id == request.SubmissionId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (dbQuiz == null)
+            throw new ArgumentNullException($"No quiz found for submission id {request.SubmissionId}");
+
+        // have all questions been answered?
+        int questionCount = dbQuiz.Quiz.Questions.Count;
+        int answerCount = dbQuiz.Answers.Count;
+
+        return questionCount == answerCount;
+    }
+}

--- a/src/Application/Quizzes/Queries/GetQuizListForUser/GetQuizListForUser.cs
+++ b/src/Application/Quizzes/Queries/GetQuizListForUser/GetQuizListForUser.cs
@@ -19,24 +19,24 @@ public sealed class Handler : IRequestHandler<GetQuizListForUser, IEnumerable<Qu
         _userService = userService;
     }
 
-        public async Task<IEnumerable<QuizDto>> Handle(GetQuizListForUser request, CancellationToken cancellationToken)
-        {
-            // get all quizzes
-            var masterQuizList = await _context.Quizzes
-                                                .Where(q => !q.IsArchived)
-                                                .Include(q => q.Questions)
-                                                    .ThenInclude(x => x.Answers)
-                                                .OrderBy(q => q.Title)
-                                                .AsNoTracking()
-                                                .ToListAsync(cancellationToken);
-
-            // get the quiz Ids for the quizzes the user has completed so we can mark off 
-            // the quizzes that they've already completed
-            var userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
-            var userQuizzes = await _context.CompletedQuizzes
-                                            .Where(q => q.UserId == userId && q.Passed)
-                                            .Select(r => r.QuizId)
+    public async Task<IEnumerable<QuizDto>> Handle(GetQuizListForUser request, CancellationToken cancellationToken)
+    {
+        // get all quizzes
+        var masterQuizList = await _context.Quizzes
+                                            .Where(q => !q.IsArchived)
+                                            .Include(q => q.Questions)
+                                                .ThenInclude(x => x.Answers)
+                                            .OrderBy(q => q.Title)
+                                            .AsNoTracking()
                                             .ToListAsync(cancellationToken);
+
+        // get the quiz Ids for the quizzes the user has completed so we can mark off 
+        // the quizzes that they've already completed
+        var userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+        var userQuizzes = await _context.CompletedQuizzes
+                                        .Where(q => q.UserId == userId && q.Passed)
+                                        .Select(r => r.QuizId)
+                                        .ToListAsync(cancellationToken);
 
         List<QuizDto> retVal = new List<QuizDto>();
         foreach (var quiz in masterQuizList)

--- a/src/Application/Quizzes/Queries/GetQuizQuestionsBySubmissionId/GetQuizQuestionsBySubmissionIdQuery.cs
+++ b/src/Application/Quizzes/Queries/GetQuizQuestionsBySubmissionId/GetQuizQuestionsBySubmissionIdQuery.cs
@@ -1,0 +1,40 @@
+﻿using SSW.Rewards.Shared.DTOs.Quizzes;
+
+namespace SSW.Rewards.Application.Quizzes.Queries.GetQuizQuestionsBySubmissionId;
+
+public class GetQuizQuestionsBySubmissionIdQuery : IRequest<List<QuizQuestionDto>>
+{
+    public int SubmissionId { get; set; }
+}
+
+public sealed class Handler : IRequestHandler<GetQuizQuestionsBySubmissionIdQuery, List<QuizQuestionDto>>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserService _userService;
+    public Handler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUserService,
+        IUserService userService)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _userService = userService;
+    }
+
+    public async Task<List<QuizQuestionDto>> Handle(GetQuizQuestionsBySubmissionIdQuery request, CancellationToken cancellationToken)
+    {
+        int userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+
+        IDictionary<int,string?> questions = await _context.CompletedQuizzes
+            .Where(q => 
+                    q.UserId == userId 
+                &&  q.Id == request.SubmissionId)
+            .SelectMany(cq => cq.Quiz.Questions)
+            .ToDictionaryAsync(q => q.Id, q => q.Text, cancellationToken);
+
+        List<QuizQuestionDto> result = questions.Select(q => new QuizQuestionDto { QuestionId = q.Key, Text = q.Value ?? "" }).ToList();
+
+        return result ?? throw new ArgumentNullException($"No questions found for submission id { request.SubmissionId }");
+    }
+}

--- a/src/Application/Quizzes/Queries/GetQuizResults/GetQuizResultsQuery.cs
+++ b/src/Application/Quizzes/Queries/GetQuizResults/GetQuizResultsQuery.cs
@@ -61,8 +61,8 @@ public sealed class Handler : IRequestHandler<GetQuizResultsQuery, QuizResultDto
             Passed          = passed,
             Results         = dbQuiz.Answers.Select(a => new QuestionResultDto
             {
-                QuestionId      = a.QuizQuestionId,
-                QuestionText    = a.QuizQuestion.Text ?? string.Empty,
+                QuestionId      = a.QuizQuestionId ?? 0,
+                QuestionText    = a.QuizQuestion?.Text ?? string.Empty,
                 AnswerText      = a.AnswerText,
                 ExplanationText = a.GPTExplanation,
                 Correct         = a.Correct,

--- a/src/Application/Quizzes/Queries/GetQuizResults/GetQuizResultsQuery.cs
+++ b/src/Application/Quizzes/Queries/GetQuizResults/GetQuizResultsQuery.cs
@@ -1,0 +1,75 @@
+﻿using SSW.Rewards.Shared.DTOs.Quizzes;
+
+namespace SSW.Rewards.Application.Quizzes.Queries.GetQuizResults;
+
+public class GetQuizResultsQuery : IRequest<QuizResultDto>
+{
+    public int SubmissionId { get; set; }
+}
+
+public sealed class Handler : IRequestHandler<GetQuizResultsQuery, QuizResultDto>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserService _userService;
+    public Handler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUserService,
+        IUserService userService)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _userService = userService;
+    }
+
+    public async Task<QuizResultDto> Handle(GetQuizResultsQuery request, CancellationToken cancellationToken)
+    {
+        int userId = await _userService.GetUserId(_currentUserService.GetUserEmail(), cancellationToken);
+
+        // Ugly query because we need all this data to figure stuff out
+        var dbQuiz = await _context.CompletedQuizzes
+            .Include(q => q.Quiz)
+                .ThenInclude(qu => qu.Questions)
+            .Include(q => q.Answers)
+                .ThenInclude(a => a.QuizQuestion)
+            .Where(q => 
+                    q.UserId == userId 
+                &&  q.Id == request.SubmissionId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (dbQuiz == null)
+            throw new ArgumentNullException($"No quiz found for submission id {request.SubmissionId}");
+
+        // have all questions been answered?
+        int questionCount = dbQuiz.Quiz.Questions.Count;
+        int answerCount = dbQuiz.Answers.Count;
+        if (questionCount != answerCount) // TODO: Figure out how we want this scenario to be handled
+            throw new ArgumentException($"Not all questions have been answered for submission id {request.SubmissionId}");
+
+        // all correct?
+        bool passed = dbQuiz.Answers.All(a => a.Correct);
+
+        // update the db record
+        dbQuiz.Passed = passed;
+        _context.CompletedQuizzes.Update(dbQuiz);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        QuizResultDto result = new QuizResultDto
+        {
+            SubmissionId    = dbQuiz.Id,
+            QuizId          = dbQuiz.QuizId,
+            Passed          = passed,
+            Results         = dbQuiz.Answers.Select(a => new QuestionResultDto
+            {
+                QuestionId      = a.QuizQuestionId,
+                QuestionText    = a.QuizQuestion.Text ?? string.Empty,
+                AnswerText      = a.AnswerText,
+                ExplanationText = a.GPTExplanation,
+                Correct         = a.Correct,
+                Confidence      = a.GPTConfidence
+            }).ToList()
+        };
+
+        return result;
+    }
+}

--- a/src/Common/DTOs/Quizzes/BeginQuizDto.cs
+++ b/src/Common/DTOs/Quizzes/BeginQuizDto.cs
@@ -1,0 +1,6 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Quizzes;
+public class BeginQuizDto
+{
+    public int SubmissionId { get; set; }
+    public List<QuizQuestionDto> Questions { get; set; } = new();
+}

--- a/src/Common/DTOs/Quizzes/QuestionResultDto.cs
+++ b/src/Common/DTOs/Quizzes/QuestionResultDto.cs
@@ -4,4 +4,10 @@ public class QuestionResultDto
 {
     public int QuestionId { get; set; }
     public bool Correct { get; set; }
+
+    // new fields for GPT quiz engine
+    public string QuestionText { get; set; } = string.Empty;
+    public string AnswerText { get; set; } = string.Empty;
+    public string ExplanationText { get; set; } = string.Empty;
+    public int Confidence { get; set; }
 }

--- a/src/Common/DTOs/Quizzes/QuizQuestionDto.cs
+++ b/src/Common/DTOs/Quizzes/QuizQuestionDto.cs
@@ -4,5 +4,7 @@ public class QuizQuestionDto
 {
     public int QuestionId { get; set; }
     public string Text { get; set; } = string.Empty;
+    
+    // TODO [tech debt]: Remove when GPT quiz engine is working
     public IList<QuestionAnswerDto> Answers { get; set; } = new List<QuestionAnswerDto>();
 }

--- a/src/Common/DTOs/Quizzes/QuizResultDto.cs
+++ b/src/Common/DTOs/Quizzes/QuizResultDto.cs
@@ -2,11 +2,12 @@
 
 public class QuizResultDto
 {
+    public int SubmissionId { get; set; }
     public int QuizId { get; set; }
     public bool Passed { get; set; } = false;
     public List<QuestionResultDto> Results { get; set; }
     public int Points { get; set; } = 0;
-
+    
     public QuizResultDto()
     {
         this.Results = new List<QuestionResultDto>();

--- a/src/Common/DTOs/Quizzes/SubmitQuizAnswerDto.cs
+++ b/src/Common/DTOs/Quizzes/SubmitQuizAnswerDto.cs
@@ -1,0 +1,7 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Quizzes;
+public class SubmitQuizAnswerDto
+{
+    public int SubmissionId { get; set; }
+    public int QuestionId { get; set; }
+    public string AnswerText { get; set; } = string.Empty;
+}

--- a/src/Common/DTOs/Quizzes/SubmittedAnswerDto.cs
+++ b/src/Common/DTOs/Quizzes/SubmittedAnswerDto.cs
@@ -1,5 +1,6 @@
 ﻿namespace SSW.Rewards.Shared.DTOs.Quizzes;
 
+// TODO [tech-debt]: Delete once GPT quiz engine is working
 public class SubmittedAnswerDto
 {
     public int QuestionId { get; set; }

--- a/src/Domain/Entities/CompletedQuiz.cs
+++ b/src/Domain/Entities/CompletedQuiz.cs
@@ -1,4 +1,5 @@
 ﻿namespace SSW.Rewards.Domain.Entities;
+
 public class CompletedQuiz : BaseEntity
 {
     public int UserId { get; set; }
@@ -7,4 +8,7 @@ public class CompletedQuiz : BaseEntity
     public virtual Quiz Quiz { get; set; }
     public bool Passed { get; set; }
     public List<SubmittedQuizAnswer> Answers { get; set; } = new();
+
+    // TODO: Add a start date/time so we can add a time limit to completing the quiz
+    // as this record should be created when they first begin the quiz.
 }

--- a/src/Domain/Entities/QuizQuestion.cs
+++ b/src/Domain/Entities/QuizQuestion.cs
@@ -5,4 +5,5 @@ public class QuizQuestion : BaseEntity
     public virtual Quiz Quiz { get; set; } = null!;
     public string? Text { get; set; } = string.Empty;
     public virtual ICollection<QuizAnswer> Answers { get; set; } = new HashSet<QuizAnswer>();
+    public virtual ICollection<SubmittedQuizAnswer> UserAnswers { get; set; } = new HashSet<SubmittedQuizAnswer>();
 }

--- a/src/Domain/Entities/SubmittedQuizAnswer.cs
+++ b/src/Domain/Entities/SubmittedQuizAnswer.cs
@@ -4,8 +4,8 @@ public class SubmittedQuizAnswer : BaseEntity
     public int SubmissionId { get; set; }
     public CompletedQuiz Submission { get; set; }
     
-    public int QuizQuestionId { get; set; }
-    public QuizQuestion QuizQuestion { get; set; }
+    public int? QuizQuestionId { get; set; }
+    public QuizQuestion? QuizQuestion { get; set; }
     public string AnswerText { get; set; } = string.Empty;
     public bool Correct { get; set; }
     public string GPTExplanation { get; set; } = string.Empty;

--- a/src/Domain/Entities/SubmittedQuizAnswer.cs
+++ b/src/Domain/Entities/SubmittedQuizAnswer.cs
@@ -3,7 +3,16 @@ public class SubmittedQuizAnswer : BaseEntity
 {
     public int SubmissionId { get; set; }
     public CompletedQuiz Submission { get; set; }
+    
+    public int QuizQuestionId { get; set; }
+    public QuizQuestion QuizQuestion { get; set; }
+    public string AnswerText { get; set; } = string.Empty;
+    public bool Correct { get; set; }
+    public string GPTExplanation { get; set; } = string.Empty;
+    public int GPTConfidence { get; set; }
 
+    // TODO [tech debt]: Remove these fields once we are happy with the GPT iteration
     public int? AnswerId { get; set; }
     public QuizAnswer? Answer { get; set; }
+
 }

--- a/src/Infrastructure/ConfigureServices.cs
+++ b/src/Infrastructure/ConfigureServices.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using SSW.Rewards.Application.Common.Interfaces;
 using SSW.Rewards.Application.Common.Models;
 using SSW.Rewards.Infrastructure;
+using SSW.Rewards.Infrastructure.Options;
 using SSW.Rewards.Infrastructure.Persistence;
 using SSW.Rewards.Infrastructure.Persistence.Interceptors;
 using SSW.Rewards.Infrastructure.Services;
@@ -16,8 +17,13 @@ public static class ConfigureServices
 {
     public static IServiceCollection AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddHttpClient();
+        
         services.AddScoped<AuditableEntitySaveChangesInterceptor>();
         services.AddScoped<AchievementIntegrationIdInterceptor>();
+        services.AddOptions<GPTServiceOptions>()
+            .Configure(configuration.GetSection(nameof(GPTServiceOptions)).Bind);
+        services.AddScoped<IQuizGPTService, QuizGPTService>();
 
         services.AddDbContext<ApplicationDbContext>(options =>
         {

--- a/src/Infrastructure/Options/GPTServiceOptions.cs
+++ b/src/Infrastructure/Options/GPTServiceOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SSW.Rewards.Infrastructure.Options;
+public sealed class GPTServiceOptions
+{
+    public string? Url { get; set; }
+}

--- a/src/Infrastructure/Persistence/Configurations/QuizConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/QuizConfiguration.cs
@@ -25,3 +25,27 @@ public class QuizAnswerConfiguration : IEntityTypeConfiguration<QuizAnswer>
             .HasForeignKey(x => x.QuestionId);
     }
 }
+
+public class QuizQuestionConfiguration : IEntityTypeConfiguration<QuizQuestion>
+{
+    public void Configure(EntityTypeBuilder<QuizQuestion> builder)
+    {
+        builder
+            .HasMany(x => x.UserAnswers)
+            .WithOne(x => x.QuizQuestion)
+            .HasForeignKey(x => x.QuizQuestionId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+
+public class SubmittedAnswerConfiguration : IEntityTypeConfiguration<SubmittedQuizAnswer>
+{
+    public void Configure(EntityTypeBuilder<SubmittedQuizAnswer> builder)
+    {
+        builder
+            .HasOne(x => x.QuizQuestion)
+            .WithMany(x => x.UserAnswers)
+            .HasForeignKey(x => x.QuizQuestionId)
+            .OnDelete(DeleteBehavior.NoAction);
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/20240122031047_AddGPTQuizFields.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240122031047_AddGPTQuizFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SSW.Rewards.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using SSW.Rewards.Infrastructure.Persistence;
 namespace SSW.Rewards.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240122031047_AddGPTQuizFields")]
+    partial class AddGPTQuizFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20240122031047_AddGPTQuizFields.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240122031047_AddGPTQuizFields.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SSW.Rewards.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGPTQuizFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AnswerText",
+                table: "SubmittedAnswers",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Correct",
+                table: "SubmittedAnswers",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "GPTConfidence",
+                table: "SubmittedAnswers",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GPTExplanation",
+                table: "SubmittedAnswers",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "QuizQuestionId",
+                table: "SubmittedAnswers",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SubmittedAnswers_QuizQuestionId",
+                table: "SubmittedAnswers",
+                column: "QuizQuestionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SubmittedAnswers_QuizQuestions_QuizQuestionId",
+                table: "SubmittedAnswers",
+                column: "QuizQuestionId",
+                principalTable: "QuizQuestions",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SubmittedAnswers_QuizQuestions_QuizQuestionId",
+                table: "SubmittedAnswers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SubmittedAnswers_QuizQuestionId",
+                table: "SubmittedAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "AnswerText",
+                table: "SubmittedAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "Correct",
+                table: "SubmittedAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "GPTConfidence",
+                table: "SubmittedAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "GPTExplanation",
+                table: "SubmittedAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "QuizQuestionId",
+                table: "SubmittedAnswers");
+        }
+    }
+}

--- a/src/Infrastructure/Services/QuizGPTService.cs
+++ b/src/Infrastructure/Services/QuizGPTService.cs
@@ -1,0 +1,34 @@
+﻿using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using SSW.Rewards.Application.Common.Interfaces;
+using SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+using SSW.Rewards.Infrastructure.Options;
+
+namespace SSW.Rewards.Infrastructure.Services;
+
+public sealed class QuizGPTService : IQuizGPTService
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _url;
+    public QuizGPTService(IOptions<GPTServiceOptions> options, IHttpClientFactory httpFactory)
+    {
+        this._url        = options.Value.Url ?? throw new ArgumentNullException("No options for GPT Service found!");
+        this._httpClient = httpFactory.CreateClient();
+    }
+    public async Task<QuizGPTResponseDto> ValidateAnswer(QuizGPTRequestDto model, CancellationToken ct)
+    {
+        var json        = JsonSerializer.Serialize(model);
+        var data        = new StringContent(json, Encoding.UTF8, "application/json");
+        var response    = await _httpClient.PostAsync(_url, data, ct);
+        
+        response.EnsureSuccessStatusCode();
+        var responseString = await response.Content.ReadAsStringAsync();
+        QuizGPTResponseDto? result = JsonSerializer.Deserialize<QuizGPTResponseDto>(responseString);
+
+        if (result == null)
+            throw new Exception("Response from GPT API was null");
+        
+        return result;
+    }
+}

--- a/src/WebAPI/Controllers/QuizzesController.cs
+++ b/src/WebAPI/Controllers/QuizzesController.cs
@@ -108,7 +108,7 @@ public class QuizzesController : ApiControllerBase
             return StatusCode(202);
     }
     
-    // GPT quiz-related endpoint 4/3
+    // GPT quiz-related endpoint 4/4
     [HttpGet]
     public async Task<ActionResult<QuizResultDto>> GetQuizResults(int submissionId)
     {

--- a/src/WebAPI/Controllers/QuizzesController.cs
+++ b/src/WebAPI/Controllers/QuizzesController.cs
@@ -8,6 +8,10 @@ using SSW.Rewards.WebAPI.Authorisation;
 using SSW.Rewards.Application.Quizzes.Queries.GetAdminQuizList;
 using SSW.Rewards.Application.Quizzes.Queries.GetAdminQuizDetails;
 using SSW.Rewards.Application.Quizzes.Queries.GetQuizDetails;
+using SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
+using SSW.Rewards.Application.Quizzes.Commands.BeginQuiz;
+using SSW.Rewards.Application.Quizzes.Queries.GetQuizQuestionsBySubmissionId;
+using SSW.Rewards.Application.Quizzes.Queries.GetQuizResults;
 
 namespace SSW.Rewards.WebAPI.Controllers;
 
@@ -69,6 +73,30 @@ public class QuizzesController : ApiControllerBase
         }));
     }
 
+    // New GPT quiz-related endpoints
+    [HttpPost]
+    public async Task<ActionResult<List<QuizQuestionDto>>> BeginQuiz(int quizId)
+    {
+        int submissionId = await Mediator.Send(new BeginQuizCommand { QuizId = quizId });
+        List<QuizQuestionDto> results = await Mediator.Send(new GetQuizQuestionsBySubmissionIdQuery { SubmissionId = submissionId });
+        return Ok(results);
+    }
+    
+    [HttpPost]
+    public async Task<ActionResult> SubmitAnswer(SubmitQuizAnswerDto model)
+    {
+        await Mediator.Send(new SubmitAnswerCommand { SubmissionId = model.SubmissionId, QuestionId = model.QuestionId, AnswerText = model.AnswerText });
+        return Ok();
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<QuizResultDto>> GetQuizResults(int submissionId)
+    {
+        var results = await Mediator.Send(new GetQuizResultsQuery { SubmissionId = submissionId });
+        return Ok(results);
+    }
+
     // TODO: Add endpoints for Admins to be able to add/update/delete quizzes and quiz questions.
     // See: https://github.com/SSWConsulting/SSW.Rewards.API/issues/5
 }
+

--- a/src/WebAPI/Controllers/QuizzesController.cs
+++ b/src/WebAPI/Controllers/QuizzesController.cs
@@ -12,6 +12,7 @@ using SSW.Rewards.Application.Quizzes.Commands.SubmitAnswerCommand;
 using SSW.Rewards.Application.Quizzes.Commands.BeginQuiz;
 using SSW.Rewards.Application.Quizzes.Queries.GetQuizQuestionsBySubmissionId;
 using SSW.Rewards.Application.Quizzes.Queries.GetQuizResults;
+using SSW.Rewards.Application.Quizzes.Queries.CheckQuizCompletion;
 
 namespace SSW.Rewards.WebAPI.Controllers;
 
@@ -73,7 +74,7 @@ public class QuizzesController : ApiControllerBase
         }));
     }
 
-    // New GPT quiz-related endpoints
+    // GPT quiz-related endpoint 1/3
     [HttpPost]
     public async Task<ActionResult<List<QuizQuestionDto>>> BeginQuiz(int quizId)
     {
@@ -82,6 +83,7 @@ public class QuizzesController : ApiControllerBase
         return Ok(results);
     }
     
+    // GPT quiz-related endpoint 2/3
     [HttpPost]
     public async Task<ActionResult> SubmitAnswer(SubmitQuizAnswerDto model)
     {
@@ -89,6 +91,17 @@ public class QuizzesController : ApiControllerBase
         return Ok();
     }
 
+    [HttpGet]
+    public async Task<ActionResult> CheckQuizCompletion(int submissionId)
+    {
+        bool b = await Mediator.Send(new CheckQuizCompletionQuery { SubmissionId = submissionId });
+        if (b)
+            return Ok();
+        else
+            return StatusCode(202);
+    }
+    
+    // GPT quiz-related endpoint 3/3
     [HttpGet]
     public async Task<ActionResult<QuizResultDto>> GetQuizResults(int submissionId)
     {
@@ -99,4 +112,3 @@ public class QuizzesController : ApiControllerBase
     // TODO: Add endpoints for Admins to be able to add/update/delete quizzes and quiz questions.
     // See: https://github.com/SSWConsulting/SSW.Rewards.API/issues/5
 }
-

--- a/src/WebAPI/Controllers/QuizzesController.cs
+++ b/src/WebAPI/Controllers/QuizzesController.cs
@@ -76,11 +76,17 @@ public class QuizzesController : ApiControllerBase
 
     // GPT quiz-related endpoint 1/3
     [HttpPost]
-    public async Task<ActionResult<List<QuizQuestionDto>>> BeginQuiz(int quizId)
+    public async Task<ActionResult<BeginQuizDto>> BeginQuiz([FromBody]int quizId)
     {
         int submissionId = await Mediator.Send(new BeginQuizCommand { QuizId = quizId });
         List<QuizQuestionDto> results = await Mediator.Send(new GetQuizQuestionsBySubmissionIdQuery { SubmissionId = submissionId });
-        return Ok(results);
+
+        BeginQuizDto model = new BeginQuizDto
+        {
+            SubmissionId = submissionId,
+            Questions = results
+        };
+        return Ok(model);
     }
     
     // GPT quiz-related endpoint 2/3

--- a/src/WebAPI/Controllers/QuizzesController.cs
+++ b/src/WebAPI/Controllers/QuizzesController.cs
@@ -74,7 +74,7 @@ public class QuizzesController : ApiControllerBase
         }));
     }
 
-    // GPT quiz-related endpoint 1/3
+    // GPT quiz-related endpoint 1/4
     [HttpPost]
     public async Task<ActionResult<BeginQuizDto>> BeginQuiz([FromBody]int quizId)
     {
@@ -89,7 +89,7 @@ public class QuizzesController : ApiControllerBase
         return Ok(model);
     }
     
-    // GPT quiz-related endpoint 2/3
+    // GPT quiz-related endpoint 2/4
     [HttpPost]
     public async Task<ActionResult> SubmitAnswer(SubmitQuizAnswerDto model)
     {
@@ -97,6 +97,7 @@ public class QuizzesController : ApiControllerBase
         return Ok();
     }
 
+    // GPT quiz-related endpoint 3/4
     [HttpGet]
     public async Task<ActionResult> CheckQuizCompletion(int submissionId)
     {
@@ -107,7 +108,7 @@ public class QuizzesController : ApiControllerBase
             return StatusCode(202);
     }
     
-    // GPT quiz-related endpoint 3/3
+    // GPT quiz-related endpoint 4/3
     [HttpGet]
     public async Task<ActionResult<QuizResultDto>> GetQuizResults(int submissionId)
     {

--- a/src/WebAPI/appsettings.json
+++ b/src/WebAPI/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "GPTServiceOptions": {
+    "Url" :  "https://localhost:1234/Quiz/SubmitAnswer"
+  },
   "UserServiceOptions": {
     "StaffSMTPDomain": "ssw.com.au"
   },

--- a/src/WebAPI/appsettings.json
+++ b/src/WebAPI/appsettings.json
@@ -1,6 +1,6 @@
 {
   "GPTServiceOptions": {
-    "Url" :  "https://localhost:1234/Quiz/SubmitAnswer"
+    "Url" :  "https://localhost:7206/Quiz/SubmitAnswer"
   },
   "UserServiceOptions": {
     "StaffSMTPDomain": "ssw.com.au"


### PR DESCRIPTION
This is part 1 of the back-end work. Next step is to make the `SubmitAnswer` endpoint non-blocking, but that can be done as a separate PR.

**WARNING: New `GPTServiceOptions` in `appSettings.json` is a local URL until we have the SSW Azure OpenAI service spun up.**

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Adding GPT quiz API endpoints

> 2. What was changed?

* Added new endpoints to QuizzesController, along with corresponding commands/queries.
* Schema changes to include new GPT-returned fields

> 3. Did you do pair or mob programming?

Sorta kinda.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->