### PR TITLE
🐛 Mobile | Fix alert potentially not displaying in refresh flow on iOS

### DIFF
--- a/src/MobileUI/ViewModels/LoginPageViewModel.cs
+++ b/src/MobileUI/ViewModels/LoginPageViewModel.cs
@@ -104,6 +104,7 @@ public partial class LoginPageViewModel : BaseViewModel
                 // Everything else is fatal
                 Crashes.TrackError(e);
                 Console.WriteLine(e);
+                await WaitForWindowClose();
                 await Application.Current.MainPage.DisplayAlert("Login Failure",
                     "There seems to have been a problem logging you in. Please try again. " + e.Message, "OK");
             }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Part of #621

> 2. What was changed?

We previously added a workaround on iOS which adds a Task.Delay() before displaying an alert after an exception in the login flow as it could result in the alert never displaying and execution never continuing. This should have been added to the refresh flow but was missing, so this adds it there. This may resolve issues with the login being stuck on a spinner on iOS.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->