### PR TITLE
♻️ Mobile | Improve V3 profile text size handling

### DIFF
--- a/src/MobileUI/Controls/ProfileActivityItem.xaml
+++ b/src/MobileUI/Controls/ProfileActivityItem.xaml
@@ -11,13 +11,14 @@
     <Border.StrokeShape>
         <RoundRectangle CornerRadius="4" />
     </Border.StrokeShape>
-    <Grid ColumnDefinitions="35, *" RowDefinitions="Auto,Auto">
+    <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto,Auto">
         <Label
             Grid.Column="0"
             Grid.Row="0"
             Grid.RowSpan="2"
             Text="&#xf51e;"
             TextColor="{StaticResource Coin}"
+            Margin="10,0"
             FontFamily="FA6Solid"
             HorizontalOptions="Center"
             VerticalOptions="Center"
@@ -37,7 +38,6 @@
         <Label Grid.Column="1"
                Grid.Row="0"
                Margin="0,10,5,5"
-               MaxLines="2"
                FontSize="16"
                Style="{StaticResource LabelBold}"
                Text="{Binding ActivityName}"/>

--- a/src/MobileUI/Controls/ProfileStats.xaml
+++ b/src/MobileUI/Controls/ProfileStats.xaml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <Border
-    HeightRequest="280"
     BackgroundColor="{StaticResource Background}"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -15,11 +14,10 @@
     <Border.StrokeShape>
         <RoundRectangle CornerRadius="8" />
     </Border.StrokeShape>
-    <Grid
-        RowDefinitions="120, 50, Auto"
-        RowSpacing="10"
+    <VerticalStackLayout
+        Spacing="10"
         Padding="0,10">
-        <VerticalStackLayout Grid.Row="0">
+        <Grid>
             <toolkit:AvatarView ImageSource="{Binding ProfilePic}"
                                 WidthRequest="120"
                                 HeightRequest="120"
@@ -31,7 +29,7 @@
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
                 TranslationX="40"
-                TranslationY="-35"
+                TranslationY="35"
                 StrokeShape="Ellipse"
                 StrokeThickness="0"
                 IsVisible="{Binding IsMe}">
@@ -40,18 +38,20 @@
                 </Border.GestureRecognizers>
                 <Label
                     FontFamily="FluentIcons"
+                    FontAutoScalingEnabled="False"
                     FontSize="25"
                     Text="&#xe299;"
                     Margin="3"
                     TextColor="White" />
             </Border>
-        </VerticalStackLayout>
+        </Grid>
 
-        <VerticalStackLayout Grid.Row="1" VerticalOptions="Center">
+        <VerticalStackLayout VerticalOptions="Center">
             <Label
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
                 HorizontalTextAlignment="Center"
+                FontAutoScalingEnabled="False"
                 Text="{Binding Name}"
                 Style="{StaticResource LabelBold}"
                 FontSize="Large"
@@ -60,6 +60,7 @@
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
                 HorizontalTextAlignment="Center"
+                FontAutoScalingEnabled="False"
                 Text="{Binding Path=IsStaff, Converter={StaticResource StaffToText}}"
                 Style="{StaticResource LabelBold}"
                 FontSize="Small"
@@ -67,8 +68,7 @@
         </VerticalStackLayout>
 
         <!-- User's own stats -->
-        <Border Grid.Row="2"
-                IsVisible="{Binding Path=ShowBalance}"
+        <Border IsVisible="{Binding Path=ShowBalance}"
                 Stroke="{StaticResource ProfileGridBorder}"
                 StrokeThickness="2"
                 Margin="20, 0">
@@ -93,11 +93,16 @@
                             <Label VerticalOptions="Center"
                                    FontFamily="FA6Solid"
                                    TextColor="{StaticResource Coin}"
+                                   FontAutoScalingEnabled="False"
                                    Text="&#xf091;" />
-                            <Label FontSize="Large" Style="{StaticResource LabelBold}" Text="{Binding Rank, StringFormat='#{0:n0}'}" />
+                            <Label FontSize="Large"
+                                   FontAutoScalingEnabled="False"
+                                   Style="{StaticResource LabelBold}"
+                                   Text="{Binding Rank, StringFormat='#{0:n0}'}" />
                         </HorizontalStackLayout>
                         <Label
                             HorizontalOptions="Center"
+                            FontAutoScalingEnabled="False"
                             Text="Ranking"
                             FontSize="Small"
                             TextColor="{StaticResource White}" />
@@ -114,13 +119,17 @@
                         <Label VerticalOptions="Center"
                                FontFamily="FA6Solid"
                                TextColor="{StaticResource Coin}"
+                               FontAutoScalingEnabled="False"
                                Text="&#x2b50;" />
-                        <Label FontSize="Large" Style="{StaticResource LabelBold}"
+                        <Label FontSize="Large"
+                               FontAutoScalingEnabled="False"
+                               Style="{StaticResource LabelBold}"
                                Text="{Binding Points, StringFormat='{0:n0}'}" />
                     </HorizontalStackLayout>
                     <Label
                         HorizontalOptions="Center"
                         Text="Points"
+                        FontAutoScalingEnabled="False"
                         FontSize="Small"
                         TextColor="{StaticResource White}" />
                 </VerticalStackLayout>
@@ -139,8 +148,11 @@
                                    VerticalTextAlignment="Center"
                                    FontFamily="FA6Solid"
                                    TextColor="{StaticResource Coin}"
+                                   FontAutoScalingEnabled="False"
                                    Text="&#xf51e;" />
-                            <Label FontSize="Large" Style="{StaticResource LabelBold}"
+                            <Label FontSize="Large"
+                                   FontAutoScalingEnabled="False"
+                                   Style="{StaticResource LabelBold}"
                                    Text="{Binding Balance, StringFormat='{0:n0}'}" />
                         </HorizontalStackLayout>
                         <Label
@@ -148,6 +160,7 @@
                             HorizontalOptions="Center"
                             Text="Credits"
                             FontSize="Small"
+                            FontAutoScalingEnabled="False"
                             TextColor="{StaticResource White}" />
                     </VerticalStackLayout>
                 </Border>
@@ -181,14 +194,19 @@
                         <HorizontalStackLayout Spacing="5" HorizontalOptions="Center">
                             <Label VerticalOptions="Center"
                                    FontFamily="FA6Solid"
+                                   FontAutoScalingEnabled="False"
                                    TextColor="{StaticResource Coin}"
                                    Text="&#xf091;" />
-                            <Label FontSize="Large" Style="{StaticResource LabelBold}" Text="{Binding Path=Rank, StringFormat='#{0:n0}'}" />
+                            <Label FontSize="Large"
+                                   FontAutoScalingEnabled="False"
+                                   Style="{StaticResource LabelBold}"
+                                   Text="{Binding Path=Rank, StringFormat='#{0:n0}'}" />
                         </HorizontalStackLayout>
                         <Label
                             HorizontalOptions="Center"
                             Text="Ranking"
                             FontSize="Small"
+                            FontAutoScalingEnabled="False"
                             TextColor="{StaticResource White}" />
                     </VerticalStackLayout>
                 </Border>
@@ -205,20 +223,24 @@
                         <HorizontalStackLayout Spacing="5" HorizontalOptions="Center">
                             <Label VerticalOptions="Center"
                                    FontFamily="FA6Solid"
+                                   FontAutoScalingEnabled="False"
                                    TextColor="{StaticResource Coin}"
                                    Text="&#x2b50;" />
-                            <Label FontSize="Large" Style="{StaticResource LabelBold}"
+                            <Label FontSize="Large"
+                                   FontAutoScalingEnabled="False"
+                                   Style="{StaticResource LabelBold}"
                                    Text="{Binding Points, StringFormat='{0:n0}'}" />
                         </HorizontalStackLayout>
                         <Label
                             HorizontalOptions="Center"
                             Text="Points"
                             FontSize="Small"
+                            FontAutoScalingEnabled="False"
                             TextColor="{StaticResource White}" />
                     </VerticalStackLayout>
                 </Border>
                 
             </Grid>
         </Border>
-    </Grid>
+    </VerticalStackLayout>
 </Border>

--- a/src/MobileUI/Pages/ProfilePages/OthersProfilePage.xaml
+++ b/src/MobileUI/Pages/ProfilePages/OthersProfilePage.xaml
@@ -30,6 +30,7 @@
                     FontFamily="FluentIcons"
                     Text="&#xe4c3;"
                     FontSize="35"
+                    FontAutoScalingEnabled="False"
                     TextColor="{StaticResource primary}" />
             </Border>
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Mainly triggered by Adam's screenshots from his emails, where his phone is set to a larger system text size and is causing many layouts to break. 

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/af41829e-ed6e-42ff-813d-2e638205eafa" width="400" />

**Figure: Layout issues with increased system text size**

Part of V3 profile changes #613 

> 2. What was changed?

Improves handling of varying text sizes on the profile page to improve accessibility.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/a91d7cab-fdb3-454d-bd0e-d1d89f6b7ef8" width="400" />

**Figure: Me page with max system text size**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/78526b07-f0c9-40f9-b638-284b213db763" width="400" />

**Figure: Other profile page with max system text size**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->