### PR TITLE
✨ Mobile | Fix the answer field for quizzes

### DIFF
--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -10,6 +10,7 @@ using SSW.Rewards.Mobile.Controls;
 using SSW.Rewards.Mobile.ViewModels.ProfileViewModels;
 using SSW.Rewards.ApiClient;
 using System.Reflection;
+using Microsoft.Maui.Platform;
 using ZXing.Net.Maui.Controls;
 using IBrowser = IdentityModel.OidcClient.Browser.IBrowser;
 
@@ -97,6 +98,13 @@ public static class MauiProgram
 #endif
 
         App.SetScope(builder.Services);
+
+#if ANDROID
+        Microsoft.Maui.Handlers.EditorHandler.Mapper.AppendToMapping(nameof(Editor), (handler, editor) =>
+        {
+            handler.PlatformView.BackgroundTintList = Android.Content.Res.ColorStateList.ValueOf(Colors.Transparent.ToPlatform());
+        });
+#endif
 
         return builder.Build();
     }

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -105,6 +105,17 @@ public static class MauiProgram
             handler.PlatformView.BackgroundTintList = Android.Content.Res.ColorStateList.ValueOf(Colors.Transparent.ToPlatform());
         });
 #endif
+        
+#if IOS
+        Microsoft.Maui.Handlers.EditorHandler.Mapper.AppendToMapping(nameof(Editor), (handler, editor) =>
+        {
+            handler.PlatformView.TintColor = UIKit.UIColor.FromRGB(204,65,65);
+        });
+        Microsoft.Maui.Handlers.EntryHandler.Mapper.AppendToMapping(nameof(Entry), (handler, editor) =>
+        {
+            handler.PlatformView.TintColor = UIKit.UIColor.FromRGB(204,65,65);
+        });
+#endif
 
         return builder.Build();
     }

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -62,8 +62,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Goldie.MauiPlugins.PageResolver" Version="1.1.1" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.7" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 		<PackageReference Include="FFImageLoadingCompat.Transformations" Version="0.1.1" />
 		<PackageReference Include="FFImageLoadingCompat.Maui" Version="0.1.1" />

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml
@@ -11,19 +11,15 @@
              x:DataType="viewModels:EarnDetailsViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.EarnDetailsPage">
     <Shell.BackButtonBehavior>
-        <BackButtonBehavior Command="{Binding BackCommand}" />
+        <BackButtonBehavior Command="{Binding GoBackCommand}" />
     </Shell.BackButtonBehavior>
     <Shell.TitleView>
         <Button Text="Done" 
                 IsVisible="{Binding ResultsVisible}" 
-                Command="{Binding BackCommand}"
+                Command="{Binding GoBackCommand}"
                 Padding="{OnPlatform iOS='0'}"
                 FontAutoScalingEnabled="False"
-                HorizontalOptions="End">
-            <Button.Resources>
-                <Style TargetType="Button" />
-            </Button.Resources>
-        </Button>
+                HorizontalOptions="End"/>
     </Shell.TitleView>
     <ContentPage.Resources>
         <converters:InverseBoolConverter x:Key="InverseBool" />
@@ -137,8 +133,14 @@
                                 AutoSize="TextChanges"
                                 Text="{Binding CurrentQuestion.Answer}"
                                 MinimumHeightRequest="150"
-                                TextChanged="InputView_OnTextChanged"
-                                Placeholder="Enter you answer here"/>
+                                Placeholder="Enter you answer here">
+                                <Editor.Behaviors>
+                                    <toolkit:EventToCommandBehavior 
+                                        x:TypeArguments="TextChangedEventArgs"
+                                        EventName="TextChanged"
+                                        Command="{Binding AnswerChangedCommand}"/>
+                                </Editor.Behaviors>
+                            </Editor>
                         </Border>
                         <Label Grid.Row="1"
                                IsVisible="{Binding CurrentQuestion.IsSubmitted}"
@@ -166,7 +168,7 @@
                         <Button Grid.Column="1"
                                 IsVisible="{Binding IsLastQuestion, Converter={StaticResource InvertedBoolConverter}}"
                                 Text="&#xf061;"
-                                Command="{Binding MoveNextCommand}"
+                                Command="{Binding MoveForwardCommand}"
                                 FontFamily="FA6Solid"
                                 TextColor="White"
                                 HeightRequest="40"
@@ -179,7 +181,7 @@
                         <Button Grid.Column="1"
                                 IsVisible="{Binding IsLastQuestion}"
                                 Text="Submit"
-                                Command="{Binding SubmitCommand}"
+                                Command="{Binding SubmitResponsesCommand}"
                                 Style="{StaticResource LabelBold}"
                                 FontSize="12"
                                 TextColor="White"

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml
@@ -124,22 +124,27 @@
                                FontSize="Large"
                                Margin="0,0,0,40"
                                Text="{Binding CurrentQuestion.Text, StringFormat='Q: {0}'}" />
-                        <Border Grid.Row="1"
-                                StrokeThickness="0"
-                                IsVisible="{Binding CurrentQuestion.IsSubmitted, Converter={StaticResource InvertedBoolConverter}}">
+                        <Border
+                            Grid.Row="1"
+                            Stroke="{StaticResource White}"
+                            IsVisible="{Binding CurrentQuestion.IsSubmitted, Converter={StaticResource InvertedBoolConverter}}">
                             <Border.StrokeShape>
                                 <RoundRectangle CornerRadius="8" />
                             </Border.StrokeShape>
-                            <Entry Text="{Binding CurrentQuestion.Answer}"
-                                    Placeholder="Enter your answer here"
-                                    BackgroundColor="White"
-                                    TextColor="Black" />
+                            <Editor
+                                TextColor="{StaticResource White}"
+                                VerticalTextAlignment="Start"
+                                AutoSize="TextChanges"
+                                Text="{Binding CurrentQuestion.Answer}"
+                                MinimumHeightRequest="150"
+                                TextChanged="InputView_OnTextChanged"
+                                Placeholder="Enter you answer here"/>
                         </Border>
                         <Label Grid.Row="1"
                                IsVisible="{Binding CurrentQuestion.IsSubmitted}"
                                Text="{Binding CurrentQuestion.Answer, StringFormat='A: {0}'}"
                                FontSize="Medium"
-                               TextColor="White" />
+                               TextColor="{StaticResource White}" />
                     </Grid>
 
                     <!-- Quiz navigation -->

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
@@ -29,4 +29,9 @@ public partial class EarnDetailsPage
         _viewModel.GoBack();
         return true;
     }
+
+    private void InputView_OnTextChanged(object sender, TextChangedEventArgs e)
+    {
+        _viewModel.AnswerChangedCommand.Execute(e.NewTextValue);
+    }
 }

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
@@ -23,15 +23,4 @@ public partial class EarnDetailsPage
         int quizId = int.Parse(QuizId);
         await _viewModel.Initialise(quizId, QuizIcon);
     }
-
-    protected override bool OnBackButtonPressed()
-    {
-        _viewModel.GoBack();
-        return true;
-    }
-
-    private void InputView_OnTextChanged(object sender, TextChangedEventArgs e)
-    {
-        _viewModel.AnswerChangedCommand.Execute(e.NewTextValue);
-    }
 }

--- a/src/MobileUI/Pages/PeoplePage.xaml
+++ b/src/MobileUI/Pages/PeoplePage.xaml
@@ -7,7 +7,8 @@
              xmlns:models="clr-namespace:SSW.Rewards.Models"
              xmlns:staff="clr-namespace:SSW.Rewards.Shared.DTOs.Staff;assembly=Shared"
              x:DataType="viewModels:DevProfilesViewModel"
-             x:Class="SSW.Rewards.Mobile.Pages.PeoplePage">
+             x:Class="SSW.Rewards.Mobile.Pages.PeoplePage"
+             HideSoftInputOnTapped="True">
     <ContentPage.Resources>
         <ResourceDictionary>
             <converters:BoolToSocialColorConverter x:Key="BoolToSocial"/>

--- a/src/MobileUI/Platforms/Android/Resources/values/colors.xml
+++ b/src/MobileUI/Platforms/Android/Resources/values/colors.xml
@@ -2,5 +2,5 @@
 <resources>
     <color name="colorPrimary">#FF121212</color>
     <color name="colorPrimaryDark">#29282d</color>
-    <color name="colorAccent">#f7f7f7</color>
+    <color name="colorAccent">#FFCC4141</color>
 </resources>

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -44,6 +44,8 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         public ICommand SubmitCommand => new Command(async () => await SubmitResponses());
 
+        public ICommand AnswerChangedCommand => new Command<TextChangedEventArgs>(async (args) => AnswerChanged(args));
+
         public ICommand ResultsButtonCommand { get; set; }
 
         [ObservableProperty]
@@ -294,6 +296,11 @@ namespace SSW.Rewards.Mobile.ViewModels
 
             CurrentQuestion = Questions[next];
             CurrentQuestionChanged();
+        }
+        
+        private async Task AnswerChanged(TextChangedEventArgs args)
+        {
+            CurrentQuestion.Answer = args.NewTextValue;
         }
     }
 

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Mopups.Services;
 using SSW.Rewards.Mobile.Messages;
@@ -35,16 +36,6 @@ namespace SSW.Rewards.Mobile.ViewModels
         public ObservableCollection<EarnQuestionViewModel> Questions { get; } = [];
 
         public ObservableCollection<QuestionResultDto> Results { get; set; } = [];
-
-        public ICommand BackCommand => new Command(async () => await GoBack());
-
-        public ICommand MoveBackCommand => new Command(() => MoveNext(Questions.IndexOf(CurrentQuestion) - 1));
-
-        public ICommand MoveNextCommand => new Command(async () => await SubmitAnswer());
-
-        public ICommand SubmitCommand => new Command(async () => await SubmitResponses());
-
-        public ICommand AnswerChangedCommand => new Command<TextChangedEventArgs>(async (args) => AnswerChanged(args));
 
         public ICommand ResultsButtonCommand { get; set; }
 
@@ -150,17 +141,18 @@ namespace SSW.Rewards.Mobile.ViewModels
                 }
             }
 
-            MoveNext(Questions.IndexOf(CurrentQuestion) + 1);
+            MoveTo(Questions.IndexOf(CurrentQuestion) + 1);
             IsBusy = false;
         }
 
+        [RelayCommand]
         private async Task SubmitResponses()
         {
             if (!CurrentQuestion.IsSubmitted)
             {
                 await SubmitAnswer();
             }
-            
+
             bool allQuestionsAnswered = Questions.All(q => q.IsSubmitted);
 
             if (allQuestionsAnswered)
@@ -238,7 +230,7 @@ namespace SSW.Rewards.Mobile.ViewModels
 
                 TestPassed = true;
 
-                ResultsButtonCommand = new Command(async () => await GoBack());
+                ResultsButtonCommand = new Command(async () => await Shell.Current.GoToAsync(".."));
 
                 SnackOptions = new SnackbarOptions
                 {
@@ -272,7 +264,8 @@ namespace SSW.Rewards.Mobile.ViewModels
             OnPropertyChanged(nameof(ResultsButtonCommand));
         }
 
-        public async Task GoBack()
+        [RelayCommand]
+        private async Task GoBack()
         {
             await Shell.Current.GoToAsync("..");
         }
@@ -289,16 +282,29 @@ namespace SSW.Rewards.Mobile.ViewModels
             IsLastQuestion = isLastQuestion && !IsLoadingQuestions;
         }
 
-        private void MoveNext(int next)
+        private void MoveTo(int index)
         {
-            if (next < 0 || next >= Questions.Count)
+            if (index < 0 || index >= Questions.Count)
                 return;
 
-            CurrentQuestion = Questions[next];
+            CurrentQuestion = Questions[index];
             CurrentQuestionChanged();
         }
-        
-        private async Task AnswerChanged(TextChangedEventArgs args)
+
+        [RelayCommand]
+        private void MoveBack()
+        {
+            MoveTo(Questions.IndexOf(CurrentQuestion) - 1);
+        }
+
+        [RelayCommand]
+        private async Task MoveForward()
+        {
+            await SubmitAnswer();
+        }
+
+        [RelayCommand]
+        private void AnswerChanged(TextChangedEventArgs args)
         {
             CurrentQuestion.Answer = args.NewTextValue;
         }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The input box for quizzes was single line. Fixes the "OS keyboard and editor (enable multiline)" task on #615 

> 2. What was changed?

✏️ 
The input box is now multiline
The input box is transparent, hence the page feels lighter
Removed underline from the input box on Android
The cursor color is Red
The keyboard hides when the user clicks outside of it on the PeoplePage
Upgraded MAUI to the latest version
Replaced `ICommand` with `RelayCommand`

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/7a9ff089-880b-4de6-8b6b-4043730a72d2" width=200/>

**Figure 1:** This is how the multiline input box looks like now.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/9e9f2b31-c3d9-4987-b2a0-1c119cdcad33" width=200/>

**Figure 2:** The multiline input box scales up and down when user adds or deletes text.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/eeb669ba-df06-4deb-ba43-fd8d03d98d00" width=200/>

**Figure 3:** The keyboard has a Done button at the right top corner of the iOS keyboard.

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->