### PR TITLE
✨ Admin | Add top 3 skills warning

### DIFF
--- a/src/AdminUI/Pages/DetailedProfile.razor
+++ b/src/AdminUI/Pages/DetailedProfile.razor
@@ -67,28 +67,30 @@
 
 @* Skill Section *@
 <MudPaper Class="mt-8">
-    <div class="d-flex justify-center" >
-            <div style="width: 50%">
-                <MudSelect T="string"
-                           MultiSelection="true"
-                           SelectAllText="Select all felines"
-                           HelperText="@value"
-                           @bind-Value="@value"
-                           @bind-SelectedValues="@selected"
-                           MaxLength="5"
-                           Counter="5"
-                           MultiSelectionTextFunc="@(new Func<List<string>, string>(GetMultiSelectionText))"
-                           Label="Skills"
-                           Clearable="true"
-                           AdornmentIcon="@MudBlazor.Icons.Material.Filled.Search"
-                           Class="ml-9">
-                    @foreach (var skill in selectionSkills.OrderBy(s => s.Name))
-                    {
-                        <MudSelectItem T="string" Value="@skill.Name" Disabled="@skill.IsDisabled">@skill.Name</MudSelectItem>
-                    }
-                </MudSelect>
-            </div>
+    <div class="d-flex justify-center">
+        <div style="width: 50%">
+            <MudSelect T="string"
+                       MultiSelection="true"
+                       SelectAllText="Select all felines"
+                       HelperText="@value"
+                       @bind-Value="@value"
+                       @bind-SelectedValues="@selected"
+                       MaxLength="5"
+                       Counter="5"
+                       MultiSelectionTextFunc="@(new Func<List<string>, string>(GetMultiSelectionText))"
+                       Label="Skills"
+                       Clearable="true"
+                       AdornmentIcon="@MudBlazor.Icons.Material.Filled.Search"
+                       Class="ml-9">
+                @foreach (var skill in selectionSkills.OrderBy(s => s.Name))
+                {
+                    <MudSelectItem T="string" Value="@skill.Name" Disabled="@skill.IsDisabled">@skill.Name</MudSelectItem>
+                }
+            </MudSelect>
+        </div>
     </div>
+
+    <MudText Typo="Typo.caption" Color="Color.Warning" Class="d-flex ml-8 mt-4">Note: Only the top 3 skills will be shown in the app</MudText>
 
     @if (_staff?.Skills?.Any() ?? false)
     {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #527 

> 2. What was changed?

Small change to add a warning on profile pages that only the top 3 skills will be displayed in the app.

<img width="942" alt="Screenshot 2024-04-17 at 12 25 03 PM" src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/ba2f165d-a6a8-4013-90e0-761c80736879">

**Figure: New warning on profile pages in the admin portal**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->