### PR TITLE
♻️ Mobile - V3 Earn page improvements

### DIFF
--- a/src/MobileUI/Controls/PointsButton.xaml
+++ b/src/MobileUI/Controls/PointsButton.xaml
@@ -38,8 +38,15 @@
             <Border Grid.Column="2"
                     HeightRequest="34"
                     WidthRequest="36"
-                    Background="{StaticResource BrandBrush}"
+                    BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                     StrokeThickness="0">
+                <Border.Triggers>
+                    <DataTrigger TargetType="Border"
+                                 Binding="{Binding IsDisabled, Source={x:Reference this}}"
+                                 Value="false">
+                        <Setter Property="Background" Value="{StaticResource BrandBrush}"/>
+                    </DataTrigger>
+                </Border.Triggers>
                 <Border.StrokeShape>
                     <RoundRectangle CornerRadius="6" />
                 </Border.StrokeShape>
@@ -51,7 +58,15 @@
                            VerticalOptions="Center"
                            HorizontalTextAlignment="Center"
                            VerticalTextAlignment="Center"
-                           Style="{StaticResource LabelBold}" />
+                           Style="{StaticResource LabelBold}">
+                        <Label.Triggers>
+                            <DataTrigger TargetType="Label"
+                                         Binding="{Binding IsDisabled, Source={x:Reference this}}"
+                                         Value="true">
+                                <Setter Property="TextColor" Value="{StaticResource Gray400}"/>
+                            </DataTrigger>
+                        </Label.Triggers>
+                    </Label>
                 </Grid>
             </Border>
         </Grid>

--- a/src/MobileUI/Controls/PointsButton.xaml.cs
+++ b/src/MobileUI/Controls/PointsButton.xaml.cs
@@ -33,6 +33,20 @@ public partial class PointsButton : ContentView
             string.Empty
         );
     
+    public bool IsDisabled
+    {
+        get => (bool)GetValue(IsDisabledProperty);
+        set => SetValue(IsDisabledProperty, value);
+    }
+
+    public static readonly BindableProperty IsDisabledProperty =
+        BindableProperty.Create(
+            nameof(IsDisabled),
+            typeof(bool),
+            typeof(PointsButton),
+            false
+        );
+    
     public PointsButton()
     {
         InitializeComponent();

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml
@@ -115,7 +115,7 @@
                                   Margin="20">
                         <CarouselView.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:EarnQuestionViewModel">
-                                <Grid RowDefinitions="80,*" RowSpacing="40">
+                                <Grid RowDefinitions="80,Auto" RowSpacing="40">
                                     <Label Grid.Row="0"
                                            HorizontalOptions="FillAndExpand"
                                            VerticalOptions="FillAndExpand"
@@ -131,7 +131,8 @@
                                         <Border.StrokeShape>
                                             <RoundRectangle CornerRadius="8" />
                                         </Border.StrokeShape>
-                                        <Editor Text="{Binding Answer}"
+                                        <Entry Text="{Binding Answer}"
+                                                Placeholder="Enter your answer here"
                                                 BackgroundColor="White"
                                                 TextColor="Black" />
                                     </Border>

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml
@@ -99,6 +99,7 @@
                     <IndicatorView Grid.Row="4"
                                    SelectedIndicatorColor="{StaticResource SSWRed}"
                                    IndicatorColor="{StaticResource IndicatorColor}"
+                                   IndicatorSize="4.5"
                                    HorizontalOptions="Center"
                                    VerticalOptions="End"
                                    x:Name="QuestionIndicator" />

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -20,6 +20,7 @@
         <ScrollView>
             <Grid RowDefinitions="Auto, *">
                 <CarouselView Grid.Row="0"
+                              x:Name="Carousel"
                               IsVisible="{Binding IsCarouselVisible}"
                               HeightRequest="400"
                               Loop="True"

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -49,7 +49,7 @@
                                     <Grid Grid.Row="0"
                                           RowDefinitions="Auto"
                                           VerticalOptions="End"
-                                          Margin="20,0,20,40">
+                                          Margin="20,0,20,30">
                                         <Border Grid.Row="0"
                                                 BackgroundColor="#BF000000"
                                                 StrokeThickness="0">

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -59,7 +59,8 @@
                                             <Grid ColumnDefinitions="*, Auto" Padding="15">
                                                 <Label Grid.Column="0"
                                                        Text="{Binding Description}"
-                                                       Style="{StaticResource LabelBold}" />
+                                                       Style="{StaticResource LabelBold}"
+                                                       VerticalTextAlignment="Center"/>
                                                 <controls:PointsButton Grid.Column="1"
                                                                        ButtonText="GO"
                                                                        Points="{Binding Points}"

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -26,7 +26,7 @@
                               Loop="True"
                               ItemsSource="{Binding CarouselQuizzes}"
                               HorizontalScrollBarVisibility="Never"
-                              Margin="20"
+                              Margin="15"
                               IndicatorView="QuizIndicator">
                     <CarouselView.ItemTemplate>
                         <DataTemplate x:DataType="quizzes:QuizDto">
@@ -78,13 +78,13 @@
                                IndicatorColor="{StaticResource IndicatorColor}"
                                HorizontalOptions="Center"
                                VerticalOptions="End"
-                               Margin="0,0,0,30"
+                               Margin="0,0,0,25"
                                x:Name="QuizIndicator" />
 
                 <CollectionView
                     Grid.Row="1"
                     ItemsSource="{Binding Quizzes}"
-                    Margin="15,10"
+                    Margin="15,0,15,10"
                     ItemsUpdatingScrollMode="KeepItemsInView"
                     ItemSizingStrategy="MeasureFirstItem">
                     <CollectionView.ItemTemplate>

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -63,7 +63,8 @@
                                                 <controls:PointsButton Grid.Column="1"
                                                                        ButtonText="GO"
                                                                        Points="{Binding Points}"
-                                                                       HorizontalOptions="End" />
+                                                                       HorizontalOptions="End"
+                                                                       IsDisabled="{Binding Passed}"/>
                                             </Grid>
                                         </Border>
                                     </Grid>
@@ -155,7 +156,8 @@
                                         <controls:PointsButton Grid.Column="2"
                                                                ButtonText="GO"
                                                                Points="{Binding Points}"
-                                                               Margin="10,0" />
+                                                               Margin="10,0"
+                                                               IsDisabled="{Binding Passed}"/>
 
                                     </Grid>
                                 </Border>

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -19,73 +19,77 @@
     <ContentPage.Content>
         <ScrollView>
             <Grid RowDefinitions="Auto, *">
-                <CarouselView Grid.Row="0"
-                              x:Name="Carousel"
-                              IsVisible="{Binding IsCarouselVisible}"
-                              HeightRequest="400"
-                              Loop="True"
-                              ItemsSource="{Binding CarouselQuizzes}"
-                              HorizontalScrollBarVisibility="Never"
-                              Margin="15"
-                              IndicatorView="QuizIndicator">
-                    <CarouselView.ItemTemplate>
-                        <DataTemplate x:DataType="quizzes:QuizDto">
-                            <Border StrokeThickness="0">
-                                <Border.StrokeShape>
-                                    <RoundRectangle CornerRadius="8" />
-                                </Border.StrokeShape>
-                                <Border.GestureRecognizers>
-                                    <TapGestureRecognizer
-                                        Command="{Binding Source={x:Reference QuizList}, Path=BindingContext.OpenQuizCommand}"
-                                        CommandParameter="{Binding Id}" />
-                                </Border.GestureRecognizers>
-                                <Grid HeightRequest="400">
-                                    <Image Grid.Row="0"
-                                           Source="{Binding CarouselImage}"
-                                           HorizontalOptions="Center"
-                                           VerticalOptions="Center"
-                                           HeightRequest="400"
-                                           Aspect="AspectFill"/>
-                                    <Grid Grid.Row="0"
-                                          RowDefinitions="Auto"
-                                          VerticalOptions="End"
-                                          Margin="20,0,20,30">
-                                        <Border Grid.Row="0"
-                                                BackgroundColor="#BF000000"
-                                                StrokeThickness="0">
-                                            <Border.StrokeShape>
-                                                <RoundRectangle CornerRadius="6" />
-                                            </Border.StrokeShape>
-                                            <Grid ColumnDefinitions="*, Auto" Padding="15">
-                                                <Label Grid.Column="0"
-                                                       Text="{Binding Description}"
-                                                       Style="{StaticResource LabelBold}"
-                                                       VerticalTextAlignment="Center"/>
-                                                <controls:PointsButton Grid.Column="1"
-                                                                       ButtonText="GO"
-                                                                       Points="{Binding Points}"
-                                                                       HorizontalOptions="End"
-                                                                       IsDisabled="{Binding Passed}"/>
-                                            </Grid>
-                                        </Border>
+                <Grid Grid.Row="0"
+                      RowDefinitions="Auto" 
+                      x:Name="CarouselSection">
+                    <CarouselView Grid.Row="0"
+                                  x:Name="Carousel"
+                                  HeightRequest="400"
+                                  Loop="True"
+                                  ItemsSource="{Binding CarouselQuizzes}"
+                                  HorizontalScrollBarVisibility="Never"
+                                  Margin="15"
+                                  IndicatorView="QuizIndicator">
+                        <CarouselView.ItemTemplate>
+                            <DataTemplate x:DataType="quizzes:QuizDto">
+                                <Border StrokeThickness="0">
+                                    <Border.StrokeShape>
+                                        <RoundRectangle CornerRadius="8" />
+                                    </Border.StrokeShape>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={x:Reference QuizList}, Path=BindingContext.OpenQuizCommand}"
+                                            CommandParameter="{Binding Id}" />
+                                    </Border.GestureRecognizers>
+                                    <Grid HeightRequest="400">
+                                        <Image Grid.Row="0"
+                                               Source="{Binding CarouselImage}"
+                                               HorizontalOptions="Center"
+                                               VerticalOptions="Center"
+                                               HeightRequest="400"
+                                               Aspect="AspectFill" />
+                                        <Grid Grid.Row="0"
+                                              RowDefinitions="Auto"
+                                              VerticalOptions="End"
+                                              Margin="20,0,20,30">
+                                            <Border Grid.Row="0"
+                                                    BackgroundColor="#BF000000"
+                                                    StrokeThickness="0">
+                                                <Border.StrokeShape>
+                                                    <RoundRectangle CornerRadius="6" />
+                                                </Border.StrokeShape>
+                                                <Grid ColumnDefinitions="*, Auto" Padding="15">
+                                                    <Label Grid.Column="0"
+                                                           Text="{Binding Description}"
+                                                           Style="{StaticResource LabelBold}"
+                                                           VerticalTextAlignment="Center" />
+                                                    <controls:PointsButton Grid.Column="1"
+                                                                           ButtonText="GO"
+                                                                           Points="{Binding Points}"
+                                                                           HorizontalOptions="End"
+                                                                           IsDisabled="{Binding Passed}" />
+                                                </Grid>
+                                            </Border>
+                                        </Grid>
                                     </Grid>
-                                </Grid>
-                            </Border>
-                        </DataTemplate>
-                    </CarouselView.ItemTemplate>
-                </CarouselView>
+                                </Border>
+                            </DataTemplate>
+                        </CarouselView.ItemTemplate>
+                    </CarouselView>
 
-                <IndicatorView Grid.Row="0"
-                               SelectedIndicatorColor="{StaticResource SSWRed}"
-                               IndicatorColor="{StaticResource IndicatorColor}"
-                               IndicatorSize="4.5"
-                               HorizontalOptions="Center"
-                               VerticalOptions="End"
-                               Margin="0,0,0,25"
-                               x:Name="QuizIndicator" />
+                    <IndicatorView Grid.Row="0"
+                                   SelectedIndicatorColor="{StaticResource SSWRed}"
+                                   IndicatorColor="{StaticResource IndicatorColor}"
+                                   IndicatorSize="4.5"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="End"
+                                   Margin="0,0,0,25"
+                                   x:Name="QuizIndicator" />
+                </Grid>
 
                 <CollectionView
                     Grid.Row="1"
+                    x:Name="QuizListSection"
                     ItemsSource="{Binding Quizzes}"
                     Margin="15,0,15,10"
                     ItemsUpdatingScrollMode="KeepItemsInView"
@@ -158,7 +162,7 @@
                                                                ButtonText="GO"
                                                                Points="{Binding Points}"
                                                                Margin="10,0"
-                                                               IsDisabled="{Binding Passed}"/>
+                                                               IsDisabled="{Binding Passed}" />
 
                                     </Grid>
                                 </Border>

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -76,6 +76,7 @@
                 <IndicatorView Grid.Row="0"
                                SelectedIndicatorColor="{StaticResource SSWRed}"
                                IndicatorColor="{StaticResource IndicatorColor}"
+                               IndicatorSize="4.5"
                                HorizontalOptions="Center"
                                VerticalOptions="End"
                                Margin="0,0,0,25"

--- a/src/MobileUI/Pages/EarnPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnPage.xaml.cs
@@ -5,6 +5,8 @@ public partial class EarnPage : ContentPage
     private readonly EarnViewModel _viewModel;
 
     private IDispatcherTimer _timer;
+    
+    private bool _isLoaded;
 
     public EarnPage(EarnViewModel viewModel)
     {
@@ -17,6 +19,7 @@ public partial class EarnPage : ContentPage
     {
         base.OnAppearing();
         await _viewModel.Initialise();
+        await Animate();
         BeginAutoScroll();
     }
     
@@ -43,5 +46,29 @@ public partial class EarnPage : ContentPage
             if (count > 0)
                 Carousel.Position = (Carousel.Position + 1) % count;
         });
+    }
+    
+    private async Task Animate()
+    {
+        if (_isLoaded)
+        {
+            return;
+        }
+        
+        CarouselSection.Opacity = 0;
+        CarouselSection.TranslationY = -400;
+        
+        QuizListSection.Opacity = 0;
+        QuizListSection.TranslationY = 400;
+        
+        await Task.WhenAll
+        (
+            CarouselSection.FadeTo(1, 600, Easing.CubicIn),
+            QuizListSection.FadeTo(1, 600, Easing.CubicIn),
+            CarouselSection.TranslateTo(0, 0, 600, Easing.SinIn),
+            QuizListSection.TranslateTo(0, 0, 600, Easing.SinIn)
+        );
+        
+        _isLoaded = true;
     }
 }

--- a/src/MobileUI/Pages/EarnPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnPage.xaml.cs
@@ -39,7 +39,9 @@ public partial class EarnPage : ContentPage
         MainThread.BeginInvokeOnMainThread(() =>
         {
             var count = _viewModel.CarouselQuizzes.Count;
-            Carousel.Position = (Carousel.Position + 1) % count;
+            
+            if (count > 0)
+                Carousel.Position = (Carousel.Position + 1) % count;
         });
     }
 }

--- a/src/MobileUI/Pages/EarnPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnPage.xaml.cs
@@ -4,6 +4,8 @@ public partial class EarnPage : ContentPage
 {
     private readonly EarnViewModel _viewModel;
 
+    private IDispatcherTimer _timer;
+
     public EarnPage(EarnViewModel viewModel)
     {
         InitializeComponent();
@@ -15,5 +17,29 @@ public partial class EarnPage : ContentPage
     {
         base.OnAppearing();
         await _viewModel.Initialise();
+        BeginAutoScroll();
+    }
+    
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _timer.Stop();
+    }
+
+    private void BeginAutoScroll()
+    {
+        _timer = Application.Current.Dispatcher.CreateTimer();
+        _timer.Interval = TimeSpan.FromSeconds(3);
+        _timer.Tick += (s,e) => Scroll();
+        _timer.Start();
+    }
+    
+    private void Scroll()
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            var count = _viewModel.CarouselQuizzes.Count;
+            Carousel.Position = (Carousel.Position + 1) % count;
+        });
     }
 }

--- a/src/MobileUI/ViewModels/EarnViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnViewModel.cs
@@ -20,9 +20,6 @@ public partial class EarnViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
 
     public ICommand OpenQuizCommand { get; set; }
 
-    [ObservableProperty]
-    private bool _isCarouselVisible;
-
     public EarnViewModel(IQuizService quizService)
     {
         _quizService = quizService;
@@ -60,7 +57,6 @@ public partial class EarnViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
             
             if (quiz.IsCarousel)
             {
-                IsCarouselVisible = true;
                 CarouselQuizzes.Add(quiz);
             }
         }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Related to #559

Adds tweaks and missing features to the Earn page that didn't quite make it to PR #606

> 2. What was changed?

1. Adds auto scrolling to the carousel
2. Adds a disabled visual state to the GO buttons for when a quiz is already passed
3. Changes Editor to Entry for answer input to fix issues with text disappearing under the keyboard and misaligned placeholder text, and allows for more intuitive entry with use of the Return key.
4. Tweaks margins and other design elements like carousel indicators to better align with the V3 mockups.
5. Adds animation to Earn page load

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/c09b0c99-0f6e-44bd-9844-c905c9c73114" width="400" />

**Figure: Tweaked design to better match mockups**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/d556e68d-eb19-4ccb-94d4-2ce25195142f" width="400" />

**Figure: Improved input handling and display**

> 3. Did you do pair or mob programming?

No 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->