### PR TITLE
♻️ Mobile | Dim text and add tick on completed quizzes

### DIFF
--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -117,21 +117,12 @@
                                                        HeightRequest="64"
                                                        WidthRequest="64"
                                                        Aspect="AspectFill" />
-
-                                                <Label Text="&#xe30b;"
-                                                       TextColor="Green"
-                                                       FontFamily="FluentIcons"
-                                                       FontSize="28"
-                                                       HorizontalOptions="End"
-                                                       VerticalOptions="End"
-                                                       IsVisible="{Binding Passed}">
-                                                </Label>
                                             </Grid>
                                         </Border>
 
                                         <Grid
                                             Grid.Column="1"
-                                            ColumnDefinitions="*"
+                                            ColumnDefinitions="*,20"
                                             RowDefinitions="*,*"
                                             VerticalOptions="Center"
                                             RowSpacing="2">
@@ -142,16 +133,44 @@
                                                    VerticalTextAlignment="End"
                                                    FontSize="18"
                                                    Style="{StaticResource LabelBold}"
-                                                   LineBreakMode="TailTruncation" />
+                                                   LineBreakMode="TailTruncation">
+                                                <Label.Triggers>
+                                                    <DataTrigger TargetType="Label"
+                                                                 Binding="{Binding Path=Passed}"
+                                                                 Value="True">
+                                                        <Setter Property="Opacity"
+                                                                Value="0.5" />
+                                                    </DataTrigger>
+                                                </Label.Triggers>
+                                            </Label>
                                             <Label Grid.Row="1"
                                                    Text="{Binding Description}"
                                                    TextColor="White"
                                                    VerticalTextAlignment="Start"
                                                    InputTransparent="True"
-                                                   FontSize="12" />
+                                                   FontSize="12">
+                                                <Label.Triggers>
+                                                    <DataTrigger TargetType="Label"
+                                                                 Binding="{Binding Path=Passed}"
+                                                                 Value="True">
+                                                        <Setter Property="Opacity"
+                                                                Value="0.5" />
+                                                    </DataTrigger>
+                                                </Label.Triggers>
+                                            </Label>
+                                            <Label Grid.Column="2"
+                                                   Grid.RowSpan="2"
+                                                   Text="&#xf058;"
+                                                   TextColor="Green"
+                                                   FontSize="20"
+                                                   FontAutoScalingEnabled="False"
+                                                   FontFamily="FA6Regular"
+                                                   VerticalOptions="Center"
+                                                   HorizontalOptions="Center"
+                                                   IsVisible="{Binding Passed}"/>
                                         </Grid>
-
-                                        <controls:PointsButton Grid.Column="2"
+                                        
+                                        <controls:PointsButton Grid.Column="3"
                                                                ButtonText="GO"
                                                                Points="{Binding Points}"
                                                                Margin="10,0"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Email from @adamcogan 

> 2. What was changed?

Completed quizzes now have greyed out text and a new tick in the quiz list to better stand out.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/04dfd422-9448-4259-9216-dd676790d630" width="400" />

**Figure: Updated look for completed quizzes**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->