### PR TITLE
Delete user profiles

### DIFF
--- a/src/AdminUI/AdminUI.csproj
+++ b/src/AdminUI/AdminUI.csproj
@@ -15,6 +15,10 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(RunConfiguration)' == 'SSW.Rewards.Admin' " />
+
+    <ItemGroup>
+      <Content Remove="Pages\ProfileDeletions.razor" />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" />
@@ -44,6 +48,7 @@
         <Content Include=".codeanalysis\codeanalysis.ruleset" />
         <Content Include=".codeanalysis\stylecop.json" />
         <None Include="Components\Dialogs\Quizzes\QuizQuestionDialog.razor" />
+        <None Include="Pages\ProfileDeletions.razor" />
         <None Include="wwwroot\js\DetailedProfile.js" />
     </ItemGroup>
 
@@ -54,5 +59,13 @@
 
     <ItemGroup>
       <ProjectReference Include="..\ApiClient\ApiClient.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <UpToDateCheckInput Remove="Pages\ProfileDeletions.razor" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_ContentIncludedByDefault Remove="Pages\ProfileDeletions.razor" />
     </ItemGroup>
 </Project>

--- a/src/AdminUI/AdminUI.csproj
+++ b/src/AdminUI/AdminUI.csproj
@@ -15,10 +15,6 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(RunConfiguration)' == 'SSW.Rewards.Admin' " />
-
-    <ItemGroup>
-      <Content Remove="Pages\ProfileDeletions.razor" />
-    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" />
@@ -48,7 +44,6 @@
         <Content Include=".codeanalysis\codeanalysis.ruleset" />
         <Content Include=".codeanalysis\stylecop.json" />
         <None Include="Components\Dialogs\Quizzes\QuizQuestionDialog.razor" />
-        <None Include="Pages\ProfileDeletions.razor" />
         <None Include="wwwroot\js\DetailedProfile.js" />
     </ItemGroup>
 

--- a/src/AdminUI/Components/Dialogs/Users/DeleteUserDialog.razor
+++ b/src/AdminUI/Components/Dialogs/Users/DeleteUserDialog.razor
@@ -1,0 +1,54 @@
+﻿@using SSW.Rewards.Shared.DTOs.Users
+
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Delete User Profile</MudText>    
+    </TitleContent>
+    <DialogContent>
+    <MudForm  @ref="_form" Model="@Dto" @bind-IsValid="@valid" @bind-Errors="@errors">
+        <MudGrid>
+                    <MudItem xs="12">
+                        <MudCheckBox T="bool" Label="@($"Are you sure you want to delete {Dto.UserName}?")" @bind-Value="DeleteDto.AdminConfirmed1" />
+                        <MudCheckBox T="bool" Label="Are you 100% sure? This can't be undone!" @bind-Value="DeleteDto.AdminConfirmed2" />
+                    </MudItem>
+            </MudGrid>
+    </MudForm >
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary" OnClick="Submit">Create</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    MudDialogInstance? MudDialog { get; set; }
+    
+    [Parameter]
+    public ProfileDeletionRequestDto Dto { get; set; } = new();
+
+    private AdminDeleteProfileDto DeleteDto { get; set; } = new();
+    
+
+    private MudForm? _form;
+    private bool valid;
+    private string[] errors = Array.Empty<string>();
+
+    private async Task Submit()
+    {
+        if (_form is not null)
+        {
+            await _form.Validate();   
+        }
+        if (valid)
+        {
+            DeleteDto.UserId = Dto.UserId;
+            MudDialog?.Close(DialogResult.Ok(Dto));
+        }
+    }
+
+    void Cancel() => MudDialog?.Cancel();
+    
+}

--- a/src/AdminUI/Components/Dialogs/Users/DeleteUserDialog.razor
+++ b/src/AdminUI/Components/Dialogs/Users/DeleteUserDialog.razor
@@ -18,7 +18,9 @@
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
         <MudButton Variant="Variant.Filled"
-                                   Color="Color.Primary" OnClick="Submit">Create</MudButton>
+                   Color="Color.Primary"
+                   OnClick="Submit"
+                   Disabled="@(!DeleteDto.AdminConfirmed1 || !DeleteDto.AdminConfirmed2)">Delete</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -45,7 +47,7 @@
         if (valid)
         {
             DeleteDto.UserId = Dto.UserId;
-            MudDialog?.Close(DialogResult.Ok(Dto));
+            MudDialog?.Close(DialogResult.Ok(DeleteDto));
         }
     }
 

--- a/src/AdminUI/Pages/ProfileDeletions.razor
+++ b/src/AdminUI/Pages/ProfileDeletions.razor
@@ -18,7 +18,8 @@
 
 <Table TItem="ProfileDeletionRequestDto"
        Items="@(_model)"
-       IsLoading="@_loading">
+       IsLoading="@_loading"
+       OnRowClick="OnRowClicked">
     <HeadingTemplate>
         <MudTh>
             Id

--- a/src/AdminUI/Pages/ProfileDeletions.razor
+++ b/src/AdminUI/Pages/ProfileDeletions.razor
@@ -1,0 +1,81 @@
+﻿@page "/delete"
+
+@using Microsoft.AspNetCore.Authorization
+@using SSW.Rewards.Admin.UI.Components
+@using SSW.Rewards.Admin.UI.Components.Dialogs.Users
+@using SSW.Rewards.ApiClient.Services
+@using SSW.Rewards.Shared.DTOs.Users
+
+@inject IUserAdminService userAdminService
+@inject IDialogService DialogService
+@inject ISnackbar SnackBar
+
+@attribute [Authorize(Roles = "Staff, Admin")]
+
+<MudText Typo="Typo.h2">Deletion Requests</MudText>
+<MudText Typo="Typo.body1">Users who have requested that their profile be deleted</MudText>
+
+
+<Table TItem="ProfileDeletionRequestDto"
+       Items="@(_model)"
+       IsLoading="@_loading">
+    <HeadingTemplate>
+        <MudTh>
+            Id
+        </MudTh>
+        <MudTh>
+            Name
+        </MudTh>
+        <MudTh>
+            When requested
+        </MudTh>
+    </HeadingTemplate>
+    <RowTemplate>
+        <MudTd>
+            @context.UserId
+        </MudTd>
+        <MudTd DataLabel="Name">
+            @context.UserName
+        </MudTd>
+        <MudTd DataLabel="Requested">
+            @context.Requested
+        </MudTd>
+    </RowTemplate>
+</Table>
+
+@code {
+    private List<ProfileDeletionRequestDto> _model = new();
+    private bool _loading = true;
+    readonly DialogOptions _disableBackdropClick = new() { DisableBackdropClick = true,  MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadUsers();
+    }
+
+    private async Task LoadUsers()
+    {
+        _loading = true;
+        _model.Clear();
+        var vm = await userAdminService.GetProfileDeletionRequests();
+        _model = vm.Requests;
+        _loading = false;
+    }
+
+    private async Task OnRowClicked(TableRowClickEventArgs<ProfileDeletionRequestDto> args)
+    {
+        var dialogParams = new DialogParameters { ["Dto"] = args.Item };
+
+        var dialog = DialogService.Show<DeleteUserDialog>("Delete a user", dialogParams);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            if (result.Data is AdminDeleteProfileDto dto)
+            {
+                await userAdminService.DeleteUserProfile(dto);
+                SnackBar.Add("User profile deleted", Severity.Success);
+                await LoadUsers();
+            }
+        }
+    }
+}

--- a/src/AdminUI/Shared/NavMenu.razor
+++ b/src/AdminUI/Shared/NavMenu.razor
@@ -13,5 +13,6 @@
         <MudNavLink Href="newusers" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.SupervisedUserCircle">New Users</MudNavLink>
         <MudNavLink Href="prizedraw" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Celebration">Prize Draw</MudNavLink>
         <MudNavLink Href="notifications" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Chat">Notifications</MudNavLink>
+        <MudNavLink Href="delete" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Delete">Delete</MudNavLink>
     </AuthorizeView>
 </MudNavMenu>

--- a/src/ApiClient/Services/IUserAdminService.cs
+++ b/src/ApiClient/Services/IUserAdminService.cs
@@ -6,6 +6,8 @@ namespace SSW.Rewards.ApiClient.Services;
 public interface IUserAdminService
 {
     Task<NewUsersViewModel> GetNewUsers(LeaderboardFilter filter, bool filterStaff, CancellationToken cancellationToken = default);
+    Task<ProfileDeletionRequestsVieWModel> GetProfileDeletionRequests(CancellationToken cancellationToken = default);
+    Task DeleteUserProfile(AdminDeleteProfileDto dto, CancellationToken cancellationToken = default);
 }
 
 public class UserAdminService : IUserAdminService
@@ -36,5 +38,36 @@ public class UserAdminService : IUserAdminService
         var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
         throw new Exception($"Failed to get new users: {responseContent}");
+    }
+
+    public async Task<ProfileDeletionRequestsVieWModel> GetProfileDeletionRequests(CancellationToken cancellationToken = default)
+    {
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetProfileDeletionRequests", cancellationToken);
+
+        if  (result.IsSuccessStatusCode)
+        {
+            var response = await result.Content.ReadFromJsonAsync<ProfileDeletionRequestsVieWModel>(cancellationToken: cancellationToken);
+
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+
+        throw new Exception($"Failed to get profile deletion requests: {responseContent}");
+    }
+
+    public async Task DeleteUserProfile(AdminDeleteProfileDto dto, CancellationToken cancellationToken = default)
+    {
+        var result = await _httpClient.PostAsJsonAsync($"{_baseRoute}DeleteUserProfile", dto, cancellationToken);
+
+        if  (!result.IsSuccessStatusCode)
+        {
+            var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+
+            throw new Exception($"Failed to delete user profile: {responseContent}");
+        }
     }
 }

--- a/src/Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/IApplicationDbContext.cs
@@ -22,5 +22,6 @@ public interface IApplicationDbContext
     DbSet<QuizAnswer> QuizAnswers { get; set; }
     DbSet<SubmittedQuizAnswer> SubmittedAnswers { get; set; }
     DbSet<UnclaimedAchievement> UnclaimedAchievements { get; set; }
+    DbSet<OpenProfileDeletionRequest> OpenProfileDeletionRequests { get; set; }
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Application/Common/Interfaces/IEmailService.cs
+++ b/src/Application/Common/Interfaces/IEmailService.cs
@@ -1,5 +1,5 @@
 ﻿using SSW.Rewards.Application.Common.Models;
-using SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
+using SSW.Rewards.Application.Users.Commands.Common;
 
 namespace SSW.Rewards.Application.Common.Interfaces;
 
@@ -10,4 +10,6 @@ public interface IEmailService
     Task<bool> SendDigitalRewardEmail(string to, string toName, string subject, DigitalRewardEmail emailProps, CancellationToken cancellationToken);
 
     Task<bool> SendProfileDeletionRequest(DeleteProfileEmail model, CancellationToken cancellationToken);
+
+    Task<bool> SendProfileDeletionConfirmation(DeleteProfileEmail model, string deletionRequestDate, CancellationToken cancellationToken);
 }

--- a/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommand.cs
+++ b/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommand.cs
@@ -1,0 +1,30 @@
+﻿using SSW.Rewards.Shared.DTOs.Users;
+
+namespace SSW.Rewards.Application.Users.Commands.AdminDeleteProfile;
+
+public class AdminDeleteProfileCommand : IRequest
+{
+    public required AdminDeleteProfileDto Profile { get; set; }
+
+}
+
+public class AdminDeleteProfileHandler : IRequestHandler<AdminDeleteProfileCommand>
+{
+    private readonly IApplicationDbContext _dbContext;
+    private readonly IEmailService _emailService;
+
+    public AdminDeleteProfileHandler(IApplicationDbContext dbContext, IEmailService emailService)
+    {
+        _dbContext = dbContext;
+        _emailService = emailService;
+    }
+
+    public async Task Handle(AdminDeleteProfileCommand request, CancellationToken cancellationToken)
+    {
+        var deletionRequest = await _dbContext.OpenProfileDeletionRequests
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.UserId == request.Profile.UserId, cancellationToken);
+
+
+    }
+}

--- a/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommand.cs
+++ b/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommand.cs
@@ -1,4 +1,7 @@
-﻿using SSW.Rewards.Shared.DTOs.Users;
+﻿using Microsoft.Extensions.Options;
+using SSW.Rewards.Application.Users.Commands.Common;
+using SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
+using SSW.Rewards.Shared.DTOs.Users;
 
 namespace SSW.Rewards.Application.Users.Commands.AdminDeleteProfile;
 
@@ -12,11 +15,16 @@ public class AdminDeleteProfileHandler : IRequestHandler<AdminDeleteProfileComma
 {
     private readonly IApplicationDbContext _dbContext;
     private readonly IEmailService _emailService;
+    private readonly string _emailSender;
 
-    public AdminDeleteProfileHandler(IApplicationDbContext dbContext, IEmailService emailService)
+    public AdminDeleteProfileHandler(
+        IApplicationDbContext dbContext,
+        IEmailService emailService,
+        IOptions<DeleteProfileOptions> options)
     {
         _dbContext = dbContext;
         _emailService = emailService;
+        _emailSender = options.Value.Recipient;
     }
 
     public async Task Handle(AdminDeleteProfileCommand request, CancellationToken cancellationToken)
@@ -25,6 +33,45 @@ public class AdminDeleteProfileHandler : IRequestHandler<AdminDeleteProfileComma
             .Include(r => r.User)
             .FirstOrDefaultAsync(r => r.UserId == request.Profile.UserId, cancellationToken);
 
+        if (deletionRequest?.User is null)
+        {
+            throw new DirectoryNotFoundException($"User with id {request.Profile.UserId} either not found or not marked for deletion.");
+        }
 
+        var emailModel = new DeleteProfileEmail
+        {
+            RewardsTeamEmail = _emailSender,
+            UserEmail = deletionRequest!.User!.Email!,
+            UserName = deletionRequest!.User!.FullName!
+        };
+
+        AnonymiseUserPII(deletionRequest.User);
+
+        deletionRequest.User.Activated = false;
+
+        _dbContext.OpenProfileDeletionRequests.Remove(deletionRequest);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _emailService.SendProfileDeletionConfirmation(emailModel, deletionRequest.CreatedUtc.ToLocalTime().ToString("f"), cancellationToken);
+
+        // TODO: update SSW.Identity. See: https://github.com/SSWConsulting/SSW.IdentityServer/issues/224
     }
+
+    public void AnonymiseUserPII(User user)
+    {
+        if (user != null)
+        {
+            var guid = Guid.NewGuid().ToString("N"); // N format removes hyphens
+                        
+            var part1 = guid.Substring(0, 8);
+            var part2 = guid.Substring(8, 8);
+            var part3 = guid.Substring(16, 8);
+            var part4 = guid.Substring(24, 8);
+
+            user.FullName = $"Anon-{part1} Anon-{part2}";
+            user.Email = $"{part3}@{part4}.com";
+        }
+    }
+
 }

--- a/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommandValidator.cs
+++ b/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommandValidator.cs
@@ -8,7 +8,14 @@ public class AdminDeleteProfileCommandValidator : AbstractValidator<AdminDeleteP
     {
         _applicationDbContext = applicationDbContext;
 
-        RuleFor(c => c.Profile.UserId).MustAsync(HaveCorrespondingDeletionRequest);
+        RuleFor(c => c.Profile.UserId)
+            .MustAsync(HaveCorrespondingDeletionRequest);
+
+        RuleFor(c => c.Profile.AdminConfirmed1)
+            .Equal(true);
+
+        RuleFor(c => c.Profile.AdminConfirmed2)
+            .Equal(true);
     }
 
     private async Task<bool> HaveCorrespondingDeletionRequest(int userId, CancellationToken cancellationToken)

--- a/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommandValidator.cs
+++ b/src/Application/Users/Commands/AdminDeleteProfile/AdminDeleteProfileCommandValidator.cs
@@ -1,0 +1,18 @@
+﻿namespace SSW.Rewards.Application.Users.Commands.AdminDeleteProfile;
+
+public class AdminDeleteProfileCommandValidator : AbstractValidator<AdminDeleteProfileCommand>
+{
+    private readonly IApplicationDbContext _applicationDbContext;
+
+    public AdminDeleteProfileCommandValidator(IApplicationDbContext applicationDbContext)
+    {
+        _applicationDbContext = applicationDbContext;
+
+        RuleFor(c => c.Profile.UserId).MustAsync(HaveCorrespondingDeletionRequest);
+    }
+
+    private async Task<bool> HaveCorrespondingDeletionRequest(int userId, CancellationToken cancellationToken)
+    {
+        return await _applicationDbContext.OpenProfileDeletionRequests.AnyAsync(r => r.UserId == userId, cancellationToken);
+    }
+}

--- a/src/Application/Users/Commands/Common/DeleteProfileEmail.cs
+++ b/src/Application/Users/Commands/Common/DeleteProfileEmail.cs
@@ -1,4 +1,5 @@
-﻿namespace SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
+﻿namespace SSW.Rewards.Application.Users.Commands.Common;
+
 public class DeleteProfileEmail
 {
     public string UserName { get; set; }

--- a/src/Application/Users/Queries/AdminGetProfileDeletionRequests/AdminGetProfileDeletionRequestsQuery.cs
+++ b/src/Application/Users/Queries/AdminGetProfileDeletionRequests/AdminGetProfileDeletionRequestsQuery.cs
@@ -1,0 +1,31 @@
+﻿using AutoMapper.QueryableExtensions;
+using SSW.Rewards.Shared.DTOs.Users;
+
+namespace SSW.Rewards.Application.Users.Queries.AdminGetProfileDeletionRequests;
+
+
+public class AdminGetProfileDeletionRequestsQuery : IRequest<ProfileDeletionRequestsVieWModel> { }
+
+public class AdminProfileDeletionRequestsQueryHandler : IRequestHandler<AdminGetProfileDeletionRequestsQuery, ProfileDeletionRequestsVieWModel>
+{
+    private readonly IApplicationDbContext _dbContext;
+    private readonly IMapper _mapper;
+
+    public AdminProfileDeletionRequestsQueryHandler(IApplicationDbContext dbContext, IMapper mapper)
+    {
+        _dbContext = dbContext;
+        _mapper = mapper;
+    }
+
+    public async Task<ProfileDeletionRequestsVieWModel> Handle(AdminGetProfileDeletionRequestsQuery request, CancellationToken cancellationToken)
+    {
+        var requests = await _dbContext.OpenProfileDeletionRequests
+            .ProjectTo<ProfileDeletionRequestDto>(_mapper.ConfigurationProvider)
+            .ToListAsync(cancellationToken);
+
+        return new ProfileDeletionRequestsVieWModel
+        {
+            Requests = requests
+        };
+    }
+}

--- a/src/Application/Users/Queries/AdminGetProfileDeletionRequests/Mapping.cs
+++ b/src/Application/Users/Queries/AdminGetProfileDeletionRequests/Mapping.cs
@@ -1,0 +1,13 @@
+﻿using SSW.Rewards.Shared.DTOs.Users;
+
+namespace SSW.Rewards.Application.Users.Queries.AdminGetProfileDeletionRequests;
+
+public class Mapping : Profile
+{
+    public Mapping()
+    {
+        CreateMap<OpenProfileDeletionRequest, ProfileDeletionRequestDto>()
+            .ForMember(dst => dst.UserName, opt => opt.MapFrom(src => src.User.FullName))
+            .ForMember(dst => dst.Requested, opt => opt.MapFrom(src => src.CreatedUtc.ToLocalTime().ToShortDateString()));
+    }
+}

--- a/src/Common/DTOs/Users/AdminDeleteProfileDto.cs
+++ b/src/Common/DTOs/Users/AdminDeleteProfileDto.cs
@@ -1,0 +1,10 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Users;
+
+public class AdminDeleteProfileDto
+{
+    public int UserId { get; set; } = 0;
+
+    public bool AdminConfirmed1 { get; set; } = false;
+
+    public bool AdminConfirmed2 { get; set; } = false;
+}

--- a/src/Common/DTOs/Users/ProfileDeletionRequestDto.cs
+++ b/src/Common/DTOs/Users/ProfileDeletionRequestDto.cs
@@ -1,0 +1,15 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Users;
+
+public class ProfileDeletionRequestDto
+{
+    public int UserId { get; set; }
+
+    public string UserName { get; set; }
+
+    public string Requested { get; set; }
+}
+
+public class ProfileDeletionRequestsVieWModel
+{
+    public List<ProfileDeletionRequestDto> Requests { get; set; } = new();
+}

--- a/src/Domain/Entities/OpenProfileDeletionRequest.cs
+++ b/src/Domain/Entities/OpenProfileDeletionRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace SSW.Rewards.Domain.Entities;
+
+public class OpenProfileDeletionRequest : BaseAuditableEntity
+{
+    public int UserId { get; set; }
+    public required User User { get; set; }
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,4 +1,5 @@
 ﻿namespace SSW.Rewards.Domain.Entities;
+
 public class User : BaseEntity
 {
     public string? FullName { get; set; } = string.Empty;

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -45,7 +45,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<UserSocialMediaId> UserSocialMediaIds { get; set; }
     public DbSet<SubmittedQuizAnswer> SubmittedAnswers { get; set; }
     public DbSet<UnclaimedAchievement> UnclaimedAchievements { get; set; }
-
+    public DbSet<OpenProfileDeletionRequest> OpenProfileDeletionRequests { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Infrastructure/Persistence/Migrations/20240327052800_AddProfileDeletionRequests.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240327052800_AddProfileDeletionRequests.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SSW.Rewards.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using SSW.Rewards.Infrastructure.Persistence;
 namespace SSW.Rewards.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240327052800_AddProfileDeletionRequests")]
+    partial class AddProfileDeletionRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20240327052800_AddProfileDeletionRequests.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240327052800_AddProfileDeletionRequests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SSW.Rewards.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProfileDeletionRequests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OpenProfileDeletionRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    LastModified = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OpenProfileDeletionRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OpenProfileDeletionRequests_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenProfileDeletionRequests_UserId",
+                table: "OpenProfileDeletionRequests",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OpenProfileDeletionRequests");
+        }
+    }
+}

--- a/src/WebAPI/Controllers/UserController.cs
+++ b/src/WebAPI/Controllers/UserController.cs
@@ -15,6 +15,8 @@ using SSW.Rewards.Application.Users.Queries.GetUserAchievements;
 using SSW.Rewards.Application.Users.Queries.GetUserRewards;
 using SSW.Rewards.Enums;
 using SSW.Rewards.WebAPI.Authorisation;
+using SSW.Rewards.Application.Users.Commands.AdminDeleteProfile;
+using SSW.Rewards.Application.Users.Queries.AdminGetProfileDeletionRequests;
 
 namespace SSW.Rewards.WebAPI.Controllers;
 
@@ -103,5 +105,20 @@ public class UserController : ApiControllerBase
     public async Task<ActionResult<NewUsersViewModel>> GetNewUsers([FromQuery] LeaderboardFilter filter, bool filterStaff)
     {
         return await Mediator.Send(new GetNewUsersQuery { Filter = filter, FilterStaff = filterStaff });
+    }
+
+    [HttpPost]
+    [Authorize(Roles = AuthorizationRoles.Admin)]
+    public async Task<IActionResult> DeleteUserProfile(AdminDeleteProfileDto dto)
+    {
+        await Mediator.Send(new AdminDeleteProfileCommand { Profile = dto });
+        return Accepted();
+    }
+
+    [HttpGet]
+    [Authorize(Roles = AuthorizationRoles.Admin)]
+    public async Task<ActionResult<ProfileDeletionRequestsVieWModel>> GetProfileDeletionRequests()
+    {
+        return await Mediator.Send(new AdminGetProfileDeletionRequestsQuery());
     }
 }

--- a/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using SSW.Rewards.Application.Common.Mappings;
 using SSW.Rewards.Domain.Entities;
 using SSW.Rewards.Shared.DTOs.Leaderboard;
+using SSW.Rewards.Shared.DTOs.Users;
 
 namespace SSW.Rewards.Application.UnitTests.Common.Mappings;
 
@@ -28,6 +29,7 @@ public class MappingTests
 
     [Test]
     [TestCase(typeof(User), typeof(LeaderboardUserDto))]
+    [TestCase(typeof(OpenProfileDeletionRequest), typeof(ProfileDeletionRequestDto))]
     public void ShouldSupportMappingFromSourceToDestination(Type source, Type destination)
     {
         var instance = GetInstanceOf(source);


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ We need to provide users with a way to request their profile is deleted to comply with App Store requirements and privacy legislation. Currently, this is done manually in the database.

> 2. What was changed?

✏️ UI and logic added to manage deletion requests via the admin portal

> 3. Did you do pair or mob programming?

✏️ NA
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->