### PR TITLE
Added missing field to db create

### DIFF
--- a/src/Infrastructure/Services/QuizGPTService.cs
+++ b/src/Infrastructure/Services/QuizGPTService.cs
@@ -124,7 +124,8 @@ public sealed class QuizGPTService : IQuizGPTService
             AnswerText          = request.AnswerText,
             Correct             = result.Correct,
             GPTConfidence       = result.Confidence,
-            GPTExplanation      = result.Explanation
+            GPTExplanation      = result.Explanation,
+            CreatedUtc          = DateTime.UtcNow
         };
         await _context.SubmittedAnswers.AddAsync(answer);
         await _context.SaveChangesAsync(CancellationToken.None);


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Spotted missing field population.

> 2. What was changed?

`CreatedUtc` is now being set on creating a new Submitted Answer.

> 3. Did you do pair or mob programming?

✏️ 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->