### PR TITLE
🐛 Mobile | Quiz flow fixes

### DIFF
--- a/src/MobileUI/Controls/Snackbar.xaml
+++ b/src/MobileUI/Controls/Snackbar.xaml
@@ -18,7 +18,6 @@
 
             <!-- Glyph Icon-->
             <Label Grid.Column="0"
-                   Grid.ColumnSpan="2"
                    x:Name="GlyphIconLabel"
                    FontSize="30"
                    FontFamily="FluentIcons"
@@ -58,8 +57,7 @@
                    x:Name="TickLabel"/>
 
             <!-- End points coin -->
-            <Label Grid.Column="1"
-                   Grid.ColumnSpan="2"
+            <Label Grid.Column="2"
                    x:Name="PointsLabel"
                    FontSize="11"
                    HorizontalOptions="End"

--- a/src/MobileUI/Controls/Snackbar.xaml.cs
+++ b/src/MobileUI/Controls/Snackbar.xaml.cs
@@ -41,7 +41,7 @@ public partial class Snackbar
         MessageLabel.Text = options.Message;
         TickLabel.IsVisible = !options.ShowPoints && options.ActionCompleted;
         PointsLabel.IsVisible = options.ShowPoints;
-        PointsLabel.Text = string.Format("⭐ {0:n0}", options.Points);
+        PointsLabel.Text = $"⭐ {options.Points:n0}";
 
         _ = SetDismissTimer();
     }

--- a/src/MobileUI/Pages/EarnPage.xaml
+++ b/src/MobileUI/Pages/EarnPage.xaml
@@ -3,7 +3,6 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:SSW.Rewards.Mobile.ViewModels"
-             xmlns:quizzes="clr-namespace:SSW.Rewards.Shared.DTOs.Quizzes;assembly=Shared"
              xmlns:controls="clr-namespace:SSW.Rewards.Mobile.Controls"
              BackgroundColor="{StaticResource FlyoutBackgroundColour}"
              x:Name="QuizList"
@@ -31,7 +30,7 @@
                                   HorizontalScrollBarVisibility="Never"
                                   IndicatorView="QuizIndicator">
                         <CarouselView.ItemTemplate>
-                            <DataTemplate x:DataType="quizzes:QuizDto">
+                            <DataTemplate x:DataType="viewModels:QuizItemViewModel">
                                 <controls:CarouselItem
                                     CarouselImage="{Binding CarouselImage}"
                                     Description="{Binding Description}"
@@ -60,7 +59,7 @@
                     BindableLayout.ItemsSource="{Binding Quizzes}"
                     Spacing="6">
                     <BindableLayout.ItemTemplate>
-                        <DataTemplate x:DataType="quizzes:QuizDto">
+                        <DataTemplate x:DataType="viewModels:QuizItemViewModel">
                             <controls:ListItem Title="{Binding Title}"
                                                Description="{Binding Description}"
                                                Points="{Binding Points}"

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -161,8 +161,8 @@ namespace SSW.Rewards.Mobile.ViewModels
 
                 var result = await _quizService.GetQuizResults(_submissionId);
 
-                await ProcessResult(result);
                 await MopupService.Instance.RemovePageAsync(popup);
+                await ProcessResult(result);
             }
             else
             {

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -222,7 +222,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                     GlyphIsBrand = true,
                     Glyph = _quizIcon,
                     Message = $"You have completed the {QuizTitle} quiz",
-                    Points = result.Points,
+                    Points = Points,
                     ShowPoints = true
                 };
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #793

> 2. What was changed?

1. Fixes text overlaying the points icon in the snackbar
2. Fixes points showing as 0 in the snackbar 
3. Only shows the snackbar after the loading screen has closed
4. Fix passed status not showing when completing a quiz by allowing data to refresh on appearing

<img src="https://private-user-images.githubusercontent.com/123032112/316349347-5268d4f4-e98f-41f8-a18a-00e8797d3459.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTE0OTk1OTAsIm5iZiI6MTcxMTQ5OTI5MCwicGF0aCI6Ii8xMjMwMzIxMTIvMzE2MzQ5MzQ3LTUyNjhkNGY0LWU5OGYtNDFmOC1hMThhLTAwZTg3OTdkMzQ1OS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMzI3JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDMyN1QwMDI4MTBaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00NTQ5NzY4YzAxOWJiNjAyMjdmOGViNmFjZTYxNmRiYTc0Y2FhOGRjMjA0NWU0OWEzYzM3ZmJjZjFiYzQyYjRlJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.IaOFR2CLDo5NJVsRwQeUkd4MCrJMDANRiOdKakLt_bE" width="400"/>

**❌ Figure: Previous snackbar with layout issues and loading screen still present**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/2fbbe2d9-3383-4ed7-8524-d71e5a55b624" width="400" />

**✅ Figure: Improved snackbar**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->