### PR TITLE
🐛 Mobile | Rank is inconsistent after switching profiles

### DIFF
--- a/src/MobileUI/Services/IUserService.cs
+++ b/src/MobileUI/Services/IUserService.cs
@@ -1,5 +1,4 @@
-﻿using System.Reactive.Subjects;
-using SSW.Rewards.Shared.DTOs.Users;
+﻿using SSW.Rewards.Shared.DTOs.Users;
 
 namespace SSW.Rewards.Mobile.Services;
 
@@ -12,12 +11,14 @@ public interface IUserService
     IObservable<int> MyPointsObservable();
     IObservable<int> MyBalanceObservable();
     IObservable<string> MyQrCodeObservable();
+    IObservable<int> MyAllTimeRankObservable();
     bool HasCachedAccount { get; }
 
     // auth methods
 
     // user details
     Task UpdateMyDetailsAsync();
+    void UpdateMyAllTimeRank(int newRank);
     Task<IEnumerable<Achievement>> GetAchievementsAsync();
     Task<IEnumerable<Achievement>> GetAchievementsAsync(int userId);
     Task<IEnumerable<Achievement>> GetProfileAchievementsAsync();

--- a/src/MobileUI/Services/UserService.cs
+++ b/src/MobileUI/Services/UserService.cs
@@ -17,6 +17,7 @@ public class UserService : IUserService
     private readonly BehaviorSubject<int> _myPoints = new(0);
     private readonly BehaviorSubject<int> _myBalance = new(0);
     private readonly BehaviorSubject<string> _myQrCode = new(string.Empty);
+    private readonly BehaviorSubject<int> _myAllTimeRank = new(Int32.MaxValue);
 
     public bool HasCachedAccount { get => Preferences.Get(nameof(HasCachedAccount), false); }
 
@@ -34,6 +35,7 @@ public class UserService : IUserService
     public IObservable<int> MyPointsObservable() => _myPoints.AsObservable();
     public IObservable<int> MyBalanceObservable() => _myBalance.AsObservable();
     public IObservable<string> MyQrCodeObservable() => _myQrCode.AsObservable();
+    public IObservable<int> MyAllTimeRankObservable() => _myAllTimeRank.AsObservable();
 
     public async Task<UserProfileDto> GetUserAsync(int userId)
     {
@@ -63,6 +65,11 @@ public class UserService : IUserService
         _myPoints.OnNext(user.Points);
         _myBalance.OnNext(user.Balance);
         _myQrCode.OnNext(user.QRCode);
+    }
+
+    public void UpdateMyAllTimeRank(int newRank)
+    {
+        _myAllTimeRank.OnNext(newRank);
     }
 
     public async Task<IEnumerable<Achievement>> GetAchievementsAsync()

--- a/src/MobileUI/ViewModels/FlyoutHeaderViewModel.cs
+++ b/src/MobileUI/ViewModels/FlyoutHeaderViewModel.cs
@@ -1,14 +1,9 @@
-﻿using System.Reactive.Linq;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SSW.Rewards.Mobile.ViewModels;
 
 public partial class FlyoutHeaderViewModel : ObservableObject
 {
-    private int _myUserId;
-
-    private readonly ILeaderService _leaderService;
-
     [ObservableProperty]
     private string _profilePic;
 
@@ -30,25 +25,16 @@ public partial class FlyoutHeaderViewModel : ObservableObject
     [ObservableProperty]
     private int _rank;
 
-    public FlyoutHeaderViewModel(IUserService userService, ILeaderService leaderService)
+    public FlyoutHeaderViewModel(IUserService userService)
     {
-        _leaderService = leaderService;
         Console.WriteLine($"[FlyoutHeaderViewModel] Email: {Email}");
 
-        userService.MyUserIdObservable().Subscribe(myUserId => _myUserId = myUserId);
         userService.MyNameObservable().Subscribe(myName => Name = myName);
         userService.MyEmailObservable().Subscribe(myEmail => Email = myEmail);
         userService.MyProfilePicObservable().Subscribe(myProfilePic => ProfilePic = myProfilePic);
         userService.MyPointsObservable().Subscribe(myPoints => Points = myPoints);
         userService.MyBalanceObservable().Subscribe(myBalance => Credits = myBalance);
         userService.MyQrCodeObservable().Subscribe(myQrCode => QrCode = myQrCode);
-
-        _ = LoadRank();
-    }
-
-    private async Task LoadRank()
-    {
-        var summaries = await _leaderService.GetLeadersAsync(false);
-        Rank = summaries.FirstOrDefault(x => x.UserId == _myUserId)?.Rank ?? 0;
+        userService.MyAllTimeRankObservable().Subscribe(myRank => Rank = myRank);
     }
 }

--- a/src/MobileUI/ViewModels/ProfileViewModels/MyProfileViewModel.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/MyProfileViewModel.cs
@@ -4,7 +4,6 @@ namespace SSW.Rewards.Mobile.ViewModels.ProfileViewModels;
 public class MyProfileViewModel(
     IRewardService rewardsService,
     IUserService userService,
-    ILeaderService leaderService,
     IDevService devService,
     IPermissionsService permissionsService)
     : ProfileViewModelBase(rewardsService, userService, devService, permissionsService)
@@ -22,7 +21,7 @@ public class MyProfileViewModel(
         _userService.MyPointsObservable().Subscribe(myPoints => Points = myPoints);
         _userService.MyBalanceObservable().Subscribe(myBalance => Balance = myBalance);
         _userService.MyQrCodeObservable().Subscribe(myQrCode => IsStaff = !string.IsNullOrWhiteSpace(myQrCode));
-        Rank = await LoadRank();
+        _userService.MyAllTimeRankObservable().Subscribe(myRank => Rank = myRank);
 
         await _initialise();
     }
@@ -31,12 +30,5 @@ public class MyProfileViewModel(
     {
         userId = myUserId;
         await LoadProfileSections();
-    }
-
-    private async Task<int> LoadRank()
-    {
-        var summaries = await leaderService.GetLeadersAsync(false);
-        var myId = userId;
-        return summaries.FirstOrDefault(x => x.UserId == myId)?.Rank ?? 0;
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Closes #817 

> 2. What was changed?

✏️ Made `Rank` reactive with the source of truth in `userService`

> 3. Did you do pair or mob programming?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->


https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/123032112/ce04cb80-e172-4304-9a0b-09a3dc5ae99f

**Figure:** the rank was # 11 on all pages for the first profile; and # 87 for the second profile

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->