### PR TITLE
♻️ Mobile | Tweak profile skills text

### DIFF
--- a/src/MobileUI/Controls/ProfileStats.xaml
+++ b/src/MobileUI/Controls/ProfileStats.xaml
@@ -288,7 +288,7 @@
             </HorizontalStackLayout.Triggers>
             <BindableLayout.ItemTemplate>
                 <DataTemplate x:DataType="staff:StaffSkillDto">
-                    <Grid RowDefinitions="Auto,*,Auto" RowSpacing="4">
+                    <Grid RowDefinitions="Auto,*,Auto" RowSpacing="8">
                         <Border Grid.Row="0"
                                 HeightRequest="64" 
                                 WidthRequest="64"
@@ -309,7 +309,7 @@
                                MaximumWidthRequest="94"
                                HorizontalOptions="Center"
                                HorizontalTextAlignment="Center"
-                               VerticalOptions="Center"
+                               VerticalOptions="Start"
                                FontSize="14"
                                Style="{StaticResource LabelBold}"/>
                         


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

As per my conversation with @2fernandez (and previously mentioned by @Anton-Polkanov), the text on the skills section on profile pages should be top aligned.

> 2. What was changed?

Sets the text to be top aligned and adds additional spacing as requested by Joseph.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/40c368c9-c8fe-4de9-89a2-e023d520af42" width="400" />

**Figure: Skill Set text is now top aligned and has improved spacing**

> 3. Did you do pair or mob programming?

n/a
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->