### PR TITLE
Remove silent front channel authentication attempt on failed token refresh

### DIFF
--- a/src/MobileUI/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileUI/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="49" android:versionName="3.0.10">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="50" android:versionName="3.0.11">
 	<application android:allowBackup="true" android:icon="@mipmap/icon_android_dark" android:supportsRtl="true" android:label="SSW Rewards"></application>
 	<!-- Setting Targeted sdk version to 32 instead of the latest 33 due to Android Permissions not correctly implemented yet
 		 See Issue: https://github.com/dotnet/maui/issues/11275 -->

--- a/src/MobileUI/Platforms/iOS/Info.plist
+++ b/src/MobileUI/Platforms/iOS/Info.plist
@@ -8,11 +8,11 @@
 	<array>
 		<string>arm64</string>
 	</array>
-    <key>UIDeviceFamily</key>
-    <array>
-        <integer>1</integer>
-        <integer>2</integer>
-    </array>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -31,14 +31,14 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scan QR codes to earn points</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.10</string>
+	<string>3.0.11</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-    <key>LSApplicationQueriesSchemes</key>
-    <array>
-        <string>mailto</string>
-    </array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>mailto</string>
+	</array>
 </dict>
 </plist>

--- a/src/MobileUI/Services/IAuthenticationService.cs
+++ b/src/MobileUI/Services/IAuthenticationService.cs
@@ -209,34 +209,6 @@ public class AuthenticationService : IAuthenticationService
             {
                 Crashes.TrackError(new Exception($"{result.Error}, {result.ErrorDescription}"));
 
-                var fcep = new Parameters
-                {
-                    { "prompt", "none" }
-                };
-
-                var silentRequest = new LoginRequest
-                {
-                    FrontChannelExtraParameters = fcep
-                };
-
-                try
-                {
-                    var silentResult = await oidcClient.LoginAsync(silentRequest);
-                    if (!silentResult.IsError)
-                    {
-                        var authResult = GetAuthResult(silentResult);
-                        await SetLoggedInState(authResult);
-                        await SetRefreshToken(authResult);
-
-                        return true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Crashes.TrackError(new Exception($"Error during silent login, {ex.Message}, stack trace: {ex.StackTrace}"));
-                    return false;
-                }
-
                 await SignInAsync();
             }
         }


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️  Email from @adamcogan subject **URGENT 🔥 rewards auth bug - can’t get in** + Teams message from @joshbermanssw

> 2. What was changed?

✏️ In the method that uses the refresh token to get a new access token, if it fails, we try to get OIDC Client to perform a silent front channel login. This is causing errors, so we've removed it and revert to an interactive login instead.

> 3. Did you do pair or mob programming?

✏️  Issue discussed with @tkapa and @Anton-Polkanov 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->