### PR TITLE
🐛 Mobile - Fix QR code showing for non-SSW accounts

### DIFF
--- a/src/MobileUI/Services/UserService.cs
+++ b/src/MobileUI/Services/UserService.cs
@@ -96,45 +96,13 @@ public class UserService : IUserService, IDisposable
     {
         var user = await _userClient.GetCurrentUser();
 
-        if (user is null)
-        {
-            return;
-        }
-
-        if (!string.IsNullOrWhiteSpace(user.FullName))
-        {
-            Preferences.Set(nameof(MyName), user.FullName);
-        }
-
-        if (!string.IsNullOrWhiteSpace(user.Email))
-        {
-            Preferences.Set(nameof(MyEmail), user.Email);
-        }
-
-        if (!string.IsNullOrWhiteSpace(user.Id.ToString()))
-        {
-            Preferences.Set(nameof(MyUserId), user.Id);
-        }
-
-        if (!string.IsNullOrWhiteSpace(user.ProfilePic))
-        {
-            Preferences.Set(nameof(MyProfilePic), user.ProfilePic);
-        }
-
-        if (!string.IsNullOrWhiteSpace(user.Points.ToString()))
-        {
-            Preferences.Set(nameof(MyPoints), user.Points);
-        }
-
-        if (!string.IsNullOrWhiteSpace(user.Balance.ToString()))
-        {
-            Preferences.Set(nameof(MyBalance), user.Balance);
-        }
-
-        if (user.QRCode != null && !string.IsNullOrWhiteSpace(user.QRCode.ToString()))
-        {
-            Preferences.Set(nameof(MyQrCode), user.QRCode);
-        }
+        Preferences.Set(nameof(MyName), user.FullName);
+        Preferences.Set(nameof(MyEmail), user.Email);
+        Preferences.Set(nameof(MyUserId), user.Id);
+        Preferences.Set(nameof(MyProfilePic), user.ProfilePic);
+        Preferences.Set(nameof(MyPoints), user.Points);
+        Preferences.Set(nameof(MyBalance), user.Balance);
+        Preferences.Set(nameof(MyQrCode), user.QRCode);
 
         WeakReferenceMessenger.Default.Send(new UserDetailsUpdatedMessage(new UserContext
         {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Part of #621

> 2. What was changed?

Always sets preferences from user data even if the new data doesn't exist so that old preferences aren't used. In this instance, a non-SSW account logging in after an SSW account meant the QR code was loading from the previous account's preferences as the new account didn't have data to overwrite it.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->