### PR TITLE
🐛 Mobile - Fix wrong quiz logo showing briefly

### DIFF
--- a/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
@@ -36,5 +36,6 @@ public partial class EarnDetailsPage : ContentPage
     {
         base.OnDisappearing();
         _viewModel.OnNextQuestionRequested -= ScrollToIndex;
+        _viewModel.Clear();
     }
 }

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -92,12 +92,12 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         public async Task Initialise(int quizId, string icon)
         {
+            IsBusy = true;
+            
             _quizId = quizId;
-
             _quizIcon = icon;
 
             IsLoadingQuestions = true;
-            Clear();
 
             var quiz = await _quizService.GetQuizDetails(_quizId);
             var beginQuiz = await _quizService.BeginQuiz(_quizId);
@@ -285,13 +285,14 @@ namespace SSW.Rewards.Mobile.ViewModels
             OnNextQuestionRequested.Invoke(this, next);
         }
 
-        private void Clear()
+        public void Clear()
         {
             Questions.Clear();
             Results.Clear();
             QuizTitle = "";
             QuizDescription = "";
-            IsBusy = true;
+            ThumbnailImage = "";
+            Points = 0;
             QuestionsVisible = true;
             ResultsVisible = false;
         }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #629

> 2. What was changed?

Fixes previous quiz thumbnail displaying briefly when switching to another quiz.

> 3. Did you do pair or mob programming?

No.

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->