### PR TITLE
✨ Mobile | Show thumbnails on skills on profile page

### DIFF
--- a/src/Application/Staff/Queries/GetStaffList/Mapping.cs
+++ b/src/Application/Staff/Queries/GetStaffList/Mapping.cs
@@ -7,7 +7,8 @@ public class Mapping : Profile
     {
         CreateMap<StaffMemberSkill, StaffSkillDto>()
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Skill.Name))
-                .ForMember(dst => dst.Level, opt => opt.MapFrom(src => src.Level));
+                .ForMember(dst => dst.Level, opt => opt.MapFrom(src => src.Level))
+                .ForMember(dst => dst.ImageUri, opt => opt.MapFrom(src => src.Skill.ImageUri));
 
         CreateMap<StaffMember, StaffMemberDto>()
                 .ForMember(dest => dest.Skills, opt => opt.MapFrom(src => src.StaffMemberSkills))

--- a/src/Common/DTOs/Staff/StaffSkillDto.cs
+++ b/src/Common/DTOs/Staff/StaffSkillDto.cs
@@ -5,5 +5,7 @@ public class StaffSkillDto
 {
     public required string Name { get; set; }
 
+    public string ImageUri { get; set; } = string.Empty;
+    
     public SkillLevel Level { get; set; }
 }

--- a/src/MobileUI/Controls/ProfileStats.xaml
+++ b/src/MobileUI/Controls/ProfileStats.xaml
@@ -293,16 +293,25 @@
                                 HeightRequest="64" 
                                 WidthRequest="64"
                                 BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                StrokeThickness="0">
+                                StrokeThickness="0"
+                                Padding="8">
                             <Border.StrokeShape>
                                 <RoundRectangle CornerRadius="8" />
                             </Border.StrokeShape>
-                            <Label FontFamily="FA6Solid"
-                                   FontAutoScalingEnabled="False"
-                                   HorizontalOptions="Center"
-                                   VerticalOptions="Center"
-                                   FontSize="28"
-                                   Text="&#xf0eb;"/>
+                            <Image Aspect="AspectFit">
+                                <Image.Source>
+                                    <Binding Path="ImageUri" >
+                                        <Binding.TargetNullValue>
+                                            <FontImageSource
+                                                FontFamily="FA6Solid"
+                                                FontAutoScalingEnabled="False"
+                                                Glyph="&#xf0eb;"
+                                                Color="{StaticResource Gray100}"
+                                                Size="28"/>
+                                        </Binding.TargetNullValue>
+                                    </Binding>
+                                </Image.Source>
+                            </Image>
                         </Border>
                         <Label Grid.Row="1"
                                Text="{Binding Name}"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Part of #613 

> 2. What was changed?

Hooks up skill thumbnails to the profile page, with a fallback icon if it does not exist.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/beaaa1e1-64cd-4781-8f8f-54d33076b263" width="400" />

**Figure: Skill thumbnails now show if they exist**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->