### PR TITLE
🐛 Mobile - Fix Earn carousel when switching pages

### DIFF
--- a/src/MobileUI/Pages/EarnPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnPage.xaml.cs
@@ -13,6 +13,7 @@ public partial class EarnPage : ContentPage
         InitializeComponent();
         _viewModel = viewModel;
         BindingContext = _viewModel;
+        _timer = Application.Current.Dispatcher.CreateTimer();
     }
 
     protected override async void OnAppearing()
@@ -27,25 +28,27 @@ public partial class EarnPage : ContentPage
     {
         base.OnDisappearing();
         _timer.Stop();
+        _timer.Tick -= OnScrollTick;
     }
 
     private void BeginAutoScroll()
     {
-        _timer = Application.Current.Dispatcher.CreateTimer();
         _timer.Interval = TimeSpan.FromSeconds(3);
-        _timer.Tick += (s,e) => Scroll();
+        _timer.Tick += OnScrollTick;
         _timer.Start();
+    }
+    
+    private void OnScrollTick(object sender, object args)
+    {
+        MainThread.BeginInvokeOnMainThread(Scroll);
     }
     
     private void Scroll()
     {
-        MainThread.BeginInvokeOnMainThread(() =>
-        {
-            var count = _viewModel.CarouselQuizzes.Count;
-            
-            if (count > 0)
-                Carousel.Position = (Carousel.Position + 1) % count;
-        });
+        var count = _viewModel.CarouselQuizzes.Count;
+        
+        if (count > 0)
+            Carousel.Position = (Carousel.Position + 1) % count;
     }
     
     private async Task Animate()


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Part of #621

> 2. What was changed?

Fixes an issue where changing pages after loading the Earn page can result in the autoscroll of the carousel acting sporadically.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->