### PR TITLE
🐛Mobile | Handle successful signIn after unsuccessful token refresh

### DIFF
--- a/src/MobileUI/Services/IAuthenticationService.cs
+++ b/src/MobileUI/Services/IAuthenticationService.cs
@@ -114,6 +114,7 @@ public class AuthenticationService : IAuthenticationService
         // TODO: remove from auth client
         SecureStorage.RemoveAll();
         Preferences.Clear();
+        Preferences.Set("FirstRun", false);
     }
 
     private async Task<ApiStatus> SetLoggedInState(AuthResult loginResult)

--- a/src/MobileUI/Services/IAuthenticationService.cs
+++ b/src/MobileUI/Services/IAuthenticationService.cs
@@ -25,9 +25,7 @@ public class AuthenticationService : IAuthenticationService
     private string RefreshToken;
 
     private string _accessToken;
-
     private DateTimeOffset _tokenExpiry;
-    private DateTimeOffset _refreshTokenExpiry;
 
     public event EventHandler<DetailsUpdatedEventArgs> DetailsUpdated;
 
@@ -66,9 +64,7 @@ public class AuthenticationService : IAuthenticationService
             }
 
             var authResult = GetAuthResult(result);
-
             await SetRefreshToken(authResult);
-
             return await SetLoggedInState(authResult);
         }
         catch (TaskCanceledException taskEx)
@@ -209,7 +205,14 @@ public class AuthenticationService : IAuthenticationService
             {
                 Crashes.TrackError(new Exception($"{result.Error}, {result.ErrorDescription}"));
 
-                await SignInAsync();
+                var signInResult = await SignInAsync();
+                if (signInResult != ApiStatus.Success)
+                {
+                    Crashes.TrackError(new Exception(
+                        $"Unsuccessful attempt to sign in after unsuccessful token refresh, ApiStatus={signInResult}"));
+                }
+
+                return signInResult == ApiStatus.Success;
             }
         }
 
@@ -225,7 +228,7 @@ public class AuthenticationService : IAuthenticationService
                 AccessToken = loginResult.AccessToken,
                 RefreshToken = loginResult.RefreshToken,
                 AccessTokenExpiration = loginResult.AccessTokenExpiration,
-                IdentityToken = loginResult.IdentityToken
+                IdentityToken = loginResult.IdentityToken,
             };
         }
         else if (result is RefreshTokenResult refreshTokenResult)
@@ -234,8 +237,8 @@ public class AuthenticationService : IAuthenticationService
             {
                 AccessToken = refreshTokenResult.AccessToken,
                 RefreshToken = refreshTokenResult.RefreshToken,
+                AccessTokenExpiration = refreshTokenResult.AccessTokenExpiration,
                 IdentityToken = refreshTokenResult.IdentityToken,
-                AccessTokenExpiration = refreshTokenResult.AccessTokenExpiration
             };
         }
         else


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #731 

> 2. What was changed?

✏️ 
- If token refresh has failed for some reason and user successfully signed in using their credentials, we need to close the login page and redirect them on the tabbed page
- After logout we need to preserve the `FirstRun` flag to avoid showing the Onboarding page multiple times

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->