### PR TITLE
🐛 Mobile | Fix for profile skill text overflow

### DIFF
--- a/src/MobileUI/Controls/ProfileStats.xaml
+++ b/src/MobileUI/Controls/ProfileStats.xaml
@@ -288,8 +288,9 @@
             </HorizontalStackLayout.Triggers>
             <BindableLayout.ItemTemplate>
                 <DataTemplate x:DataType="staff:StaffSkillDto">
-                    <VerticalStackLayout Spacing="4">
-                        <Border HeightRequest="64" 
+                    <Grid RowDefinitions="Auto,*,Auto" RowSpacing="4">
+                        <Border Grid.Row="0"
+                                HeightRequest="64" 
                                 WidthRequest="64"
                                 BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                                 StrokeThickness="0">
@@ -303,12 +304,18 @@
                                    FontSize="28"
                                    Text="&#xf0eb;"/>
                         </Border>
-                        <Label Text="{Binding Name}"
+                        <Label Grid.Row="1"
+                               Text="{Binding Name}"
+                               MaximumWidthRequest="94"
                                HorizontalOptions="Center"
-                               FontSize="15"
+                               HorizontalTextAlignment="Center"
+                               VerticalOptions="Center"
+                               FontSize="14"
                                Style="{StaticResource LabelBold}"/>
                         
                         <HorizontalStackLayout
+                            Grid.Row="2"
+                            HorizontalOptions="Center"
                             BindableLayout.ItemsSource="{Binding Level, Converter={StaticResource LevelToStars}}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate>
@@ -327,7 +334,7 @@
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>
                         </HorizontalStackLayout>
-                    </VerticalStackLayout>
+                    </Grid>
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </HorizontalStackLayout>

--- a/src/MobileUI/Services/DevService.cs
+++ b/src/MobileUI/Services/DevService.cs
@@ -88,10 +88,7 @@ public class DevService : IDevService
         }
         catch (Exception e)
         {
-            if (!await ExceptionHandler.HandleApiException(e))
-            {
-                throw;
-            }
+            await ExceptionHandler.HandleApiException(e);
         }
 
         return null;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed an issue with the new Skill Set section on the V3 profile page where large amounts of text on skill names could mess up the layout.

Related to #613

> 2. What was changed?

This allows the skill names to break to new lines to prevent the layout being messed up, and adjusts all skill heights accordingly.
Also includes a fix where it could crash if it can't find a profile.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/fe599feb-d479-41b3-b4d0-49ae287029fd" width="400" />

**Figure: Skill text now wraps to new lines if necessary**

> 3. Did you do pair or mob programming?

No 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->