### PR TITLE
🐛 Mobile | Enable Mono interpreter for single library on iOS in Release mode

### DIFF
--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!--<TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks>--> 
+		<!--<TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks>-->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>SSW.Rewards.Mobile</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -218,6 +218,9 @@
 	<PropertyGroup>
 		<AndroidEnableMarshalMethods>false</AndroidEnableMarshalMethods>
 	</PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('Release')) And $(TargetFramework.Contains('ios'))">
+        <MtouchInterpreter>-all,System.Collections.Immutable</MtouchInterpreter>
+    </PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 	  <WarningLevel>4</WarningLevel>
 	  <PlatformTarget>anycpu</PlatformTarget>

--- a/src/MobileUI/Services/PermissionsService.cs
+++ b/src/MobileUI/Services/PermissionsService.cs
@@ -41,7 +41,7 @@ public class PermissionsService : IPermissionsService
             // Prompt the user to turn on in settings
             // On iOS once a permission has been denied it may not be requested again from the application
             var message =
-                $"You need to grant access to {typeof(TPermission).Name} in Settings on your phone to use this feature";
+                $"You need to grant access to {typeof(TPermission).Name} in Settings on your phone to use this feature.";
             await CommunityToolkit.Maui.Alerts.Snackbar
                 .Make(message, duration: TimeSpan.FromSeconds(5))
                 .Show();
@@ -61,7 +61,7 @@ public class PermissionsService : IPermissionsService
         }
 
         await CommunityToolkit.Maui.Alerts.Snackbar
-            .Make("You cannot use this feature without granting access", duration: TimeSpan.FromSeconds(5))
+            .Make("You cannot use this feature without granting access.", duration: TimeSpan.FromSeconds(5))
             .Show();
 
         return false;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #777 

> 2. What was changed?

✏️ Enabled Mono interpreter for System.Collections.Immutable on iOS in Release mode. For details, see the link to an issue in the MAUI Community Toolkit repo on #777.

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->