### PR TITLE
Adds base entity to the interceptor

### DIFF
--- a/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
@@ -50,6 +50,17 @@ public class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
                 entry.Entity.LastModified = _dateTime.Now;
             }
         }
+
+        // Technical debt: The following requires a refactor, but this workaround will ensure we capture the CreatedUtc time for all entities
+        // See: https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/749
+
+        foreach (var entry in context.ChangeTracker.Entries<BaseEntity>())
+        {
+            if (entry.State == EntityState.Added)
+            {
+                entry.Entity.CreatedUtc = _dateTime.Now;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #749 - CreatedUTC not captured for new users

> 2. What was changed?

✏️ Added `BaseEntity` to the interceptor. This a workaround - the `User` entity needs to be properly refactored to inherit `BaseAuditableEntity`. And we need to carefully consider the use case for both base enities.

<img width="680" alt="image" src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/19944129/ca1e08fa-63d8-4232-80a9-e05ae6011ccb">

**Figure A new user account has this field populated correctly**

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->