### PR TITLE
🐛 Mobile | Fix large bottom gap on Activity page and hook up continuous scrolling

### DIFF
--- a/src/ApiClient/Services/IActivityFeedService.cs
+++ b/src/ApiClient/Services/IActivityFeedService.cs
@@ -5,8 +5,8 @@ namespace SSW.Rewards.ApiClient.Services;
 
 public interface IActivityFeedService
 {
-    Task<ActivityFeedViewModel> GetAllActivities(CancellationToken cancellationToken);
-    Task<ActivityFeedViewModel> GetFriendsActivities(CancellationToken cancellationToken);
+    Task<ActivityFeedViewModel> GetAllActivities(int take, int skip, CancellationToken cancellationToken);
+    Task<ActivityFeedViewModel> GetFriendsActivities(int take, int skip, CancellationToken cancellationToken);
 }
 
 public class ActivityFeedService(IHttpClientFactory clientFactory) : IActivityFeedService
@@ -15,9 +15,9 @@ public class ActivityFeedService(IHttpClientFactory clientFactory) : IActivityFe
 
     private const string _baseRoute = "api/ActivityFeed/";
 
-    public async Task<ActivityFeedViewModel> GetAllActivities(CancellationToken cancellationToken)
+    public async Task<ActivityFeedViewModel> GetAllActivities(int take, int skip, CancellationToken cancellationToken)
     {
-        var result = await _httpClient.GetAsync($"{_baseRoute}GetAllActivities", cancellationToken);
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetAllActivities?skip={skip}&take={take}", cancellationToken);
 
         if  (result.IsSuccessStatusCode)
         {
@@ -33,9 +33,9 @@ public class ActivityFeedService(IHttpClientFactory clientFactory) : IActivityFe
         throw new Exception($"Failed to get all activities: {responseContent}");
     }
     
-    public async Task<ActivityFeedViewModel> GetFriendsActivities(CancellationToken cancellationToken)
+    public async Task<ActivityFeedViewModel> GetFriendsActivities(int take, int skip, CancellationToken cancellationToken)
     {
-        var result = await _httpClient.GetAsync($"{_baseRoute}GetFriendsActivities", cancellationToken);
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetFriendsActivities?skip={skip}&take={take}", cancellationToken);
 
         if  (result.IsSuccessStatusCode)
         {

--- a/src/MobileUI/Pages/ActivityPage.xaml
+++ b/src/MobileUI/Pages/ActivityPage.xaml
@@ -30,82 +30,85 @@
             <CollectionView
                 ItemsSource="{Binding Feed}"
                 ItemsUpdatingScrollMode="KeepItemsInView"
-                IsVisible="True">
+                IsVisible="True"
+                RemainingItemsThreshold="5"
+                RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}">
                 <CollectionView.ItemsLayout>
-                    <GridItemsLayout Orientation="Vertical"
-                                     VerticalItemSpacing="8" />
+                    <GridItemsLayout Orientation="Vertical" />
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="activityFeed:ActivityFeedItemDto">
-                        <Border
-                            BackgroundColor="{StaticResource MainBackground}"
-                            Stroke="{StaticResource MainBackground}"
-                            StrokeShape="RoundRectangle 10">
-                            <Grid RowDefinitions="Auto, *"
-                                  RowSpacing="10"
-                                  Padding="15">
-                                <Grid Grid.Row="0"
-                                      ColumnDefinitions="Auto, *"
-                                      ColumnSpacing="15">
-                                    <mct:AvatarView
-                                        Grid.Column="0"
-                                        ImageSource="{Binding UserAvatar}"
-                                        WidthRequest="50"
-                                        HeightRequest="50"
-                                        CornerRadius="25"
-                                        BorderWidth="2" />
-                                    <VerticalStackLayout
-                                        Grid.Column="1"
-                                        VerticalOptions="Center">
-                                        <Label
-                                            FontSize="20"
-                                            Style="{StaticResource LabelBold}"
-                                            Text="{Binding UserName}" />
-                                        <Label
-                                            FontSize="14"
-                                            Text="{Binding UserTitle}" />
-                                        <Label
-                                            FontSize="14"
-                                            Text="{Binding TimeElapsed}"
-                                            Margin="0,3,0,0"/>
-                                    </VerticalStackLayout>
-                                </Grid>
-                                <Border
-                                    Grid.Row="1"
-                                    BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                    Stroke="{StaticResource MainBackground}"
-                                    StrokeShape="RoundRectangle 5"
-                                    Padding="10">
-                                    <Grid ColumnDefinitions="Auto, *"
+                        <Grid Padding="0,0,0,8">
+                            <Border
+                                BackgroundColor="{StaticResource MainBackground}"
+                                Stroke="{StaticResource MainBackground}"
+                                StrokeShape="RoundRectangle 10">
+                                <Grid RowDefinitions="Auto, *"
+                                      RowSpacing="10"
+                                      Padding="15">
+                                    <Grid Grid.Row="0"
+                                          ColumnDefinitions="Auto, *"
                                           ColumnSpacing="15">
-                                        <Label
+                                        <mct:AvatarView
                                             Grid.Column="0"
-                                            Text="&#xf51e;"
-                                            TextColor="{StaticResource Coin}"
-                                            FontFamily="FA6Solid"
-                                            HorizontalOptions="Center"
-                                            VerticalOptions="Center"
-                                            FontSize="14"
-                                            Style="{StaticResource LabelBold}"
-                                            FontAutoScalingEnabled="False"
-                                            InputTransparent="True">
-                                            <Label.Triggers>
-                                                <DataTrigger TargetType="Label"
-                                                             Binding="{Binding Achievement.AchievementType}"
-                                                             Value="{x:Static enums:AchievementType.Attended}">
-                                                    <Setter Property="TextColor" Value="White"/>
-                                                    <Setter Property="Text" Value="&#xf3c5;"/>
-                                                </DataTrigger>
-                                            </Label.Triggers>
-                                        </Label>
-                                        <Label
+                                            ImageSource="{Binding UserAvatar}"
+                                            WidthRequest="50"
+                                            HeightRequest="50"
+                                            CornerRadius="25"
+                                            BorderWidth="2" />
+                                        <VerticalStackLayout
                                             Grid.Column="1"
-                                            FontSize="14"
-                                            Text="{Binding AchievementMessage}" />
+                                            VerticalOptions="Center">
+                                            <Label
+                                                FontSize="20"
+                                                Style="{StaticResource LabelBold}"
+                                                Text="{Binding UserName}" />
+                                            <Label
+                                                FontSize="14"
+                                                Text="{Binding UserTitle}" />
+                                            <Label
+                                                FontSize="14"
+                                                Text="{Binding TimeElapsed}"
+                                                Margin="0,3,0,0"/>
+                                        </VerticalStackLayout>
                                     </Grid>
-                                </Border>
-                            </Grid>
-                        </Border>
+                                    <Border
+                                        Grid.Row="1"
+                                        BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                                        Stroke="{StaticResource MainBackground}"
+                                        StrokeShape="RoundRectangle 5"
+                                        Padding="10">
+                                        <Grid ColumnDefinitions="Auto, *"
+                                              ColumnSpacing="15">
+                                            <Label
+                                                Grid.Column="0"
+                                                Text="&#xf51e;"
+                                                TextColor="{StaticResource Coin}"
+                                                FontFamily="FA6Solid"
+                                                HorizontalOptions="Center"
+                                                VerticalOptions="Center"
+                                                FontSize="14"
+                                                Style="{StaticResource LabelBold}"
+                                                FontAutoScalingEnabled="False"
+                                                InputTransparent="True">
+                                                <Label.Triggers>
+                                                    <DataTrigger TargetType="Label"
+                                                                 Binding="{Binding Achievement.AchievementType}"
+                                                                 Value="{x:Static enums:AchievementType.Attended}">
+                                                        <Setter Property="TextColor" Value="White"/>
+                                                        <Setter Property="Text" Value="&#xf3c5;"/>
+                                                    </DataTrigger>
+                                                </Label.Triggers>
+                                            </Label>
+                                            <Label
+                                                Grid.Column="1"
+                                                FontSize="14"
+                                                Text="{Binding AchievementMessage}" />
+                                        </Grid>
+                                    </Border>
+                                </Grid>
+                            </Border>
+                        </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>

--- a/src/MobileUI/ViewModels/ActivityPageViewModel.cs
+++ b/src/MobileUI/ViewModels/ActivityPageViewModel.cs
@@ -180,9 +180,7 @@ public partial class ActivityPageViewModel(IActivityFeedService activityService)
             return;
 
         _skip += _take;
-        
         IsBusy = true;
-
         var feed = await GetFeedData();
         
         if (feed.Count == 0)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #843

> 2. What was changed?

Fixes a large bottom gap at the end of the collection views on the Activity and finishes up some incomplete work to hook up continuous scrolling by taking advantage of the take/skip parameters of the API.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/eb8a32ab-564f-472d-adfb-b31af4946aa4" width="400" />

**❌ Figure: Large gap at bottom of Activity page**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/0e148ab3-c610-4044-adfb-c8046cee7e35" width="400" />

**✅ Figure: Gap no longer present at the bottom of the Activity page. If more items are available they will be loaded as you continue to scroll.**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->