### PR TITLE
🐛 Mobile | Hook up button command to redeem page carousel item

### DIFF
--- a/src/MobileUI/Controls/CarouselItem.xaml
+++ b/src/MobileUI/Controls/CarouselItem.xaml
@@ -11,7 +11,7 @@
     </Border.StrokeShape>
     <Border.GestureRecognizers>
         <TapGestureRecognizer
-            Command="{Binding ButtonCommand, Source={x:Reference this}}"
+            Command="{Binding ButtonClickedCommand, Source={x:Reference this}}"
             CommandParameter="{Binding ItemId, Source={x:Reference this}}" />
     </Border.GestureRecognizers>
     <Grid HeightRequest="400">

--- a/src/MobileUI/Controls/CarouselItem.xaml.cs
+++ b/src/MobileUI/Controls/CarouselItem.xaml.cs
@@ -1,10 +1,8 @@
-﻿using System.Windows.Input;
-using CommunityToolkit.Mvvm.ComponentModel;
-using Maui.BindableProperty.Generator.Core;
+﻿using CommunityToolkit.Mvvm.Input;
 
 namespace SSW.Rewards.Mobile.Controls;
 
-public partial class CarouselItem : Border
+public partial class CarouselItem
 {
     public string CarouselImage
     {
@@ -62,16 +60,16 @@ public partial class CarouselItem : Border
             string.Empty
         );
     
-    public ICommand ButtonCommand
+    public IAsyncRelayCommand ButtonCommand
     {
-        get => (ICommand)GetValue(ButtonCommandProperty);
+        get => (IAsyncRelayCommand)GetValue(ButtonCommandProperty);
         set => SetValue(ButtonCommandProperty, value);
     }
 
     public static readonly BindableProperty ButtonCommandProperty =
         BindableProperty.Create(
             nameof(ButtonCommand),
-            typeof(ICommand),
+            typeof(IAsyncRelayCommand),
             typeof(CarouselItem)
         );
     
@@ -106,5 +104,14 @@ public partial class CarouselItem : Border
     public CarouselItem()
     {
         InitializeComponent();
+    }
+    
+    [RelayCommand]
+    private async Task ButtonClicked()
+    {
+        if (!IsButtonDisabled && ButtonCommand != null)
+        {
+            await ButtonCommand.ExecuteAsync(ItemId);
+        }
     }
 }

--- a/src/MobileUI/Pages/RedeemPage.xaml
+++ b/src/MobileUI/Pages/RedeemPage.xaml
@@ -100,7 +100,8 @@
                                             Points="{Binding Cost}"
                                             ButtonText="GET"
                                             ItemId="{Binding Id}"
-                                            IsButtonDisabled="{Binding CanAfford, Converter={StaticResource InverseBool}}"/>
+                                            IsButtonDisabled="{Binding CanAfford, Converter={StaticResource InverseBool}}"
+                                            ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}"/>
                                     </DataTemplate>
                                 </CarouselView.ItemTemplate>
                             </CarouselView>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#792 

> 2. What was changed?

Hooks up the correct button command to carousel items on the redeem page, and sets it to handle the disabled state correctly.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->