### PR TITLE
added benchmark answer to QuizGPT integration

### DIFF
--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTRequestDto.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTRequestDto.cs
@@ -4,4 +4,5 @@ public class QuizGPTRequestDto
 {
     public string QuestionText { get; set; } = "";
     public string AnswerText { get; set; } = "";
+    public string? BenchmarkAnswer { get; set; }
 }

--- a/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTResponseDto.cs
+++ b/src/Application/Quizzes/Commands/SubmitAnswerCommand/QuizGPTResponseDto.cs
@@ -17,4 +17,7 @@ public class QuizGPTResponseDto
 
     [JsonPropertyName("confidence")]
     public int Confidence { get; set; }
+
+    [JsonPropertyName("usedBenchmarkAnswer")]
+    public bool UsedBenchmarkAnswer { get; set; }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

GPT gets confused with difficult questions. We now supply it a `BenchmarkAnswer` (which is the text of the correct `QuizAnswer` entity for the given question).

> 2. What was changed?

Additional field - `BenchmarkAnswer` is being supplied to QuizGPT.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->