### PR TITLE
Fix mobile auth bug

### DIFF
--- a/src/MobileUI/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileUI/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="44" android:versionName="3.0.7">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="45" android:versionName="3.0.8">
 	<application android:allowBackup="true" android:icon="@mipmap/icon_dark" android:supportsRtl="true" android:label="SSW Rewards"></application>
 	<!-- Setting Targeted sdk version to 32 instead of the latest 33 due to Android Permissions not correctly implemented yet
 		 See Issue: https://github.com/dotnet/maui/issues/11275 -->

--- a/src/MobileUI/Platforms/iOS/Info.plist
+++ b/src/MobileUI/Platforms/iOS/Info.plist
@@ -33,7 +33,7 @@
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.7</string>
+	<string>3.0.8</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>


### PR DESCRIPTION
cc: @Dhruv-0987

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Email from @adamcogan, subj: "Rewards - installed new version and it forgot me again !!"

And ongoing authentication issues.

In summary, the app should be silently refreshing authentication, but was (frustratingly) frequently requiring users to log in interactively.

> 2. What was changed?

✏️ Erroneous logic to track refresh token expiration was removed.

In a previous commit, I added a check to see if the refresh token had expired. The principle being that if the refresh token has expired, there's no point attempting a refresh, so to save time (and improve UX) the app would move immediately to interactive login.

* **Note**: The app actually also attempts to use the browser cookie to log in silently via the browser if the refresh token fails, but this is also time limited and wasn't mitigating the issue.

The problem is that the logic here is flawed. The expiration time of refresh tokens is not known (ever). The `RefreshTokenResult` returns an `ExpiresIn` property, but this is the expiry for the _access token_ within the result, _not_ the refresh token.

The lifetime of access tokens is 1 hour. Consequently, the app was ignoring perfectly good refresh tokens and forcing interactive logins.

> 3. Did you do pair or mob programming?

✏️ NA
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->