### PR TITLE
Revert accidental pushes to main

### DIFF
--- a/_docs/Instructions-Compile.md
+++ b/_docs/Instructions-Compile.md
@@ -9,6 +9,7 @@
 - iOS SDK setup/installed w/ Xamarin (https://docs.microsoft.com/en-us/xamarin/ios/get-started/installation/)
 - [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) (Easy way to upload and download files (see Local Emulator Database)
 - [Azure Data Studio](https://azure.microsoft.com/en-us/products/data-studio/) (Not required, can use IDE Tools for DB Querying)
+- [PowerShell Core](https://github.com/PowerShell/PowerShell)
 
 - Install Dev Tunnels or Ngrok see the rule https://ssw.com.au/rules/port-forwarding/
   - [dev tunnels](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=macos) (Recommended)
@@ -26,7 +27,6 @@
 2. Get the Secrets from Keeper 
    1. **Client Secrets | SSW | SSW.Rewards | Developer Secrets**
    2. Add them as .NET User Secrets for `WebAPI.csproj`
-   3. Replace placeholder keys in `appsettings.*.json` with the values from the .NET User Secrets.
 3. Create a Developer Certificate https://learn.microsoft.com/en-us/aspnet/core/security/docker-https?view=aspnetcore-8.0#certificates
    1. Create `WebAPI.pfx` with a password of `ThisPassword` (You can change change this, but the `docker-compose.yml` should be updated appropriately)
 
@@ -45,17 +45,19 @@ dotnet dev-certs https --trust
 
 4. Cd into the Repo
 5. Run the Docker Containers
+* On Windows, open PowerShell and run:
  ```bash
- docker compose build
- docker compose --profile all up -d
- ```   
-
+ ./up.ps1
+ ```
+* On macOS or Linux, open a terminal and run:
+```bash
+pwsh ./up
+```
+  
 You should now be able to access the AdminUI hosted locally at https://localhost:7137  
-
-
+  
 You should now be able to access the WebAPI Swagger docs at https://localhost:5001/swagger/index.html
 
-  
 **Note:** You can run only the WebAPI or AdminUI by running:
 ```bash
 docker compose --profile webapi up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   # SQL Server
@@ -9,7 +9,7 @@ services:
       - ACCEPT_EULA=1
     ports:
       - 1433:1433
-  
+
   # Azurite
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite
@@ -32,9 +32,8 @@ services:
       - ASPNETCORE_Kestrel__Certificates__Default__Password=ThisPassword
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/WebAPI.pfx
     volumes:
-       - ~/.aspnet/https:/https:ro
-    profiles: ['all', 'webapi']
-    
+      - ${CERTS_PATH}:/https:ro
+    profiles: ["all", "webapi"]
 
   # Admin UI
   adminui:
@@ -50,5 +49,5 @@ services:
       - ASPNETCORE_Kestrel__Certificates__Default__Password=ThisPassword
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/WebAPI.pfx
     volumes:
-      - ~/.aspnet/https:/https:ro
-    profiles: ['all', 'admin']
+      - ${CERTS_PATH}:/https:ro
+    profiles: ["all", "admin"]

--- a/up.ps1
+++ b/up.ps1
@@ -1,0 +1,43 @@
+Write-Host "🏗️ Creating SSW Rewards docker environment..."
+
+Write-Host "Checking for .env file..."
+
+if (-not(Test-Path "./.env")) {
+    Write-Host "🚧 Setting up docker environment..."
+
+    $homeFolderPath = Resolve-Path ~
+
+    $certsPath = "$homeFolderPath/.aspnet/https"
+
+    $devCertPath = "$certsPath/WebAPI.pfx"
+
+    if (-not(Test-Path $devCertPath)) {
+        Write-Host "Developer certificate not found."
+        Write-Host "Run the followin commands, then run this script again."
+
+        if ($IsWindows) {
+            Write-Host "dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\WebAPI.pfx -p ThisPassword"
+        }
+        else {
+            Write-Host "dotnet dev-certs https -ep ${HOME}/.aspnet/https/WebAPI.pfx -p ThisPassword"
+        }
+
+        Write-Host "dotnet dev-certs https --trust"
+
+        exit -1
+    }
+
+    "CERTS_PATH=$certsPath" | Out-File -Encoding utf8 -FilePath "./.env"
+}
+
+Write-Host "✅ Done!"
+
+Write-Host "🏗️ Building docker images..."
+
+docker-compose build
+
+Write-Host "✅ Done!"
+
+Write-Host "▶️ Starting docker containers..."
+
+docker compose --profile all up -d


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Branch protection rules were inadvertently overwritten when we added `settings.yml` to the repo. Accidental pushes to main have then occurred; this PR reverts them.

> 2. What was changed?

✏️ Revert to the last merged commit prior to accidental pushes to main

> 3. Did you do pair or mob programming?

✏️ I worked with @lukecookssw and @tkapa 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->