### PR TITLE
✨ Mobile | Hide Label and Divider for non-SSW users

### DIFF
--- a/src/MobileUI/Controls/FlyoutHeader.xaml
+++ b/src/MobileUI/Controls/FlyoutHeader.xaml
@@ -26,6 +26,7 @@
                     BorderWidth="2"/>
 
 
+    <!-- User Name -->
     <HorizontalStackLayout Grid.Row="1"
                            Margin="0,0,5,0"
                            Spacing="5"
@@ -44,6 +45,7 @@
                IsVisible="{Binding IsStaff}"/>
     </HorizontalStackLayout>
 
+    <!-- User Stats -->
     <Grid Grid.Row="2"
           RowSpacing="2"
           RowDefinitions="40,40,40"
@@ -127,7 +129,7 @@
                    VerticalTextAlignment="Center"
                    TextColor="White"
                    Text="{Binding Path=Credits, StringFormat='{0:n0}'}" />
-            </Border>
+        </Border>
         <!-- TODO: Bind Redeem button when implemented -->
         <!-- https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/560 -->
         <!-- <Border Grid.Column="1" -->
@@ -148,6 +150,7 @@
         <!-- </Border> -->
     </Grid>
 
+    <!-- Divider -->
     <VerticalStackLayout Grid.Row="3"
                          VerticalOptions="Start">
         <BoxView HorizontalOptions="FillAndExpand"
@@ -160,6 +163,7 @@
                  VerticalOptions="Start"/>
     </VerticalStackLayout>
 
+    <!-- Email -->
     <Grid
         Grid.Row="4"
         ColumnDefinitions="20,*"
@@ -202,7 +206,8 @@
         <!--        Text="Brisbane"/> -->
     </Grid>
     
-    <VerticalStackLayout Grid.Row="5" Spacing="10">
+    <!-- QR Code -->
+    <VerticalStackLayout Grid.Row="5" Spacing="10" IsVisible="{Binding IsStaff}">
         <Label Text="Scan me:"
                FontSize="Small"
                Style="{StaticResource LabelBold}"
@@ -218,8 +223,11 @@
                                  VerticalOptions="Center"/>
     </VerticalStackLayout>
     
-    <VerticalStackLayout Grid.Row="6"
-                         VerticalOptions="Start">
+    <!-- Divider -->
+    <VerticalStackLayout 
+        Grid.Row="6"
+        IsVisible="{Binding IsStaff}"
+        VerticalOptions="Start">
         <BoxView HorizontalOptions="FillAndExpand"
                  HeightRequest="1"
                  Color="#171717"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Incorrect UI

> 2. What was changed?

✏️ Hide a label and divider when `IsStaff` is `false`

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/ad645d16-0e72-4a4e-81fa-404ca29233ac" width=200/>

**Figure:** ❌ Before - "Scan me" and divider are not relevant for the user


<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/ba473325-1dd1-47e9-8a3e-505c88f1e6b9" width=200/>

**Figure:** ✅ Before - "Scan me" and divider are hidden
