### PR TITLE
🐛 Mobile | Stabilisation before release | Fix snackbar

### DIFF
--- a/src/MobileUI/Controls/Snackbar.xaml
+++ b/src/MobileUI/Controls/Snackbar.xaml
@@ -10,8 +10,7 @@
             StrokeThickness="0"
             WidthRequest="300"
             x:Name="GridBackground">
-        <Grid x:Name="MainLayout"
-              HorizontalOptions="CenterAndExpand"
+        <Grid HorizontalOptions="CenterAndExpand"
               Margin="5"
               Padding="5"
               WidthRequest="300"
@@ -26,6 +25,7 @@
                    HeightRequest="40"
                    WidthRequest="40"
                    Margin="10,0"
+                   Padding="{OnPlatform Android='0,5,0,0', iOS='0'}"
                    HorizontalOptions="Start"
                    VerticalOptions="Center"
                    VerticalTextAlignment="Center"
@@ -57,7 +57,7 @@
                    HorizontalTextAlignment="Center"
                    x:Name="TickLabel"/>
 
-            <!--End points coint-->
+            <!-- End points coin -->
             <Label Grid.Column="1"
                    Grid.ColumnSpan="2"
                    x:Name="PointsLabel"

--- a/src/MobileUI/Controls/Snackbar.xaml.cs
+++ b/src/MobileUI/Controls/Snackbar.xaml.cs
@@ -1,10 +1,8 @@
-﻿using CommunityToolkit.Maui.Views;
+﻿namespace SSW.Rewards.Mobile.Controls;
 
-namespace SSW.Rewards.Mobile.Controls;
-
-public partial class Snackbar : Popup
+public partial class Snackbar
 {
-    private static SnackbarOptions DefaultOptions = new SnackbarOptions
+    private static SnackbarOptions defaultOptions = new()
     {
         ActionCompleted = true,
         Glyph = "\uf3ca",
@@ -17,16 +15,12 @@ public partial class Snackbar : Popup
     public Snackbar(SnackbarOptions? options = null)
     {
         InitializeComponent();
-
         SetOptions(options);
     }
 
     private void SetOptions(SnackbarOptions options)
     {
-        if (options == null)
-        {
-            options = DefaultOptions;
-        }
+        options ??= defaultOptions;
 
         if (options.ActionCompleted)
         {
@@ -41,17 +35,8 @@ public partial class Snackbar : Popup
             GlyphIconLabel.BackgroundColor = Color.FromArgb("414141");
         }
 
-
         GlyphIconLabel.Text = options.Glyph;
-
-        if (options.GlyphIsBrand)
-        {
-            GlyphIconLabel.FontFamily = "FA6Brands";
-        }
-        else
-        {
-            GlyphIconLabel.FontFamily = "FluentIcons";
-        }
+        GlyphIconLabel.FontFamily = options.GlyphIsBrand ? "FA6Brands" : "FluentIcons";
 
         MessageLabel.Text = options.Message;
         TickLabel.IsVisible = !options.ShowPoints && options.ActionCompleted;
@@ -64,22 +49,16 @@ public partial class Snackbar : Popup
     private async Task SetDismissTimer()
     {
         await Task.Delay(5000);
-
-        Close();
+        await CloseAsync();
     }
 }
 
 public class SnackbarOptions
 {
-public bool ActionCompleted { get; set; }
-
-public string Glyph { get; set; }
-
-public string Message { get; set; }
-
-public bool GlyphIsBrand { get; set; }
-
-public int Points { get; set; }
-
-public bool ShowPoints { get; set; }
+    public bool ActionCompleted { get; set; }
+    public string Glyph { get; set; }
+    public string Message { get; set; }
+    public bool GlyphIsBrand { get; set; }
+    public int Points { get; set; }
+    public bool ShowPoints { get; set; }
 }


### PR DESCRIPTION
align icon vertically on Android

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Task 1 on #609

> 2. What was changed?

✏️ Use `await CloseAsync` instead of `Close`
✏️ Align achievement icon in the snackbar vertically

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->