### PR TITLE
🐛 Mobile | Handle decline of camera permission

### DIFF
--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -85,6 +85,7 @@ public static class MauiProgram
         builder.Services.AddTransient<AuthHandler>();
         builder.Services.AddSingleton(options);
         builder.Services.AddSingleton<ISnackbarService, SnackBarService>();
+        builder.Services.AddSingleton<IPermissionsService, PermissionsService>();
 
         builder.Services.AddSingleton<FlyoutHeader>();
         builder.Services.AddSingleton<FlyoutHeaderViewModel>();
@@ -106,7 +107,7 @@ public static class MauiProgram
             handler.PlatformView.BackgroundTintList = Android.Content.Res.ColorStateList.ValueOf(Colors.Transparent.ToPlatform());
         });
 #endif
-        
+
 #if IOS
         Microsoft.Maui.Handlers.EditorHandler.Mapper.AppendToMapping(nameof(Editor), (handler, editor) =>
         {

--- a/src/MobileUI/Services/IPermissionsService.cs
+++ b/src/MobileUI/Services/IPermissionsService.cs
@@ -1,0 +1,6 @@
+namespace SSW.Rewards.Mobile.Services;
+
+public interface IPermissionsService
+{
+    Task<bool> CheckAndRequestPermission<TPermission>() where TPermission : Permissions.BasePermission, new();
+}

--- a/src/MobileUI/Services/PermissionsService.cs
+++ b/src/MobileUI/Services/PermissionsService.cs
@@ -1,0 +1,69 @@
+
+namespace SSW.Rewards.Mobile.Services;
+
+public class PermissionsService : IPermissionsService
+{
+    public async Task<bool> CheckAndRequestPermission<TPermission>() where TPermission : Permissions.BasePermission, new()
+    {
+        bool result;
+#if ANDROID
+        result = await CheckAndRequestPermissionOnAndroid<TPermission>();
+#elif IOS
+        result = await CheckAndRequestPermissionOnIOS<TPermission>();
+#endif
+
+        return result;
+    }
+
+    // ReSharper disable once UnusedMember.Local
+    private async Task<bool> CheckAndRequestPermissionOnAndroid<TPermission>() where TPermission : Permissions.BasePermission, new()
+    {
+        var status = await Permissions.CheckStatusAsync<TPermission>(); // for the first check returns PermissionStatus.Denied
+        if (status == PermissionStatus.Granted)
+        {
+            return true;
+        }
+
+        return await RequestPermission<TPermission>();
+    }
+
+    // ReSharper disable once UnusedMember.Local
+    private async Task<bool> CheckAndRequestPermissionOnIOS<TPermission>() where TPermission : Permissions.BasePermission, new()
+    {
+        var status = await Permissions.CheckStatusAsync<TPermission>(); // for the first check returns PermissionStatus.Unknown
+        if (status == PermissionStatus.Granted)
+        {
+            return true;
+        }
+
+        if (status == PermissionStatus.Denied)
+        {
+            // Prompt the user to turn on in settings
+            // On iOS once a permission has been denied it may not be requested again from the application
+            var message =
+                $"You need to grant access to {typeof(TPermission).Name} in Settings on your phone to be able to use this feature";
+            await CommunityToolkit.Maui.Alerts.Snackbar
+                .Make(message, duration: TimeSpan.FromSeconds(5))
+                .Show();
+
+            return false;
+        }
+
+        return await RequestPermission<TPermission>();
+    }
+
+    private static async Task<bool> RequestPermission<TPermission>() where TPermission : Permissions.BasePermission, new()
+    {
+        var requestStatus = await Permissions.RequestAsync<TPermission>();
+        if (requestStatus == PermissionStatus.Granted)
+        {
+            return true;
+        }
+
+        await CommunityToolkit.Maui.Alerts.Snackbar
+            .Make("You cannot use this feature without granting access", duration: TimeSpan.FromSeconds(5))
+            .Show();
+
+        return false;
+    }
+}

--- a/src/MobileUI/Services/PermissionsService.cs
+++ b/src/MobileUI/Services/PermissionsService.cs
@@ -41,7 +41,7 @@ public class PermissionsService : IPermissionsService
             // Prompt the user to turn on in settings
             // On iOS once a permission has been denied it may not be requested again from the application
             var message =
-                $"You need to grant access to {typeof(TPermission).Name} in Settings on your phone to be able to use this feature";
+                $"You need to grant access to {typeof(TPermission).Name} in Settings on your phone to use this feature";
             await CommunityToolkit.Maui.Alerts.Snackbar
                 .Make(message, duration: TimeSpan.FromSeconds(5))
                 .Show();

--- a/src/MobileUI/ViewModels/CameraPageViewModel.cs
+++ b/src/MobileUI/ViewModels/CameraPageViewModel.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace SSW.Rewards.Mobile.ViewModels;
 
-public partial class CameraPageViewModel(IUserService userService) : BaseViewModel
+public partial class CameraPageViewModel(IUserService userService, IPermissionsService permissionsService) : BaseViewModel
 {
     [ObservableProperty]
     private bool _useButtonEnabled;
@@ -23,21 +23,16 @@ public partial class CameraPageViewModel(IUserService userService) : BaseViewMod
     [RelayCommand]
     private async Task TakePhoto()
     {
-        PermissionStatus storageStatus = await Permissions.CheckStatusAsync<Permissions.StorageWrite>();
-        PermissionStatus cameraStatus = await Permissions.CheckStatusAsync<Permissions.Camera>();
+        var storageGranted = await permissionsService.CheckAndRequestPermission<Permissions.StorageWrite>();
+        if (!storageGranted)
+            return;
+
+        var cameraGranted = await permissionsService.CheckAndRequestPermission<Permissions.Camera>();
+        if (!cameraGranted)
+            return;
 
         try
         {
-            if (storageStatus != PermissionStatus.Granted)
-            {
-                await Permissions.RequestAsync<Permissions.StorageWrite>();
-            }
-
-            if (cameraStatus != PermissionStatus.Granted)
-            {
-                await Permissions.RequestAsync<Permissions.Camera>();
-            }
-
             await CapturePhoto();
         }
         catch (Exception ex)

--- a/src/MobileUI/ViewModels/ProfileViewModels/MyProfileViewModel.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/MyProfileViewModel.cs
@@ -9,8 +9,9 @@ public class MyProfileViewModel(
     IUserService userService,
     ISnackbarService snackbarService,
     ILeaderService leaderService,
-    IDevService devService)
-    : ProfileViewModelBase(rewardsService, userService, snackbarService, devService),
+    IDevService devService,
+    IPermissionsService permissionsService)
+    : ProfileViewModelBase(rewardsService, userService, snackbarService, devService, permissionsService),
         IRecipient<ProfilePicUpdatedMessage>,
         IRecipient<PointsAwardedMessage>,
         IRecipient<SocialUsernameAddedMessage>
@@ -95,7 +96,7 @@ public class MyProfileViewModel(
 
         return Task.CompletedTask;
     }
-    
+
     private async Task<int> LoadRank()
     {
         var summaries = await leaderService.GetLeadersAsync(false);

--- a/src/MobileUI/ViewModels/ProfileViewModels/OthersProfileViewModel.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/OthersProfileViewModel.cs
@@ -7,13 +7,14 @@ public partial class OthersProfileViewModel(
     IRewardService rewardsService,
     IUserService userService,
     ISnackbarService snackbarService,
-    IDevService devService)
-    : ProfileViewModelBase(rewardsService, userService, snackbarService, devService)
+    IDevService devService,
+    IPermissionsService permissionsService)
+    : ProfileViewModelBase(rewardsService, userService, snackbarService, devService, permissionsService)
 {
     public async Task Initialise()
     {
         IsMe = false;
-        
+
         await _initialise();
     }
 
@@ -28,10 +29,10 @@ public partial class OthersProfileViewModel(
         Points = vm.TotalPoints;
         Rank = vm.Rank;
         IsStaff = vm.IsStaff;
-        
+
         ShowBalance = false;
-    }    
-    
+    }
+
     public void SetUser(NetworkProfileDto vm)
     {
         ProfilePic = vm.ProfilePicture;
@@ -41,7 +42,7 @@ public partial class OthersProfileViewModel(
         Points = vm.TotalPoints;
         Rank = vm.Rank;
         IsStaff = true;
-                
+
         ShowBalance = false;
     }
 
@@ -50,7 +51,7 @@ public partial class OthersProfileViewModel(
     {
         await Navigation.PopModalAsync();
     }
-    
+
     [RelayCommand]
     private async Task EmailUser()
     {

--- a/src/MobileUI/ViewModels/TopBarViewModel.cs
+++ b/src/MobileUI/ViewModels/TopBarViewModel.cs
@@ -7,6 +7,8 @@ namespace SSW.Rewards.Mobile.ViewModels;
 
 public partial class TopBarViewModel : ObservableObject
 {
+    private readonly IPermissionsService _permissionsService;
+
     [ObservableProperty]
     string profilePic;
 
@@ -19,8 +21,9 @@ public partial class TopBarViewModel : ObservableObject
     [ObservableProperty]
     bool showDone = false;
 
-    public TopBarViewModel()
+    public TopBarViewModel(IPermissionsService permissionsService)
     {
+        _permissionsService = permissionsService;
         WeakReferenceMessenger.Default.Register<ProfilePicUpdatedMessage>(this, (r, m) =>
         {
             ProfilePic = m.ProfilePic;
@@ -55,7 +58,11 @@ public partial class TopBarViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenScanner()
     {
-        await App.Current.MainPage.Navigation.PushModalAsync<ScanPage>();
+        var granted = await _permissionsService.CheckAndRequestPermission<Permissions.Camera>();
+        if (granted)
+        {
+            await App.Current.MainPage.Navigation.PushModalAsync<ScanPage>();
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ App crash on iOS. #777 

> 2. What was changed?

✏️ Added `PermissionsService` which handles permission requests slightly differently for Android and iOS:
- Android will display the request again and again until it's accepted by the user.
- iOS won't display the request once it's rejected, so the user has to give permissions via Settings.


https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/11dcad80-d3e5-45d5-826b-4fffcc1ead0e


https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/44ddc04e-1dd0-4651-be23-6f4e585ad35c



> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->