### PR TITLE
Send redeem emails to marketing

### DIFF
--- a/src/Infrastructure/Services/RewardSender.cs
+++ b/src/Infrastructure/Services/RewardSender.cs
@@ -31,7 +31,7 @@ public class RewardSender : IRewardSender
         // replaced with the user's details once we implement
         // physical address functionality and automatic sending
         // of rewards
-        string recipientEmail = "SSWRewards@ssw.com.au";
+        string recipientEmail = "SSWMarketing@ssw.com.au";
         string recipientName = "SSW Marketing";
 
         bool rewardSentSuccessully;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Redeem emails are going to the Rewards team

> 2. What was changed?

✏️ Emails now going to marketing

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->