### PR TITLE
🐛 Mobile | Stabilisation before release | Fix Leaderboard not updating

### DIFF
--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -32,7 +32,7 @@
 
             <Grid Grid.Row="1"
                   ColumnDefinitions="6*,14*,6*">
-                <!-- 3rd -->
+                <!-- 2nd -->
                 <controls:Podium Leader="{Binding Second}"
                                  Grid.Column="0"/>
                 
@@ -40,7 +40,7 @@
                 <controls:Podium Leader="{Binding First}"
                                  Grid.Column="1"/>
 
-                <!-- 2nd -->
+                <!-- 3rd -->
                 <controls:Podium Leader="{Binding Third}"
                                  Grid.Column="2"/>
             </Grid>

--- a/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
+++ b/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
@@ -192,6 +192,10 @@ public partial class LeaderBoardViewModel : BaseViewModel, IRecipient<PointsAwar
         await UpdateSearchResults(leaders);
         UpdateMyRankIfRequired(leaders.FirstOrDefault(l => l.IsMe == true));
 
+        // setting to null to trigger PropertyChanged event
+        First = null!;
+        Second = null!;
+        Third = null!;
         First = leaders.FirstOrDefault();
         Second = leaders.Skip(1).FirstOrDefault();
         Third = leaders.Skip(2).FirstOrDefault();


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #609 

> 2. What was changed?

✏️ Set properties to `null`, so that `PropertyChanged` event is triggered

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->