### PR TITLE
🐛 Mobile - Fix achievement popups appearing blank on Android

### DIFF
--- a/src/MobileUI/PopupPages/LinkSocial.xaml
+++ b/src/MobileUI/PopupPages/LinkSocial.xaml
@@ -17,14 +17,19 @@
                                    HasBackgroundAnimation="True"/>
     </pages:PopupPage.Animation>
 
-    <Frame WidthRequest="300"
-           HeightRequest="300"
-           HorizontalOptions="Center"
-           VerticalOptions="Center"
-           HasShadow="True"
-           BackgroundColor="{StaticResource LeaderCardBackground}"
-           CornerRadius="1">
-
+    <Border WidthRequest="300"
+            HeightRequest="300"
+            HorizontalOptions="Center"
+            VerticalOptions="Center"
+            BackgroundColor="{StaticResource LeaderCardBackground}">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="1" />
+        </Border.StrokeShape>
+        <Border.Shadow>
+            <Shadow Brush="Black"
+                    Radius="40"
+                    Opacity="0.8"/>
+        </Border.Shadow>
         <Grid RowDefinitions="*, *, *">
             <Label Grid.Row="0"
                    x:Name="TitleLabel"
@@ -73,5 +78,5 @@
                     Clicked="SaveButton_Clicked"
                     x:Name="SaveButton"/>
         </Grid>
-    </Frame>
+    </Border>
 </pages:PopupPage>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #627

> 2. What was changed?

These popups weren't working due to an issue with Frame in .NET MAUI on Android (which is effectively deprecated). Moving to Border fixes this.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->