### PR TITLE
🐛 Mobile | Fix back button circle

### DIFF
--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -22,7 +22,7 @@
                                 CornerRadius="20"
                                 BorderColor="White"
                                 BorderWidth="2"
-                                Margin="10,8,10,5"
+                                Margin="10,7,10,5"
                                 IsVisible="{Binding ShowAvatar}">
                     <mct:AvatarView.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding ToggleFlyoutCommand}" />
@@ -33,15 +33,18 @@
                     HeightRequest="40"
                     WidthRequest="40"
                     CornerRadius="20"
+                    MinimumHeightRequest="36"
+                    MinimumWidthRequest="36"
                     BorderColor="White"
                     BackgroundColor="{StaticResource SSWRed}"
-                    Margin="10,7.5"
+                    Margin="10,7,10,5"
                     Padding="0"
                     IsVisible="{Binding ShowBack}"
                     Command="{Binding GoBackCommand}">
                     <Button.ImageSource>
                         <FontImageSource FontFamily="FluentIcons"
                                          Glyph="&#xf189;"
+                                         Size="22"
                                          Color="White"/>
                     </Button.ImageSource>
                 </Button>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Noticed this small issue in the app

> 2. What was changed?

Minor fix for a small issue where the back button is an imperfect circle and gets cut off slightly. Now matches the same dimensions as the user avatar.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/b48a2706-cd15-4ebf-9a7c-0200563894a3" width="400" />

**❌ Figure: Back button looks off due to imperfect circle and bottom being cut off**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/fb38d5ab-b1fa-4fc8-87c9-0015eb273b07" width="400" />

**✅ Figure: Back button now a proper circle that isn't cut off**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->