### PR TITLE
🐛 Mobile | Set leaderboard pull-to-refresh below filter

### DIFF
--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -20,7 +20,18 @@
         <mct:StatusBarBehavior StatusBarColor="{StaticResource Background}"
           StatusBarStyle="LightContent" />
     </ContentPage.Behaviors>
-    <Grid>
+    <StackLayout Orientation="Vertical">
+        <controls:SegmentedControl
+            Segments="{Binding Periods}"
+            HeightRequest="50"
+            Padding="15,10,15,0"
+            SelectedSegment="{Binding SelectedPeriod, Mode=OneWayToSource}">
+            <controls:SegmentedControl.Behaviors>
+                <mct:EventToCommandBehavior
+                    EventName="SelectionChanged"
+                    Command="{Binding FilterByPeriodCommand}" />
+            </controls:SegmentedControl.Behaviors>
+        </controls:SegmentedControl>
         <RefreshView
             Command="{Binding RefreshLeaderboardCommand}"
             IsRefreshing="{Binding IsRefreshing}">
@@ -31,27 +42,15 @@
                 ItemSizingStrategy="MeasureFirstItem"
                 IsVisible="False">
                 <CollectionView.Header>
-                    <Grid Padding="15,10,15,0" HeightRequest="370" RowSpacing="6" RowDefinitions="1*, 7*">
-                        <controls:SegmentedControl
-                            Segments="{Binding Periods}"
-                            Grid.Row="0"
-                            SelectedSegment="{Binding SelectedPeriod, Mode=OneWayToSource}">
-                            <controls:SegmentedControl.Behaviors>
-                                <mct:EventToCommandBehavior
-                                    EventName="SelectionChanged"
-                                    Command="{Binding FilterByPeriodCommand}" />
-                            </controls:SegmentedControl.Behaviors>
-                        </controls:SegmentedControl>
-                        <Grid Grid.Row="1" ColumnDefinitions="6*,14*,6*">
-                             <!-- 2nd -->
-                             <controls:Podium Leader="{Binding Second}" Grid.Column="0" />
+                    <Grid Grid.Row="1" Padding="15,10,15,0" HeightRequest="320" ColumnDefinitions="6*,14*,6*">
+                        <!-- 2nd -->
+                        <controls:Podium Leader="{Binding Second}" Grid.Column="0" />
 
-                             <!-- 1st -->
-                             <controls:Podium Leader="{Binding First}" Grid.Column="1" />
+                        <!-- 1st -->
+                        <controls:Podium Leader="{Binding First}" Grid.Column="1" />
 
-                             <!-- 3rd -->
-                             <controls:Podium Leader="{Binding Third}" Grid.Column="2" />
-                        </Grid>
+                        <!-- 3rd -->
+                        <controls:Podium Leader="{Binding Third}" Grid.Column="2" />
                     </Grid>
                 </CollectionView.Header>
                 <CollectionView.ItemTemplate>
@@ -166,5 +165,5 @@
             IsEnabled="{Binding IsRunning}"
             IsRunning="{Binding IsRunning}"
             IsVisible="{Binding IsRunning}" />
-    </Grid>
+    </StackLayout>
 </ContentPage>

--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -24,8 +24,8 @@
         <controls:SegmentedControl
             Grid.Row="0"
             Segments="{Binding Periods}"
-            HeightRequest="50"
-            Padding="15,10,15,0"
+            HeightRequest="45"
+            Margin="15,10,15,0"
             SelectedSegment="{Binding SelectedPeriod, Mode=OneWayToSource}">
             <controls:SegmentedControl.Behaviors>
                 <mct:EventToCommandBehavior

--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -40,6 +40,8 @@
             <CollectionView
                 ItemsSource="{Binding SearchResults}"
                 x:Name="LeadersCollection"
+                ItemsUpdatingScrollMode="KeepItemsInView"
+                ItemSizingStrategy="MeasureFirstItem"
                 IsVisible="False">
                 <CollectionView.Header>
                     <Grid Grid.Row="1" Padding="15,10,15,0" HeightRequest="320" ColumnDefinitions="6*,14*,6*">

--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -25,7 +25,7 @@
             Grid.Row="0"
             Segments="{Binding Periods}"
             HeightRequest="45"
-            Margin="15,10,15,0"
+            Margin="15,10,15,15"
             SelectedSegment="{Binding SelectedPeriod, Mode=OneWayToSource}">
             <controls:SegmentedControl.Behaviors>
                 <mct:EventToCommandBehavior

--- a/src/MobileUI/Pages/LeaderboardPage.xaml
+++ b/src/MobileUI/Pages/LeaderboardPage.xaml
@@ -20,8 +20,9 @@
         <mct:StatusBarBehavior StatusBarColor="{StaticResource Background}"
           StatusBarStyle="LightContent" />
     </ContentPage.Behaviors>
-    <StackLayout Orientation="Vertical">
+    <Grid RowDefinitions="Auto,*">
         <controls:SegmentedControl
+            Grid.Row="0"
             Segments="{Binding Periods}"
             HeightRequest="50"
             Padding="15,10,15,0"
@@ -33,13 +34,12 @@
             </controls:SegmentedControl.Behaviors>
         </controls:SegmentedControl>
         <RefreshView
+            Grid.Row="1"
             Command="{Binding RefreshLeaderboardCommand}"
             IsRefreshing="{Binding IsRefreshing}">
             <CollectionView
                 ItemsSource="{Binding SearchResults}"
                 x:Name="LeadersCollection"
-                ItemsUpdatingScrollMode="KeepItemsInView"
-                ItemSizingStrategy="MeasureFirstItem"
                 IsVisible="False">
                 <CollectionView.Header>
                     <Grid Grid.Row="1" Padding="15,10,15,0" HeightRequest="320" ColumnDefinitions="6*,14*,6*">
@@ -159,11 +159,13 @@
             </CollectionView>
         </RefreshView>
         <ActivityIndicator
+            Grid.Row="0"
+            Grid.RowSpan="2"
             HorizontalOptions="Center"
             VerticalOptions="Center"
             Color="{StaticResource SSWRed}"
             IsEnabled="{Binding IsRunning}"
             IsRunning="{Binding IsRunning}"
             IsVisible="{Binding IsRunning}" />
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
+++ b/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
@@ -23,7 +23,7 @@ public partial class LeaderBoardViewModel : BaseViewModel
         _leaderService = leaderService;
         userService.MyUserIdObservable().Subscribe(myUserId => _myUserId = myUserId);
         userService.MyPointsObservable().Subscribe(myPoints => MyPoints = myPoints);
-        userService.MyBalanceObservable().Subscribe(myBalance => HandleMyBalanceChange(myBalance));
+        userService.MyBalanceObservable().Subscribe(HandleMyBalanceChange);
     }
 
     public ObservableCollection<LeaderViewModel> Leaders { get; } = [];
@@ -73,8 +73,6 @@ public partial class LeaderBoardViewModel : BaseViewModel
 
             await LoadLeaderboard();
             _loaded = true;
-
-            await FilterAndSortLeaders(Leaders, LeaderboardFilter.ThisWeek);
 
             IsRunning = false;
         }
@@ -129,6 +127,8 @@ public partial class LeaderBoardViewModel : BaseViewModel
 
             Leaders.Add(vm);
         }
+        
+        await FilterAndSortLeaders(Leaders, CurrentPeriod);
     }
 
     private async Task UpdateSearchResults(IEnumerable<LeaderViewModel> sortedLeaders)
@@ -195,8 +195,14 @@ public partial class LeaderBoardViewModel : BaseViewModel
     private async void HandleMyBalanceChange(int myBalance)
     {
         MyBalance = myBalance;
+
+        // Don't attempt to refresh leaderboard until initial load is complete
+        if (!_loaded)
+        {
+            return;
+        }
+
         await LoadLeaderboard();
-        await FilterAndSortLeaders(Leaders, CurrentPeriod);
         IsRefreshing = false;
     }
 

--- a/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
+++ b/src/MobileUI/ViewModels/LeaderBoardViewModel.cs
@@ -67,16 +67,6 @@ public partial class LeaderBoardViewModel : BaseViewModel
 
     public async Task Initialise()
     {
-        if (!_loaded)
-        {
-            IsRunning = true;
-
-            await LoadLeaderboard();
-            _loaded = true;
-
-            IsRunning = false;
-        }
-
         if (Periods is null || !Periods.Any())
         {
             Periods = new List<Segment>
@@ -86,6 +76,16 @@ public partial class LeaderBoardViewModel : BaseViewModel
                 new() { Name = "This Year", Value = LeaderboardFilter.ThisYear },
                 new() { Name = "All Time", Value = LeaderboardFilter.Forever },
             };
+        }
+        
+        if (!_loaded)
+        {
+            IsRunning = true;
+
+            await LoadLeaderboard();
+            _loaded = true;
+
+            IsRunning = false;
         }
     }
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #778 

> 2. What was changed?

Updates the pull-to-refresh functionality on the leaderboard page to not pull down the whole page but only the content below the filter. Also fixes an issue where the leaderboard can be loaded multiple times on initial load, which can mess up the animations.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->