### PR TITLE
🐛 Admin | Fix Authorize View Issue with Array Role Claim

### DIFF
--- a/src/AdminUI/Program.cs
+++ b/src/AdminUI/Program.cs
@@ -65,7 +65,8 @@ public class Program
             }
 
             options.ProviderOptions.ResponseType = "code";
-        });
+        })
+        .AddAccountClaimsPrincipalFactory<RolesClaimsPrincipalFactory>();
 
         await builder.Build().RunAsync();
     }

--- a/src/AdminUI/RolesClaimsPrincipalFactory.cs
+++ b/src/AdminUI/RolesClaimsPrincipalFactory.cs
@@ -17,27 +17,32 @@ public class RolesClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteU
         if (user.Identity.IsAuthenticated)
         {
             var identity = (ClaimsIdentity)user.Identity;
+
             var roleClaims = identity.FindAll(identity.RoleClaimType);
+
             if (roleClaims != null && roleClaims.Any())
             {
-                foreach (var existingClaim in roleClaims)
+                var count = roleClaims.Count();
+
+                for (int i = 0; i < count; i++)
                 {
-                    identity.RemoveClaim(existingClaim);
+                    identity.RemoveClaim(roleClaims.ElementAt(i));
                 }
 
                 var rolesElem = account.AdditionalProperties[identity.RoleClaimType];
+
                 if (rolesElem is JsonElement roles)
                 {
                     if (roles.ValueKind == JsonValueKind.Array)
                     {
                         foreach (var role in roles.EnumerateArray())
                         {
-                            identity.AddClaim(new Claim(options.RoleClaim, role.GetString()));
+                            identity.AddClaim(new Claim(ClaimTypes.Role, role.GetString()));
                         }
                     }
                     else
                     {
-                        identity.AddClaim(new Claim(options.RoleClaim, roles.GetString()));
+                        identity.AddClaim(new Claim(ClaimTypes.Role, roles.GetString()));
                     }
                 }
             }

--- a/src/AdminUI/RolesClaimsPrincipalFactory.cs
+++ b/src/AdminUI/RolesClaimsPrincipalFactory.cs
@@ -1,0 +1,48 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
+
+namespace SSW.Rewards.Admin.UI;
+
+public class RolesClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteUserAccount>
+{
+    public RolesClaimsPrincipalFactory(IAccessTokenProviderAccessor accessor) : base(accessor)
+    {
+    }
+
+    public override async ValueTask<ClaimsPrincipal> CreateUserAsync(RemoteUserAccount account, RemoteAuthenticationUserOptions options)
+    {
+        var user = await base.CreateUserAsync(account, options);
+        if (user.Identity.IsAuthenticated)
+        {
+            var identity = (ClaimsIdentity)user.Identity;
+            var roleClaims = identity.FindAll(identity.RoleClaimType);
+            if (roleClaims != null && roleClaims.Any())
+            {
+                foreach (var existingClaim in roleClaims)
+                {
+                    identity.RemoveClaim(existingClaim);
+                }
+
+                var rolesElem = account.AdditionalProperties[identity.RoleClaimType];
+                if (rolesElem is JsonElement roles)
+                {
+                    if (roles.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var role in roles.EnumerateArray())
+                        {
+                            identity.AddClaim(new Claim(options.RoleClaim, role.GetString()));
+                        }
+                    }
+                    else
+                    {
+                        identity.AddClaim(new Claim(options.RoleClaim, roles.GetString()));
+                    }
+                }
+            }
+        }
+
+        return user;
+    }
+}

--- a/src/AdminUI/RolesClaimsPrincipalFactory.cs
+++ b/src/AdminUI/RolesClaimsPrincipalFactory.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
 
 namespace SSW.Rewards.Admin.UI;
 
+// SSW.Identity currently returns roles as a string array.
+// This is here because of this https://github.com/dotnet/aspnetcore/issues/21836
 public class RolesClaimsPrincipalFactory : AccountClaimsPrincipalFactory<RemoteUserAccount>
 {
     public RolesClaimsPrincipalFactory(IAccessTokenProviderAccessor accessor) : base(accessor)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Found a bug on Admin deployment.
SSW.Identity returns Roles in the Token as a string array, which the Blazor `AuthorizeView` doesn't like. 

I found this issue that has a solution https://github.com/dotnet/aspnetcore/issues/21836

> 2. What was changed?

✏️ Added middleware to the Oidc flow to Remove the Role claims from the user's identity, and re-add them as individual role claims.

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->