### PR TITLE
Force Dark Mode Always

### DIFF
--- a/src/AdminUI/Shared/MainLayout.razor
+++ b/src/AdminUI/Shared/MainLayout.razor
@@ -63,7 +63,7 @@
     {
         if (firstRender && _mudThemeProvider is not null)
         {
-            _isDarkMode = await _mudThemeProvider.GetSystemPreference();
+            _isDarkMode = true;
             StateHasChanged();
         }
     }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

A conversation about System Preference Being the Default for Admin Portal. However, we don't have a theme switch in the 2024 design, and should be Dark mode

> 2. What was changed?

Update Dark Mode to always be on.

> 3. Did you do pair or mob programming?

✏️ 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->