### PR TITLE
🐛 Mobile - Prevent double submission for quiz answers

### DIFF
--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -119,9 +119,10 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         private async Task SubmitAnswer()
         {
+            IsBusy = true;
             var question = Questions.FirstOrDefault(q => q.QuestionId == CurrentQuestion.QuestionId);
 
-            if (!string.IsNullOrEmpty(CurrentQuestion.Answer))
+            if (!CurrentQuestion.IsSubmitted && !string.IsNullOrEmpty(CurrentQuestion.Answer))
             {
                 await _quizService.SubmitAnswer(new SubmitQuizAnswerDto()
                 {
@@ -135,12 +136,17 @@ namespace SSW.Rewards.Mobile.ViewModels
             }
             
             MoveNext(Questions.IndexOf(CurrentQuestion) + 1);
+            IsBusy = false;
         }
 
         private async Task SubmitResponses()
         {
-            await SubmitAnswer();
             bool allQuestionsAnswered = Questions.All(q => q.IsSubmitted);
+
+            if (IsLastQuestion && !allQuestionsAnswered)
+            {
+                await SubmitAnswer();
+            }
             
             if (allQuestionsAnswered)
             {

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -141,12 +141,12 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         private async Task SubmitResponses()
         {
-            bool allQuestionsAnswered = Questions.All(q => q.IsSubmitted);
-
-            if (IsLastQuestion && !allQuestionsAnswered)
+            if (!CurrentQuestion.IsSubmitted)
             {
                 await SubmitAnswer();
             }
+            
+            bool allQuestionsAnswered = Questions.All(q => q.IsSubmitted);
             
             if (allQuestionsAnswered)
             {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Just a small issue I noticed when testing where a user could submit an answer multiple times which results in an error popup. Part of #621

> 2. What was changed?

This is a small tweak to prevent a user from submitting an answer twice and also where the final answer could be submitted twice when retrying the final quiz completion check.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->