### PR TITLE
✨ Mobile | Claim rewards in-person

### DIFF
--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -244,7 +244,7 @@ else
 
     private async Task ClaimPrizeForWinner(EligibleUserDto winner)
     {
-        var result = await rewardAdminService.ClaimForUser(_selectedRewardCode, winner.UserId ?? 0, CancellationToken.None);
+        var result = await rewardAdminService.ClaimForUser(_selectedRewardCode, winner.UserId ?? 0, false, CancellationToken.None);
 
         if (result.status == RewardStatus.Claimed)
         {

--- a/src/AdminUI/Pages/Rewards.razor
+++ b/src/AdminUI/Pages/Rewards.razor
@@ -113,7 +113,7 @@
                 case AssignReward usr:
                     if (usr?.Id == null) return;
 
-                    await rewardAdminService.ClaimForUser(usr.Code, usr.Id, CancellationToken.None);
+                    await rewardAdminService.ClaimForUser(usr.Code, usr.Id, false, CancellationToken.None);
                     // TODO: Add nice notification for returned status
                     
                     SnackBar.Add($"Reward claimed", Severity.Success);

--- a/src/AdminUI/Shared/MainLayout.razor
+++ b/src/AdminUI/Shared/MainLayout.razor
@@ -63,7 +63,7 @@
     {
         if (firstRender && _mudThemeProvider is not null)
         {
-            _isDarkMode = await _mudThemeProvider.GetSystemPreference();
+            _isDarkMode = true;
             StateHasChanged();
         }
     }

--- a/src/ApiClient/Services/IRewardAdminService.cs
+++ b/src/ApiClient/Services/IRewardAdminService.cs
@@ -10,7 +10,7 @@ public interface IRewardAdminService
     Task UpdateReward(RewardEditDto reward, CancellationToken cancellationToken);
     Task DeleteReward(int rewardId, CancellationToken cancellationToken);
 
-    Task<ClaimRewardResult> ClaimForUser(string code, int userId, CancellationToken cancellationToken);
+    Task<ClaimRewardResult> ClaimForUser(string code, int userId, bool isPendingRedemption, CancellationToken cancellationToken);
 }
 
 public class RewardAdminService : IRewardAdminService
@@ -87,9 +87,9 @@ public class RewardAdminService : IRewardAdminService
         throw new Exception($"Failed to delete reward: {responseContent}");
     }
 
-    public async Task<ClaimRewardResult> ClaimForUser(string code, int userId, CancellationToken cancellationToken)
+    public async Task<ClaimRewardResult> ClaimForUser(string code, int userId, bool isPendingRedemption, CancellationToken cancellationToken)
     {
-        var result = await _httpClient.PostAsJsonAsync($"{_baseRoute}ClaimForUser", new { code, userId }, cancellationToken);
+        var result = await _httpClient.PostAsJsonAsync($"{_baseRoute}ClaimForUser", new { code, userId, isPendingRedemption }, cancellationToken);
 
         if  (result.IsSuccessStatusCode)
         {

--- a/src/ApiClient/Services/IRewardService.cs
+++ b/src/ApiClient/Services/IRewardService.cs
@@ -12,6 +12,9 @@ public interface IRewardService
 
 
     Task<ClaimRewardResult> RedeemReward(ClaimRewardDto claim, CancellationToken cancellationToken);
+
+    Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim,
+        CancellationToken cancellationToken);
 }
 
 public class RewardService : IRewardService
@@ -108,6 +111,25 @@ public class RewardService : IRewardService
         if  (result.IsSuccessStatusCode)
         {
             var response = await result.Content.ReadFromJsonAsync<ClaimRewardResult>(cancellationToken: cancellationToken);
+
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+
+        throw new Exception($"Failed to claim reward: {responseContent}");
+    }
+    
+    public async Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim, CancellationToken cancellationToken)
+    {
+        var result = await _httpClient.PostAsJsonAsync($"{_baseRoute}CreatePendingRedemption", claim, cancellationToken);
+
+        if  (result.IsSuccessStatusCode)
+        {
+            var response = await result.Content.ReadFromJsonAsync<CreatePendingRedemptionResult>(cancellationToken: cancellationToken);
 
             if (response is not null)
             {

--- a/src/ApiClient/Services/IRewardService.cs
+++ b/src/ApiClient/Services/IRewardService.cs
@@ -13,7 +13,10 @@ public interface IRewardService
 
     Task<ClaimRewardResult> RedeemReward(ClaimRewardDto claim, CancellationToken cancellationToken);
 
-    Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim,
+    Task<CreatePendingRedemptionResult> CreatePendingRedemption(CreatePendingRedemptionDto claim,
+        CancellationToken cancellationToken);
+
+    Task<CancelPendingRedemptionResult> CancelPendingRedemption(CancelPendingRedemptionDto claim,
         CancellationToken cancellationToken);
 }
 
@@ -123,7 +126,7 @@ public class RewardService : IRewardService
         throw new Exception($"Failed to claim reward: {responseContent}");
     }
     
-    public async Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim, CancellationToken cancellationToken)
+    public async Task<CreatePendingRedemptionResult> CreatePendingRedemption(CreatePendingRedemptionDto claim, CancellationToken cancellationToken)
     {
         var result = await _httpClient.PostAsJsonAsync($"{_baseRoute}CreatePendingRedemption", claim, cancellationToken);
 
@@ -139,6 +142,25 @@ public class RewardService : IRewardService
 
         var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
-        throw new Exception($"Failed to claim reward: {responseContent}");
+        throw new Exception($"Failed to create pending redemption: {responseContent}");
+    }
+    
+    public async Task<CancelPendingRedemptionResult> CancelPendingRedemption(CancelPendingRedemptionDto claim, CancellationToken cancellationToken)
+    {
+        var result = await _httpClient.PostAsJsonAsync($"{_baseRoute}CancelPendingRedemption", claim, cancellationToken);
+
+        if  (result.IsSuccessStatusCode)
+        {
+            var response = await result.Content.ReadFromJsonAsync<CancelPendingRedemptionResult>(cancellationToken: cancellationToken);
+
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+
+        throw new Exception($"Failed to cancel pending redemption: {responseContent}");
     }
 }

--- a/src/ApiClient/Services/IUserService.cs
+++ b/src/ApiClient/Services/IUserService.cs
@@ -19,6 +19,9 @@ public interface IUserService
     Task<UserAchievementsViewModel> GetUserAchievements(int userId, CancellationToken cancellationToken = default);
 
     Task<UserRewardsViewModel> GetUserRewards(int userId, CancellationToken cancellationToken = default);
+
+    Task<UserPendingRedemptionsViewModel> GetUserPendingRedemptions(int userId,
+        CancellationToken cancellationToken = default);
 }
 
 public class UserService : IUserService
@@ -160,6 +163,25 @@ public class UserService : IUserService
         var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
         throw new Exception($"Failed to get user rewards: {responseContent}");
+    }
+    
+    public async Task<UserPendingRedemptionsViewModel> GetUserPendingRedemptions(int userId, CancellationToken cancellationToken = default)
+    {
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetUserPendingRedemptions?userId={userId}", cancellationToken);
+
+        if  (result.IsSuccessStatusCode)
+        {
+            var response = await result.Content.ReadFromJsonAsync<UserPendingRedemptionsViewModel>(cancellationToken: cancellationToken);
+
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+
+        throw new Exception($"Failed to get user pending redemptions: {responseContent}");
     }
     
     public async Task<NewUsersViewModel> GetNewUsers(LeaderboardFilter filter, bool filterStaff, CancellationToken cancellationToken = default)

--- a/src/Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/IApplicationDbContext.cs
@@ -24,5 +24,6 @@ public interface IApplicationDbContext
     DbSet<SubmittedQuizAnswer> SubmittedAnswers { get; set; }
     DbSet<UnclaimedAchievement> UnclaimedAchievements { get; set; }
     DbSet<OpenProfileDeletionRequest> OpenProfileDeletionRequests { get; set; }
+    DbSet<PendingRedemption> PendingRedemptions { get; set; }
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Application/Common/Interfaces/IUserService.cs
+++ b/src/Application/Common/Interfaces/IUserService.cs
@@ -54,4 +54,8 @@ public interface IUserService
     // Get user's QR code
     string GetStaffQRCode(string emailAddress);
     Task<string> GetStaffQRCode(string emailAddress, CancellationToken cancellationToken);
+    
+    // Get user's pending redemptions
+    UserPendingRedemptionsViewModel GetUserPendingRedemptions(int userId);
+    Task<UserPendingRedemptionsViewModel> GetUserPendingRedemptions(int userId, CancellationToken cancellationToken);
 }

--- a/src/Application/Rewards/Commands/CancelPendingRedemption/CancelPendingRedemptionCommand.cs
+++ b/src/Application/Rewards/Commands/CancelPendingRedemption/CancelPendingRedemptionCommand.cs
@@ -1,0 +1,65 @@
+﻿using System.Text;
+using Microsoft.Extensions.Logging;
+using SSW.Rewards.Shared.DTOs.Rewards;
+
+namespace SSW.Rewards.Application.Rewards.Commands;
+
+public class CancelPendingRedemptionCommand : IRequest<CancelPendingRedemptionResult>
+{
+    public int Id { get; set; }
+}
+
+public class CancelPendingRedemptionCommandHandler : IRequestHandler<CancelPendingRedemptionCommand, CancelPendingRedemptionResult>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly ILogger<CreatePendingRedemptionCommandHandler> _logger;
+    private readonly ICurrentUserService _currentUserService;
+
+    public CancelPendingRedemptionCommandHandler(
+            IApplicationDbContext context,
+            ILogger<CreatePendingRedemptionCommandHandler> logger,
+            ICurrentUserService currentUserService)
+    {
+        _context = context;
+        _logger = logger;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<CancelPendingRedemptionResult> Handle(CancelPendingRedemptionCommand request, CancellationToken cancellationToken)
+    {
+        User? user = await _context.Users
+            .Where(u => u.Email == _currentUserService.GetUserEmail())
+            .Include(pr => pr.PendingRedemptions)
+            .Include(u => u.UserAchievements)
+            .ThenInclude(ua => ua.Achievement)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (user == null)
+        {
+            _logger.LogError("User with email {Email} does not exist!", _currentUserService.GetUserEmail());
+            return new CancelPendingRedemptionResult
+            {
+                Status = RewardStatus.Error
+            };
+        }
+
+        var pendingRedemption = user.PendingRedemptions.FirstOrDefault(pr => pr.RewardId == request.Id && !pr.CancelledByUser && !pr.CancelledByAdmin && !pr.Completed);
+
+        if (pendingRedemption == null)
+        {
+            _logger.LogError("Pending redemption for reward id {Id} does not exist!", request.Id);
+            return new CancelPendingRedemptionResult
+            {
+                Status = RewardStatus.Error
+            };
+        }
+
+        pendingRedemption.CancelledByUser = true;
+        await _context.SaveChangesAsync(cancellationToken);
+        
+        return new CancelPendingRedemptionResult
+        {
+            Status = RewardStatus.Cancelled
+        };
+    }
+}

--- a/src/Application/Rewards/Commands/CancelPendingRedemption/CancelPendingRedemptionCommand.cs
+++ b/src/Application/Rewards/Commands/CancelPendingRedemption/CancelPendingRedemptionCommand.cs
@@ -43,7 +43,10 @@ public class CancelPendingRedemptionCommandHandler : IRequestHandler<CancelPendi
             };
         }
 
-        var pendingRedemption = user.PendingRedemptions.FirstOrDefault(pr => pr.RewardId == request.Id && !pr.CancelledByUser && !pr.CancelledByAdmin && !pr.Completed);
+        var pendingRedemption = user.PendingRedemptions.FirstOrDefault(pr =>
+            pr.RewardId == request.Id &&
+            pr is { CancelledByUser: false, CancelledByAdmin: false, Completed: false }
+        );
 
         if (pendingRedemption == null)
         {
@@ -56,7 +59,7 @@ public class CancelPendingRedemptionCommandHandler : IRequestHandler<CancelPendi
 
         pendingRedemption.CancelledByUser = true;
         await _context.SaveChangesAsync(cancellationToken);
-        
+
         return new CancelPendingRedemptionResult
         {
             Status = RewardStatus.Cancelled

--- a/src/Application/Rewards/Commands/ClaimRewardForUser/ClaimRewardForUserCommand.cs
+++ b/src/Application/Rewards/Commands/ClaimRewardForUser/ClaimRewardForUserCommand.cs
@@ -35,7 +35,7 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
         Reward? reward = null;
         PendingRedemption? pendingRedemption = null;
         var userId = request.UserId;
-        
+
         if (request.IsPendingRedemption)
         {
             pendingRedemption = await _context.PendingRedemptions
@@ -45,6 +45,15 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
 
             if (pendingRedemption != null)
             {
+                if (pendingRedemption.Completed)
+                {
+                    _logger.LogError("Pending reward was already scanned: {0}", request.Code);
+                    return new ClaimRewardResult
+                    {
+                        status = RewardStatus.Duplicate
+                    };
+                }
+
                 reward = pendingRedemption.Reward;
                 userId = pendingRedemption.UserId;
             }

--- a/src/Application/Rewards/Commands/ClaimRewardForUser/ClaimRewardForUserCommand.cs
+++ b/src/Application/Rewards/Commands/ClaimRewardForUser/ClaimRewardForUserCommand.cs
@@ -8,6 +8,7 @@ public class ClaimRewardForUserCommand : IRequest<ClaimRewardResult>
 {
     public int UserId { get; set; }
     public string Code { get; set; }
+    public bool IsPendingRedemption { get; set; }
 }
 
 public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUserCommand, ClaimRewardResult>
@@ -31,10 +32,30 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
 
     public async Task<ClaimRewardResult> Handle(ClaimRewardForUserCommand request, CancellationToken cancellationToken)
     {
-        var reward = await _context
-            .Rewards
-            .Where(r => r.Code == request.Code)
-            .FirstOrDefaultAsync(cancellationToken);
+        Reward? reward = null;
+        PendingRedemption? pendingRedemption = null;
+        var userId = request.UserId;
+        
+        if (request.IsPendingRedemption)
+        {
+            pendingRedemption = await _context.PendingRedemptions
+                .Include(pr => pr.Reward)
+                .Where(pr => pr.Code == request.Code)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (pendingRedemption != null)
+            {
+                reward = pendingRedemption.Reward;
+                userId = pendingRedemption.UserId;
+            }
+        }
+        else
+        {
+            reward = await _context
+                .Rewards
+                .Where(r => r.Code == request.Code)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
 
         if (reward == null)
         {
@@ -46,13 +67,13 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
         }
 
         User? user = await _context.Users
-            .Where(u => u.Id == request.UserId)
+            .Where(u => u.Id == userId)
             .Include(u => u.UserAchievements).ThenInclude(ua => ua.Achievement)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (user == null)
         {
-            _logger.LogError("User with ID {userId} claiming the reward {rewardId}({rewardName}) does not exist!", request.UserId, reward.Id, reward.Name);
+            _logger.LogError("User with ID {UserId} claiming the reward {RewardId}({RewardName}) does not exist!", userId, reward.Id, reward.Name);
             return new ClaimRewardResult
             {
                 status = RewardStatus.Error
@@ -98,6 +119,11 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
                      AwardedAt = _dateTime.Now,
                  });
 
+            if (pendingRedemption != null)
+            {
+                pendingRedemption.Completed = true;
+            }
+
             await _context.SaveChangesAsync(cancellationToken);
         }
         catch (Exception e)
@@ -113,7 +139,7 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
 
         return new ClaimRewardResult
         {
-            status = RewardStatus.Claimed,
+            status = request.IsPendingRedemption ? RewardStatus.Confirmed : RewardStatus.Claimed,
             Reward = rewardModel
         };
     }

--- a/src/Application/Rewards/Commands/CreatePendingRedemption/CreatePendingRedemptionCommand.cs
+++ b/src/Application/Rewards/Commands/CreatePendingRedemption/CreatePendingRedemptionCommand.cs
@@ -1,0 +1,118 @@
+﻿using System.Text;
+using Microsoft.Extensions.Logging;
+using SSW.Rewards.Shared.DTOs.Rewards;
+
+namespace SSW.Rewards.Application.Rewards.Commands;
+
+public class CreatePendingRedemptionCommand : IRequest<CreatePendingRedemptionResult>
+{
+    public int UserId { get; set; }
+    public int Id { get; set; }
+}
+
+public class CreatePendingRedemptionCommandHandler : IRequestHandler<CreatePendingRedemptionCommand, CreatePendingRedemptionResult>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+    private readonly ILogger<CreatePendingRedemptionCommandHandler> _logger;
+    private readonly IDateTime _dateTime;
+    private readonly ICurrentUserService _currentUserService;
+
+    public CreatePendingRedemptionCommandHandler(
+            IApplicationDbContext context,
+            IMapper mapper,
+            ILogger<CreatePendingRedemptionCommandHandler> logger,
+            IDateTime dateTime,
+            ICurrentUserService currentUserService)
+    {
+        _context = context;
+        _mapper = mapper;
+        _logger = logger;
+        _dateTime = dateTime;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<CreatePendingRedemptionResult> Handle(CreatePendingRedemptionCommand request, CancellationToken cancellationToken)
+    {
+        var reward = await _context
+            .Rewards
+            .Where(r => r.Id == request.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (reward == null)
+        {
+            _logger.LogError("Reward not found with id: {Id}", request.Id);
+            return new CreatePendingRedemptionResult
+            {
+                status = RewardStatus.NotFound
+            };
+        }
+        
+        User? user = await _context.Users
+            .Where(u => u.Email == _currentUserService.GetUserEmail())
+            .Include(u => u.UserAchievements)
+            .ThenInclude(ua => ua.Achievement)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (user == null)
+        {
+            _logger.LogError("User with ID {UserId} claiming the reward {RewardId}({RewardName}) does not exist!", request.UserId, reward.Id, reward.Name);
+            return new CreatePendingRedemptionResult
+            {
+                status = RewardStatus.Error
+            };
+        }
+
+        var userRewards = await _context
+                .UserRewards
+                .Include(ur => ur.Reward)
+                .Where(ur => ur.UserId == user.Id)
+                .ToListAsync(cancellationToken);
+
+        int pointsUsed = userRewards.Sum(ur => ur.Reward.Cost);
+        int totalPoints = user.UserAchievements.Sum(ua => ua.Achievement.Value);
+        int balance = totalPoints - pointsUsed;
+
+        if (balance < reward.Cost)
+        {
+            _logger.LogInformation("User does not have enough points to claim reward");
+            return new CreatePendingRedemptionResult
+            {
+                status = RewardStatus.NotEnoughPoints
+            };
+        }
+
+        var codeData = Encoding.ASCII.GetBytes($"pnd:{Guid.NewGuid().ToString()}");
+        var code = Convert.ToBase64String(codeData);
+        
+        try
+        {
+            user.PendingRedemptions.Add(new PendingRedemption
+            {
+                Code = code,
+                ClaimedAt = _dateTime.Now,
+                RewardId = reward.Id,
+                UserId = user.Id
+            });
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e.Message, e);
+            return new CreatePendingRedemptionResult
+            {
+                status = RewardStatus.Error
+            };
+        }
+
+        var rewardModel = _mapper.Map<RewardDto>(reward);
+
+        return new CreatePendingRedemptionResult
+        {
+            status = RewardStatus.Pending,
+            Reward = rewardModel,
+            Code = code
+        };
+    }
+}

--- a/src/Application/SSW.Rewards.Application.csproj
+++ b/src/Application/SSW.Rewards.Application.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
       <Folder Include="Network\Queries\" />
-      <Folder Include="PrizeDraw\Commands\" />
+      <Folder Include="PendingRedemptions\Commands\" />
     </ItemGroup>
 
 </Project>

--- a/src/Application/SSW.Rewards.Application.csproj
+++ b/src/Application/SSW.Rewards.Application.csproj
@@ -24,9 +24,4 @@
         <ProjectReference Include="..\Domain\SSW.Rewards.Domain.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Network\Queries\" />
-      <Folder Include="PendingRedemptions\Commands\" />
-    </ItemGroup>
-
 </Project>

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -301,6 +301,21 @@ public class UserService : IUserService, IRolesService
             UserRewards = vm
         };
     }
+    
+    public UserPendingRedemptionsViewModel GetUserPendingRedemptions(int userId)
+    {
+        return GetUserPendingRedemptions(userId, CancellationToken.None).Result;
+    }
+    
+    public async Task<UserPendingRedemptionsViewModel> GetUserPendingRedemptions(int userId, CancellationToken cancellationToken)
+    {
+        var pendingRedemptions = await _dbContext.PendingRedemptions
+            .Where(x => x.User.Id == userId && !x.Completed && !x.CancelledByAdmin && !x.CancelledByAdmin)
+            .ProjectTo<UserPendingRedemptionDto>(_mapper.ConfigurationProvider)
+            .ToListAsync(cancellationToken);
+
+        return new UserPendingRedemptionsViewModel { UserId = userId, PendingRedemptions = pendingRedemptions };
+    }
 
     public IEnumerable<Role> GetUserRoles(int userId)
     {

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -310,7 +310,7 @@ public class UserService : IUserService, IRolesService
     public async Task<UserPendingRedemptionsViewModel> GetUserPendingRedemptions(int userId, CancellationToken cancellationToken)
     {
         var pendingRedemptions = await _dbContext.PendingRedemptions
-            .Where(x => x.User.Id == userId && !x.Completed && !x.CancelledByAdmin && !x.CancelledByAdmin)
+            .Where(x => x.User.Id == userId && !x.Completed && !x.CancelledByAdmin && !x.CancelledByUser)
             .ProjectTo<UserPendingRedemptionDto>(_mapper.ConfigurationProvider)
             .ToListAsync(cancellationToken);
 

--- a/src/Application/Users/Queries/GetCurrentUser/GetCurrentUserQuery.cs
+++ b/src/Application/Users/Queries/GetCurrentUser/GetCurrentUserQuery.cs
@@ -34,6 +34,7 @@ public class GetCurrentUserQueryHandler : IRequestHandler<GetCurrentUserQuery, C
         if (user.IsStaff())
         {
             var code = await _userService.GetStaffQRCode(user.Email, cancellationToken);
+            user.IsStaff = true;
 
             if (!string.IsNullOrWhiteSpace(code))
             {

--- a/src/Application/Users/Queries/GetUserPendingRedemptions/GetUserPendingRedemptionsQuery.cs
+++ b/src/Application/Users/Queries/GetUserPendingRedemptions/GetUserPendingRedemptionsQuery.cs
@@ -1,0 +1,23 @@
+﻿using SSW.Rewards.Shared.DTOs.Users;
+
+namespace SSW.Rewards.Application.Users.Queries.GetUserPendingRedemptions;
+
+public class GetUserPendingRedemptionsQuery : IRequest<UserPendingRedemptionsViewModel>
+{
+    public int UserId { get; set; }
+}
+
+public class GetUserPendingRedemptionsQueryHandler : IRequestHandler<GetUserPendingRedemptionsQuery, UserPendingRedemptionsViewModel>
+{
+    private readonly IUserService _userService;
+
+    public GetUserPendingRedemptionsQueryHandler(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    public async Task<UserPendingRedemptionsViewModel> Handle(GetUserPendingRedemptionsQuery request, CancellationToken cancellationToken)
+    {
+        return await _userService.GetUserPendingRedemptions(request.UserId, cancellationToken);
+    }
+}

--- a/src/Application/Users/Queries/GetUserPendingRedemptions/Mapping.cs
+++ b/src/Application/Users/Queries/GetUserPendingRedemptions/Mapping.cs
@@ -1,0 +1,17 @@
+﻿using SSW.Rewards.Shared.DTOs.Users;
+
+namespace SSW.Rewards.Application.Users.Queries.GetUserPendingRedemptions;
+public class Mapping : Profile
+{
+    public Mapping()
+    {
+        CreateMap<PendingRedemption, UserPendingRedemptionDto>()
+                .ForMember(dst => dst.Code, opt => opt.MapFrom(src => src.Code))
+                .ForMember(dst => dst.ClaimedAt, opt => opt.MapFrom(src => src.ClaimedAt))
+                .ForMember(dst => dst.RewardId, opt => opt.MapFrom(src => src.RewardId));
+
+        CreateMap<User, UserPendingRedemptionsViewModel>()
+                .ForMember(dst => dst.UserId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dst => dst.PendingRedemptions, opt => opt.MapFrom(src => src.PendingRedemptions));
+    }
+}

--- a/src/Common/DTOs/Rewards/CancelPendingRedemptionDto.cs
+++ b/src/Common/DTOs/Rewards/CancelPendingRedemptionDto.cs
@@ -2,7 +2,7 @@
 
 namespace SSW.Rewards.Shared.DTOs.Rewards;
 
-public class CreatePendingRedemptionDto
+public class CancelPendingRedemptionDto
 {
     public int Id { get; set; }
 }

--- a/src/Common/DTOs/Rewards/CancelPendingRedemptionResult.cs
+++ b/src/Common/DTOs/Rewards/CancelPendingRedemptionResult.cs
@@ -2,7 +2,7 @@
 
 namespace SSW.Rewards.Shared.DTOs.Rewards;
 
-public class CreatePendingRedemptionDto
+public class CancelPendingRedemptionResult
 {
-    public int Id { get; set; }
+    public RewardStatus Status { get; set; }
 }

--- a/src/Common/DTOs/Rewards/ClaimRewardDto.cs
+++ b/src/Common/DTOs/Rewards/ClaimRewardDto.cs
@@ -9,4 +9,6 @@ public class ClaimRewardDto
     
     public Address Address { get; set; }
     public bool InPerson { get; set; } = true;
+    public int UserId { get; set; }
+    public bool IsPendingRedemption { get; set; }
 }

--- a/src/Common/DTOs/Rewards/CreatePendingRedemptionDto.cs
+++ b/src/Common/DTOs/Rewards/CreatePendingRedemptionDto.cs
@@ -1,0 +1,12 @@
+﻿using SSW.Rewards.Shared.DTOs.AddressTypes;
+
+namespace SSW.Rewards.Shared.DTOs.Rewards;
+
+public class CreatePendingRedemptionDto
+{
+    public string Code { get; set; }
+    public int Id { get; set; }
+    
+    public Address Address { get; set; }
+    public bool InPerson { get; set; } = true;
+}

--- a/src/Common/DTOs/Rewards/CreatePendingRedemptionResult.cs
+++ b/src/Common/DTOs/Rewards/CreatePendingRedemptionResult.cs
@@ -1,0 +1,10 @@
+﻿using SSW.Rewards.Shared.DTOs.AddressTypes;
+
+namespace SSW.Rewards.Shared.DTOs.Rewards;
+
+public class CreatePendingRedemptionResult
+{
+    public RewardDto? Reward { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public RewardStatus status { get; set; }
+}

--- a/src/Common/DTOs/Users/CurrentUserDto.cs
+++ b/src/Common/DTOs/Users/CurrentUserDto.cs
@@ -15,4 +15,6 @@ public class CurrentUserDto
     public int Balance { get; set; }
 
     public string? QRCode { get; set; }
+    
+    public bool IsStaff { get; set; }
 }

--- a/src/Common/DTOs/Users/UserPendingRedemptionDto.cs
+++ b/src/Common/DTOs/Users/UserPendingRedemptionDto.cs
@@ -1,0 +1,8 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Users;
+
+public class UserPendingRedemptionDto
+{
+    public string? Code { get; set; }
+    public DateTime ClaimedAt { get; set; }
+    public int RewardId { get; set; }
+}

--- a/src/Common/DTOs/Users/UserPendingRedemptionsViewModel.cs
+++ b/src/Common/DTOs/Users/UserPendingRedemptionsViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Users;
+
+public class UserPendingRedemptionsViewModel
+{
+    public int UserId { get; set; }
+    public IEnumerable<UserPendingRedemptionDto> PendingRedemptions { get; set; } = Enumerable.Empty<UserPendingRedemptionDto>();
+}

--- a/src/Domain/Entities/PendingRedemption.cs
+++ b/src/Domain/Entities/PendingRedemption.cs
@@ -1,0 +1,11 @@
+namespace SSW.Rewards.Domain.Entities;
+
+public class PendingRedemption : BaseEntity
+{
+    public string? Code { get; set; }
+    public DateTime ClaimedAt { get; set; }
+    public Reward Reward { get; set; } = null!;
+    public User User { get; set; } = null!;
+    public bool CancelledByUser { get; set; }
+    public bool CancelledByAdmin { get; set; }
+}

--- a/src/Domain/Entities/PendingRedemption.cs
+++ b/src/Domain/Entities/PendingRedemption.cs
@@ -10,4 +10,5 @@ public class PendingRedemption : BaseEntity
     public User User { get; set; } = null!;
     public bool CancelledByUser { get; set; }
     public bool CancelledByAdmin { get; set; }
+    public bool Completed { get; set; }
 }

--- a/src/Domain/Entities/PendingRedemption.cs
+++ b/src/Domain/Entities/PendingRedemption.cs
@@ -4,7 +4,9 @@ public class PendingRedemption : BaseEntity
 {
     public string? Code { get; set; }
     public DateTime ClaimedAt { get; set; }
+    public int RewardId { get; set; }
     public Reward Reward { get; set; } = null!;
+    public int UserId { get; set; }
     public User User { get; set; } = null!;
     public bool CancelledByUser { get; set; }
     public bool CancelledByAdmin { get; set; }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -15,4 +15,5 @@ public class User : BaseEntity
     public ICollection<CompletedQuiz> CompletedQuizzes { get; set; } = new HashSet<CompletedQuiz>();
     public ICollection<UserSocialMediaId> SocialMediaIds { get; set; } = new HashSet<UserSocialMediaId>();
     public ICollection<Quiz> CreatedQuizzes { get; set; } = new HashSet<Quiz>();
+    public ICollection<PendingRedemption> PendingRedemptions { get; set; } = new HashSet<PendingRedemption>();
 }

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -47,6 +47,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<SubmittedQuizAnswer> SubmittedAnswers { get; set; }
     public DbSet<UnclaimedAchievement> UnclaimedAchievements { get; set; }
     public DbSet<OpenProfileDeletionRequest> OpenProfileDeletionRequests { get; set; }
+    public DbSet<PendingRedemption> PendingRedemptions { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Infrastructure/Persistence/Migrations/20240423044517_AddPendingRedemption.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240423044517_AddPendingRedemption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SSW.Rewards.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using SSW.Rewards.Infrastructure.Persistence;
 namespace SSW.Rewards.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240423044517_AddPendingRedemption")]
+    partial class AddPendingRedemption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20240423044517_AddPendingRedemption.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240423044517_AddPendingRedemption.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SSW.Rewards.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingRedemption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PendingRedemptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Code = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ClaimedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    RewardId = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    CancelledByUser = table.Column<bool>(type: "bit", nullable: false),
+                    CancelledByAdmin = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PendingRedemptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PendingRedemptions_Rewards_RewardId",
+                        column: x => x.RewardId,
+                        principalTable: "Rewards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PendingRedemptions_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingRedemptions_RewardId",
+                table: "PendingRedemptions",
+                column: "RewardId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingRedemptions_UserId",
+                table: "PendingRedemptions",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PendingRedemptions");
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/20240423071015_AddUserPendingRedemptions.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240423071015_AddUserPendingRedemptions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SSW.Rewards.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using SSW.Rewards.Infrastructure.Persistence;
 namespace SSW.Rewards.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240423071015_AddUserPendingRedemptions")]
+    partial class AddUserPendingRedemptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20240423071015_AddUserPendingRedemptions.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240423071015_AddUserPendingRedemptions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SSW.Rewards.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserPendingRedemptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/20240424021445_AddCompletedToUserPendingRedemption.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240424021445_AddCompletedToUserPendingRedemption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SSW.Rewards.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using SSW.Rewards.Infrastructure.Persistence;
 namespace SSW.Rewards.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240424021445_AddCompletedToUserPendingRedemption")]
+    partial class AddCompletedToUserPendingRedemption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20240424021445_AddCompletedToUserPendingRedemption.cs
+++ b/src/Infrastructure/Persistence/Migrations/20240424021445_AddCompletedToUserPendingRedemption.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SSW.Rewards.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompletedToUserPendingRedemption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Completed",
+                table: "PendingRedemptions",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Completed",
+                table: "PendingRedemptions");
+        }
+    }
+}

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -11,8 +11,15 @@ using SSW.Rewards.Mobile.ViewModels.ProfileViewModels;
 using SSW.Rewards.ApiClient;
 using System.Reflection;
 using Microsoft.Maui.Platform;
+using SSW.Rewards.ApiClient.Services;
 using ZXing.Net.Maui.Controls;
 using IBrowser = IdentityModel.OidcClient.Browser.IBrowser;
+using IQuizService = SSW.Rewards.Mobile.Services.IQuizService;
+using IRewardService = SSW.Rewards.Mobile.Services.IRewardService;
+using IUserService = SSW.Rewards.Mobile.Services.IUserService;
+using QuizService = SSW.Rewards.Mobile.Services.QuizService;
+using RewardService = SSW.Rewards.Mobile.Services.RewardService;
+using UserService = SSW.Rewards.Mobile.Services.UserService;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 namespace SSW.Rewards.Mobile;
@@ -87,6 +94,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<ISnackbarService, SnackBarService>();
         builder.Services.AddSingleton<IPermissionsService, PermissionsService>();
         builder.Services.AddSingleton<IPushNotificationsService, PushNotificationsService>();
+        builder.Services.AddSingleton<IRewardAdminService, RewardAdminService>();
 
         builder.Services.AddSingleton<FlyoutHeader>();
         builder.Services.AddSingleton<FlyoutHeaderViewModel>();

--- a/src/MobileUI/Models/Reward.cs
+++ b/src/MobileUI/Models/Reward.cs
@@ -13,5 +13,7 @@
         public bool IsCarousel { get; set; }
         public bool IsHidden { get; set; }
         public bool CanAfford { get; set; }
+        public bool IsPendingRedemption { get; set; }
+        public string PendingRedemptionCode { get; set; }
     }
 }

--- a/src/MobileUI/Models/ScanResult.cs
+++ b/src/MobileUI/Models/ScanResult.cs
@@ -6,6 +6,7 @@
         Duplicate,
         NotFound,
         InsufficientBalance,
-        Error
+        Error,
+        Confirmed
     }
 }

--- a/src/MobileUI/Pages/RedeemPage.xaml
+++ b/src/MobileUI/Pages/RedeemPage.xaml
@@ -130,7 +130,16 @@
                                                        ButtonText="GET"
                                                        ThumbnailImage="{Binding ImageUri}"
                                                        PlaceholderGlyph="&#xf06b;"
-                                                       ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}"/> 
+                                                       ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}">
+                                        <controls:ListItem.Triggers>
+                                            <DataTrigger TargetType="controls:ListItem"
+                                                         Binding="{Binding IsPendingRedemption}"
+                                                         Value="True">
+                                                <Setter Property="ButtonText"
+                                                        Value="QR" />
+                                            </DataTrigger>
+                                        </controls:ListItem.Triggers>
+                                    </controls:ListItem>
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>
                         </VerticalStackLayout>

--- a/src/MobileUI/PopupPages/RedeemReward.xaml
+++ b/src/MobileUI/PopupPages/RedeemReward.xaml
@@ -8,7 +8,7 @@
                  xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
                  xmlns:addr="clr-namespace:SSW.Rewards.Shared.DTOs.AddressTypes;assembly=Shared"
                  xmlns:lottie="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
-                 xmlns:controls1="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"
+                 xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"
                  x:Name="RedeemRewardPopup"
                  x:DataType="viewModels:RedeemRewardViewModel"
                  x:Class="SSW.Rewards.Mobile.PopupPages.RedeemReward"
@@ -172,7 +172,7 @@
                         <Label Text="Please show this code to SSW staff to claim your reward:"
                                HorizontalOptions="Center"
                                HorizontalTextAlignment="Center"/>
-                        <controls1:BarcodeGeneratorView
+                        <zxing:BarcodeGeneratorView
                                                  Format="QrCode"
                                                  Value="{Binding QrCode}"
                                                  HorizontalOptions="Center"

--- a/src/MobileUI/PopupPages/RedeemReward.xaml
+++ b/src/MobileUI/PopupPages/RedeemReward.xaml
@@ -8,6 +8,7 @@
                  xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
                  xmlns:addr="clr-namespace:SSW.Rewards.Shared.DTOs.AddressTypes;assembly=Shared"
                  xmlns:lottie="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
+                 xmlns:controls1="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"
                  x:Name="RedeemRewardPopup"
                  x:DataType="viewModels:RedeemRewardViewModel"
                  x:Class="SSW.Rewards.Mobile.PopupPages.RedeemReward"
@@ -164,6 +165,24 @@
                             </HorizontalStackLayout>
                         </Border>
                     </Grid>
+                    
+                    <!-- Pending redemption QR code -->
+                    <VerticalStackLayout IsVisible="{Binding IsQrCodeVisible}"
+                                         Spacing="10"
+                                         Margin="0,0,0,30">
+                        <Label Text="Please show this code to SSW staff to claim your reward:"
+                               HorizontalOptions="Center"
+                               HorizontalTextAlignment="Center"/>
+                        <controls1:BarcodeGeneratorView
+                                                 Format="QrCode"
+                                                 Value="{Binding QrCode}"
+                                                 HorizontalOptions="Center"
+                                                 BackgroundColor="#DDDDDD"
+                                                 ForegroundColor="Transparent"
+                                                 WidthRequest="150"
+                                                 HeightRequest="150"
+                                                 VerticalOptions="Center"/>
+                    </VerticalStackLayout>
 
                     <!-- Address search -->
                     <VerticalStackLayout IsVisible="{Binding IsAddressVisible}"
@@ -312,6 +331,15 @@
                                                  Size="16"/>
                             </Button.ImageSource>
                         </Button>
+                        
+                        <Button Background="{StaticResource SSWRed}"
+                                CornerRadius="4"
+                                IsVisible="{Binding IsBalanceVisible}"
+                                Text="Redeem at event"
+                                FontAttributes="Bold"
+                                VerticalOptions="Center"
+                                HorizontalOptions="Center"
+                                Command="{Binding RedeemInPersonClickedCommand}"/>
                         
                         <Button Background="{StaticResource SSWRed}"
                                 CornerRadius="4"

--- a/src/MobileUI/PopupPages/RedeemReward.xaml
+++ b/src/MobileUI/PopupPages/RedeemReward.xaml
@@ -314,9 +314,41 @@
                                          WidthRequest="200"
                                          Scale="1"/>
 
+                    <VerticalStackLayout HorizontalOptions="Center"
+                                         Margin="0,0,0,30"
+                                         Spacing="15"
+                                         IsVisible="{Binding IsBalanceVisible}">
+                        <Button Background="{StaticResource SSWRed}"
+                                CornerRadius="4"
+                                Text="Redeem in-person"
+                                WidthRequest="160"
+                                FontAttributes="Bold"
+                                VerticalOptions="Center"
+                                HorizontalOptions="Center"
+                                Command="{Binding RedeemInPersonClickedCommand}"/>
+                        
+                        <Button Background="{StaticResource SSWRed}"
+                                CornerRadius="4"
+                                Text="Ship to my address"
+                                WidthRequest="160"
+                                FontAttributes="Bold"
+                                VerticalOptions="Center"
+                                HorizontalOptions="Center"
+                                Command="{Binding NextClickedCommand}"/>
+                    </VerticalStackLayout>
 
-                    <HorizontalStackLayout HorizontalOptions="Center"
-                                           Spacing="10" >
+                    <VerticalStackLayout HorizontalOptions="Center"
+                                         Spacing="15">
+                        <Button Background="{StaticResource SSWRed}"
+                                CornerRadius="4"
+                                WidthRequest="80"
+                                IsVisible="{Binding ConfirmEnabled}"
+                                Text="Confirm"
+                                FontAttributes="Bold"
+                                VerticalOptions="Center"
+                                HorizontalOptions="Center"
+                                Command="{Binding ConfirmClickedCommand}"/>
+                        
                         <Button Text="{Binding CloseButtonText}"
                                 Command="{Binding ClosePopupCommand}"
                                 ContentLayout="Left, 10"
@@ -331,36 +363,7 @@
                                                  Size="16"/>
                             </Button.ImageSource>
                         </Button>
-                        
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
-                                IsVisible="{Binding IsBalanceVisible}"
-                                Text="Redeem at event"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                Command="{Binding RedeemInPersonClickedCommand}"/>
-                        
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
-                                IsVisible="{Binding IsBalanceVisible}"
-                                Text="Next"
-                                WidthRequest="80"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                Command="{Binding NextClickedCommand}"/>
-                        
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
-                                WidthRequest="80"
-                                IsVisible="{Binding ConfirmEnabled}"
-                                Text="Confirm"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                Command="{Binding ConfirmClickedCommand}"/>
-                    </HorizontalStackLayout>
+                    </VerticalStackLayout>
                 </VerticalStackLayout>
                 <ActivityIndicator
                     HorizontalOptions="Fill"

--- a/src/MobileUI/PopupPages/RedeemReward.xaml
+++ b/src/MobileUI/PopupPages/RedeemReward.xaml
@@ -45,350 +45,343 @@
             </Setter>
         </Style>
     </pages:PopupPage.Resources>
-    <ScrollView>
-        <Border
-            HorizontalOptions="Fill"
-            VerticalOptions="Center"
-            MinimumHeightRequest="400"
-            Padding="25"
-            Margin="40"
-            StrokeThickness="2"
-            Stroke="{StaticResource BorderDefault}"
-            BackgroundColor="{StaticResource Background}">
-            <Border.StrokeShape>
-                <RoundRectangle CornerRadius="8" />
-            </Border.StrokeShape>
-            <Grid>
-                <VerticalStackLayout>
-                    <Border HeightRequest="80"
-                            WidthRequest="80"
-                            BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                            StrokeThickness="0"
-                            Margin="0,0,0,30">
-                        <Border.StrokeShape>
-                            <RoundRectangle CornerRadius="6" />
-                        </Border.StrokeShape>
-                        <Grid>
-                            <Image HorizontalOptions="Center"
-                                   VerticalOptions="Center"
-                                   Aspect="AspectFill"
-                                   Source="{Binding Image}"
-                                   IsVisible="{Binding Image, Converter={StaticResource IsStringNotNullOrEmpty}}" />
-                            <Label FontFamily="FA6Solid"
-                                   FontAutoScalingEnabled="False"
-                                   VerticalOptions="Center"
-                                   HorizontalOptions="Center"
-                                   Text="&#xf06b;"
-                                   TextColor="{StaticResource Gray300}"
-                                   FontSize="28"
-                                   IsVisible="{Binding Image, Converter={StaticResource IsStringNullOrEmpty}}" />
-                        </Grid>
-                    </Border>
-
-                    <Label Text="{Binding Heading}"
-                           FontSize="24"
-                           HorizontalOptions="Center"
-                           HorizontalTextAlignment="Center"
-                           Style="{StaticResource LabelBold}" />
-
-                    <Label Text="{Binding Description}"
-                           FontSize="18"
-                           TextColor="{StaticResource Gray300}"
-                           HorizontalOptions="Center"
-                           HorizontalTextAlignment="Center"
-                           Margin="0,0,0,30" />
-
-                    <!-- Balance section -->
-                    <Grid RowDefinitions="Auto,Auto"
-                          ColumnDefinitions="Auto,Auto"
-                          HorizontalOptions="Center"
-                          RowSpacing="6"
-                          ColumnSpacing="10"
-                          Margin="0,0,0,30"
-                          IsVisible="{Binding IsBalanceVisible}">
-                        <Label Grid.Row="0"
-                               Grid.Column="0"
-                               Text="Your Balance"
-                               FontSize="18"
-                               HorizontalOptions="Center"
-                               VerticalOptions="Center" />
-
-                        <Border Grid.Row="0"
-                                Grid.Column="1"
-                                BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                StrokeThickness="0"
-                                Padding="15,4">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="6" />
-                            </Border.StrokeShape>
-                            <HorizontalStackLayout Spacing="8">
-                                <Label
-                                    TextColor="{StaticResource Coin}"
-                                    Text="&#xf51e;"
-                                    FontFamily="FA6Solid"
-                                    VerticalOptions="Center"
-                                    FontSize="11"
-                                    InputTransparent="True" />
-                                <Label Text="{Binding UserBalance, StringFormat='{0:n0}'}"
-                                       VerticalOptions="Center"
-                                       FontSize="18" />
-                            </HorizontalStackLayout>
-                        </Border>
-
-                        <Label Grid.Row="1"
-                               Grid.Column="0"
-                               Text="Product Cost"
-                               FontSize="18"
-                               HorizontalOptions="Center"
-                               VerticalOptions="Center" />
-
-                        <Border Grid.Row="1"
-                                Grid.Column="1"
-                                BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                StrokeThickness="0"
-                                Padding="15,4">
-                            <Border.StrokeShape>
-                                <RoundRectangle CornerRadius="6" />
-                            </Border.StrokeShape>
-                            <HorizontalStackLayout Spacing="8">
-                                <Label
-                                    TextColor="{StaticResource Coin}"
-                                    Text="&#xf51e;"
-                                    FontFamily="FA6Solid"
-                                    VerticalOptions="Center"
-                                    FontSize="11"
-                                    InputTransparent="True" />
-                                <Label Text="{Binding Cost, StringFormat='{0:n0}'}"
-                                       VerticalOptions="Center"
-                                       FontSize="18" />
-                            </HorizontalStackLayout>
-                        </Border>
-                    </Grid>
-                    
-                    <!-- Pending redemption QR code -->
-                    <VerticalStackLayout IsVisible="{Binding IsQrCodeVisible}"
-                                         Spacing="10"
-                                         Margin="0,0,0,30">
-                        <Label Text="Please show this code to SSW staff to claim your reward:"
-                               HorizontalOptions="Center"
-                               HorizontalTextAlignment="Center"/>
-                        <zxing:BarcodeGeneratorView
-                                                 Format="QrCode"
-                                                 Value="{Binding QrCode}"
-                                                 HorizontalOptions="Center"
-                                                 BackgroundColor="#DDDDDD"
-                                                 ForegroundColor="Transparent"
-                                                 WidthRequest="150"
-                                                 HeightRequest="150"
-                                                 VerticalOptions="Center"/>
-                    </VerticalStackLayout>
-
-                    <!-- Address search -->
-                    <VerticalStackLayout IsVisible="{Binding IsAddressVisible}"
-                                         Spacing="2"
-                                         Margin="0,0,0,30">
-                        <controls:Search Command="{Binding SearchAddressCommand}"
-                                         IsSearching="{Binding IsSearching}"
-                                         BorderColor="{StaticResource BorderDefault}"
-                                         BackgroundColor="{StaticResource Gray900}"
-                                         Placeholder="Search for an address"/>
-                        
-                        <CollectionView ItemsSource="{Binding SearchResults}"
-                                        SelectedItem="{Binding SelectedAddress}"
-                                        SelectionChangedCommand="{Binding AddressSelectedCommand}"
-                                        SelectionMode="Single"
-                                        VerticalScrollBarVisibility="Always"
-                                        BackgroundColor="{StaticResource Gray950}"
-                                        MaximumHeightRequest="250">
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="addr:Address">
-                                    <Grid HeightRequest="30"
-                                          Margin="5">
-                                        <Label Text="{Binding freeformAddress}"
-                                               Margin="5"
-                                               VerticalOptions="Center"
-                                               VerticalTextAlignment="Center"
-                                               HorizontalOptions="Center"
-                                               HorizontalTextAlignment="Center"/>
-                                        
-                                        <Label HorizontalOptions="End"
-                                               Margin="5,5,10,5"
-                                               VerticalOptions="Center"
-                                               VerticalTextAlignment="Center"
-                                               FontFamily="FA6Solid"
-                                               TextColor="{StaticResource CorrectColor}"
-                                               LineBreakMode="WordWrap"
-                                               Text="&#xf058;"
-                                               Style="{StaticResource SelectedCheckLabelStyle}">
-                                            
-                                        </Label>
-                                    </Grid>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-                    </VerticalStackLayout>
-                    
-                    <VerticalStackLayout IsVisible="{Binding ConfirmEnabled}">
-                        <Label Text="Sending to:"
-                               HorizontalOptions="Center"
-                               HorizontalTextAlignment="Center" 
-                               Margin="5,10,5,5"/>
-                        
-                        <Label Text="{Binding SelectedAddress.freeformAddress}"
-                                 HorizontalOptions="Center"
-                                 HorizontalTextAlignment="Center"
-                                 Margin="5,5,5,10"/>
-                        
-                        <HorizontalStackLayout HorizontalOptions="Center"
-                                               Spacing="10"
-                                               Margin="0,15">
-                            <Label Text="Edit"
-                                   TextColor="{StaticResource SSWRed}"
-                                   VerticalOptions="Center"
-                                   HorizontalOptions="Center">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                          Command="{Binding EditAddressCommand}" />
-                                </Label.GestureRecognizers>
-                            </Label>
-                            <Label Text="Search again"
-                                   TextColor="{StaticResource SSWRed}"
-                                   VerticalOptions="Center">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer NumberOfTapsRequired="1"
-                                                          Command="{Binding SearchAgainCommand}" />
-                                </Label.GestureRecognizers>
-                            </Label>
-                        </HorizontalStackLayout>
-                        
-                        <toolkit:Expander IsExpanded="{Binding IsAddressEditExpanded}"
-                                          Margin="0,0,0,5">
-                            <VerticalStackLayout BindingContext="{Binding Source={x:Reference RedeemRewardPopup}, Path=BindingContext.SelectedAddress}"
-                                                 x:DataType="addr:Address"
-                                                 Spacing="5">
-                                <Entry Text="{Binding streetNumber}"
-                                       Placeholder="Street Number" />
-                                <Entry Text="{Binding streetName}"
-                                        Placeholder="Street Name" />
-                                <Entry Text="{Binding municipalitySubdivision}"
-                                        Placeholder="Suburb" />
-                                <Entry Text="{Binding municipality}"
-                                        Placeholder="City" />
-                                <Entry Text="{Binding countrySubdivisionCode}"
-                                        Placeholder="State" />
-                                <Entry Text="{Binding postalCode}"
-                                        Placeholder="Postcode" />
-                            </VerticalStackLayout>
-                        </toolkit:Expander>
-                    </VerticalStackLayout>
-                    
-                    <!-- Technical debt: This should be a single lottie view with a binding to the source, however source binding doesn't work -->
-                    <lottie:SKLottieView Source="delivery2.json"
-                                         IsVisible="{Binding SendingClaim}"
-                                         IsAnimationEnabled="True"
-                                         RepeatCount="-1"
-                                         VerticalOptions="CenterAndExpand"
-                                         HorizontalOptions="CenterAndExpand"
-                                         HeightRequest="200"
-                                         WidthRequest="200"
-                                         Scale="1"/>
-                    
-                    <lottie:SKLottieView Source="delivery1.json"
-                                         IsVisible="{Binding ClaimSuccess}"
-                                         IsAnimationEnabled="True"
-                                         RepeatCount="-1"
-                                         VerticalOptions="CenterAndExpand"
-                                         HorizontalOptions="CenterAndExpand"
-                                         HeightRequest="200"
-                                         WidthRequest="200"
-                                         Scale="1"/>
-                    
-                    <lottie:SKLottieView Source="error.json"
-                                         IsVisible="{Binding ClaimError}"
-                                         IsAnimationEnabled="True"
-                                         RepeatCount="-1"
-                                         VerticalOptions="CenterAndExpand"
-                                         HorizontalOptions="CenterAndExpand"
-                                         HeightRequest="200"
-                                         WidthRequest="200"
-                                         Scale="1"/>
-
-                    <VerticalStackLayout HorizontalOptions="Center"
-                                         Margin="0,0,0,30"
-                                         Spacing="15"
-                                         IsVisible="{Binding IsBalanceVisible}">
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
-                                Text="Redeem in-person"
-                                WidthRequest="160"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                Command="{Binding RedeemInPersonClickedCommand}"/>
-                        
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
-                                Text="Ship to my address"
-                                WidthRequest="160"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                Command="{Binding NextClickedCommand}"/>
-                    </VerticalStackLayout>
-
-                    <VerticalStackLayout HorizontalOptions="Center"
-                                         Spacing="15">
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
+    <Grid>
+        <Grid Padding="30,70" VerticalOptions="Center">
+            <Border
+                VerticalOptions="Center"
+                Padding="25"
+                StrokeThickness="1"
+                StrokeShape="RoundRectangle 8"
+                Stroke="{StaticResource BorderDefault}"
+                BackgroundColor="{StaticResource Background}">
+                <Grid>
+                    <VerticalStackLayout>
+                        <Border HeightRequest="80"
                                 WidthRequest="80"
-                                IsVisible="{Binding ConfirmEnabled}"
-                                Text="Confirm"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                Command="{Binding ConfirmClickedCommand}"/>
-                        
-                        <Button Background="{StaticResource SSWRed}"
-                                CornerRadius="4"
-                                Text="Cancel redemption"
-                                FontAttributes="Bold"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Center"
-                                IsVisible="{Binding IsQrCodeVisible}"
-                                Command="{Binding CancelPendingRedemptionClickedCommand}">
-                            <Button.ImageSource>
-                                <FontImageSource Glyph="&#xf00d;" 
-                                                 FontFamily="FA6Solid"
-                                                 FontAutoScalingEnabled="True"
-                                                 Size="16"/>
-                            </Button.ImageSource>
-                        </Button>
-                        
-                        <Button Text="{Binding CloseButtonText}"
-                                Command="{Binding ClosePopupCommand}"
-                                ContentLayout="Left, 10"
                                 BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                VerticalOptions="Start"
-                                HorizontalOptions="Center"
-                                CornerRadius="4">
-                            <Button.ImageSource>
-                                <FontImageSource Glyph="&#xf057;" 
-                                                 FontFamily="FA6Regular"
-                                                 FontAutoScalingEnabled="True"
-                                                 Size="16"/>
-                            </Button.ImageSource>
-                        </Button>
-                    </VerticalStackLayout>
-                </VerticalStackLayout>
-                <ActivityIndicator
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Fill"
-                    Color="{StaticResource SSWRed}"
-                    IsEnabled="{Binding IsBusy}"
-                    IsRunning="{Binding IsBusy}"
-                    IsVisible="{Binding IsBusy}" />
-            </Grid>
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 6"
+                                Margin="0,0,0,30">
+                            <Grid>
+                                <Image HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       Aspect="AspectFill"
+                                       Source="{Binding Image}"
+                                       IsVisible="{Binding Image, Converter={StaticResource IsStringNotNullOrEmpty}}" />
+                                <Label FontFamily="FA6Solid"
+                                       FontAutoScalingEnabled="False"
+                                       VerticalOptions="Center"
+                                       HorizontalOptions="Center"
+                                       Text="&#xf06b;"
+                                       TextColor="{StaticResource Gray300}"
+                                       FontSize="28"
+                                       IsVisible="{Binding Image, Converter={StaticResource IsStringNullOrEmpty}}" />
+                            </Grid>
+                        </Border>
 
-        </Border>
-    </ScrollView>
+                        <Label Text="{Binding Heading}"
+                               FontSize="24"
+                               HorizontalOptions="Center"
+                               HorizontalTextAlignment="Center"
+                               Style="{StaticResource LabelBold}" />
+
+                        <Label Text="{Binding Description}"
+                               FontSize="18"
+                               TextColor="{StaticResource Gray300}"
+                               HorizontalOptions="Center"
+                               HorizontalTextAlignment="Center"
+                               Margin="0,0,0,30" />
+
+                        <!-- Balance section -->
+                        <Grid RowDefinitions="Auto,Auto"
+                              ColumnDefinitions="Auto,Auto"
+                              HorizontalOptions="Center"
+                              RowSpacing="6"
+                              ColumnSpacing="10"
+                              Margin="0,0,0,30"
+                              IsVisible="{Binding IsBalanceVisible}">
+                            <Label Grid.Row="0"
+                                   Grid.Column="0"
+                                   Text="Your Balance"
+                                   FontSize="18"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center" />
+
+                            <Border Grid.Row="0"
+                                    Grid.Column="1"
+                                    BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                                    StrokeThickness="0"
+                                    StrokeShape="RoundRectangle 6"
+                                    Padding="15,4">
+                                <HorizontalStackLayout Spacing="8">
+                                    <Label
+                                        TextColor="{StaticResource Coin}"
+                                        Text="&#xf51e;"
+                                        FontFamily="FA6Solid"
+                                        VerticalOptions="Center"
+                                        FontSize="11"
+                                        InputTransparent="True" />
+                                    <Label Text="{Binding UserBalance, StringFormat='{0:n0}'}"
+                                           VerticalOptions="Center"
+                                           FontSize="18" />
+                                </HorizontalStackLayout>
+                            </Border>
+
+                            <Label Grid.Row="1"
+                                   Grid.Column="0"
+                                   Text="Product Cost"
+                                   FontSize="18"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center" />
+
+                            <Border Grid.Row="1"
+                                    Grid.Column="1"
+                                    BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                                    StrokeThickness="0"
+                                    StrokeShape="RoundRectangle 6"
+                                    Padding="15,4">
+                                <HorizontalStackLayout Spacing="8">
+                                    <Label
+                                        TextColor="{StaticResource Coin}"
+                                        Text="&#xf51e;"
+                                        FontFamily="FA6Solid"
+                                        VerticalOptions="Center"
+                                        FontSize="11"
+                                        InputTransparent="True" />
+                                    <Label Text="{Binding Cost, StringFormat='{0:n0}'}"
+                                           VerticalOptions="Center"
+                                           FontSize="18" />
+                                </HorizontalStackLayout>
+                            </Border>
+                        </Grid>
+
+                        <!-- Pending redemption QR code -->
+                        <VerticalStackLayout IsVisible="{Binding IsQrCodeVisible}"
+                                             Spacing="10"
+                                             Margin="0,0,0,30">
+                            <Label Text="Please show this code to SSW staff to claim your reward:"
+                                   HorizontalOptions="Center"
+                                   HorizontalTextAlignment="Center"/>
+                            <zxing:BarcodeGeneratorView
+                                                     Format="QrCode"
+                                                     Value="{Binding QrCode}"
+                                                     HorizontalOptions="Center"
+                                                     BackgroundColor="#DDDDDD"
+                                                     ForegroundColor="Transparent"
+                                                     WidthRequest="150"
+                                                     HeightRequest="150"
+                                                     VerticalOptions="Center"/>
+                        </VerticalStackLayout>
+
+                        <!-- Address search -->
+                        <VerticalStackLayout IsVisible="{Binding IsAddressVisible}"
+                                             Spacing="2"
+                                             Margin="0,0,0,30">
+                            <controls:Search Command="{Binding SearchAddressCommand}"
+                                             IsSearching="{Binding IsSearching}"
+                                             BorderColor="{StaticResource BorderDefault}"
+                                             BackgroundColor="{StaticResource Gray900}"
+                                             Placeholder="Search for an address"/>
+
+                            <CollectionView ItemsSource="{Binding SearchResults}"
+                                            SelectedItem="{Binding SelectedAddress}"
+                                            SelectionChangedCommand="{Binding AddressSelectedCommand}"
+                                            SelectionMode="Single"
+                                            VerticalScrollBarVisibility="Always"
+                                            BackgroundColor="{StaticResource Gray950}"
+                                            MaximumHeightRequest="250">
+                                <CollectionView.ItemTemplate>
+                                    <DataTemplate x:DataType="addr:Address">
+                                        <Grid HeightRequest="30"
+                                              Margin="5">
+                                            <Label Text="{Binding freeformAddress}"
+                                                   Margin="5"
+                                                   VerticalOptions="Center"
+                                                   VerticalTextAlignment="Center"
+                                                   HorizontalOptions="Center"
+                                                   HorizontalTextAlignment="Center"/>
+
+                                            <Label HorizontalOptions="End"
+                                                   Margin="5,5,10,5"
+                                                   VerticalOptions="Center"
+                                                   VerticalTextAlignment="Center"
+                                                   FontFamily="FA6Solid"
+                                                   TextColor="{StaticResource CorrectColor}"
+                                                   LineBreakMode="WordWrap"
+                                                   Text="&#xf058;"
+                                                   Style="{StaticResource SelectedCheckLabelStyle}">
+
+                                            </Label>
+                                        </Grid>
+                                    </DataTemplate>
+                                </CollectionView.ItemTemplate>
+                            </CollectionView>
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding ConfirmEnabled}">
+                            <Label Text="Sending to:"
+                                   HorizontalOptions="Center"
+                                   HorizontalTextAlignment="Center"
+                                   Margin="5,10,5,5"/>
+
+                            <Label Text="{Binding SelectedAddress.freeformAddress}"
+                                     HorizontalOptions="Center"
+                                     HorizontalTextAlignment="Center"
+                                     Margin="5,5,5,10"/>
+
+                            <HorizontalStackLayout HorizontalOptions="Center"
+                                                   Spacing="10"
+                                                   Margin="0,15">
+                                <Label Text="Edit"
+                                       TextColor="{StaticResource SSWRed}"
+                                       VerticalOptions="Center"
+                                       HorizontalOptions="Center">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer NumberOfTapsRequired="1"
+                                                              Command="{Binding EditAddressCommand}" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                                <Label Text="Search again"
+                                       TextColor="{StaticResource SSWRed}"
+                                       VerticalOptions="Center">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer NumberOfTapsRequired="1"
+                                                              Command="{Binding SearchAgainCommand}" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                            </HorizontalStackLayout>
+
+                            <toolkit:Expander IsExpanded="{Binding IsAddressEditExpanded}"
+                                              Margin="0,0,0,5">
+                                <VerticalStackLayout BindingContext="{Binding Source={x:Reference RedeemRewardPopup}, Path=BindingContext.SelectedAddress}"
+                                                     x:DataType="addr:Address"
+                                                     Spacing="5">
+                                    <Entry Text="{Binding streetNumber}"
+                                           Placeholder="Street Number" />
+                                    <Entry Text="{Binding streetName}"
+                                            Placeholder="Street Name" />
+                                    <Entry Text="{Binding municipalitySubdivision}"
+                                            Placeholder="Suburb" />
+                                    <Entry Text="{Binding municipality}"
+                                            Placeholder="City" />
+                                    <Entry Text="{Binding countrySubdivisionCode}"
+                                            Placeholder="State" />
+                                    <Entry Text="{Binding postalCode}"
+                                            Placeholder="Postcode" />
+                                </VerticalStackLayout>
+                            </toolkit:Expander>
+                        </VerticalStackLayout>
+
+                        <!-- Technical debt: This should be a single lottie view with a binding to the source, however source binding doesn't work -->
+                        <lottie:SKLottieView Source="delivery2.json"
+                                             IsVisible="{Binding SendingClaim}"
+                                             IsAnimationEnabled="True"
+                                             RepeatCount="-1"
+                                             VerticalOptions="CenterAndExpand"
+                                             HorizontalOptions="CenterAndExpand"
+                                             HeightRequest="200"
+                                             WidthRequest="200"
+                                             Scale="1"/>
+
+                        <lottie:SKLottieView Source="delivery1.json"
+                                             IsVisible="{Binding ClaimSuccess}"
+                                             IsAnimationEnabled="True"
+                                             RepeatCount="-1"
+                                             VerticalOptions="CenterAndExpand"
+                                             HorizontalOptions="CenterAndExpand"
+                                             HeightRequest="200"
+                                             WidthRequest="200"
+                                             Scale="1"/>
+
+                        <lottie:SKLottieView Source="error.json"
+                                             IsVisible="{Binding ClaimError}"
+                                             IsAnimationEnabled="True"
+                                             RepeatCount="-1"
+                                             VerticalOptions="CenterAndExpand"
+                                             HorizontalOptions="CenterAndExpand"
+                                             HeightRequest="200"
+                                             WidthRequest="200"
+                                             Scale="1"/>
+
+                        <Grid
+                            ColumnDefinitions="*,15,*"
+                            Margin="0,0,0,30"
+                            IsVisible="{Binding IsBalanceVisible}">
+                            <Button Grid.Column="0"
+                                    Background="{StaticResource SSWRed}"
+                                    CornerRadius="4"
+                                    Text="Redeem in-person"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="Center"
+                                    Command="{Binding RedeemInPersonClickedCommand}"/>
+
+                            <Button Grid.Column="2"
+                                    Background="{StaticResource SSWRed}"
+                                    CornerRadius="4"
+                                    Text="Ship to my address"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="Center"
+                                    Command="{Binding NextClickedCommand}"/>
+                        </Grid>
+
+                        <VerticalStackLayout HorizontalOptions="Center"
+                                             Spacing="15">
+                            <Button Background="{StaticResource SSWRed}"
+                                    CornerRadius="4"
+                                    WidthRequest="80"
+                                    IsVisible="{Binding ConfirmEnabled}"
+                                    Text="Confirm"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="Center"
+                                    Command="{Binding ConfirmClickedCommand}"/>
+
+                            <Button Background="{StaticResource SSWRed}"
+                                    CornerRadius="4"
+                                    Text="Cancel redemption"
+                                    FontAttributes="Bold"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="Center"
+                                    IsVisible="{Binding IsQrCodeVisible}"
+                                    Command="{Binding CancelPendingRedemptionClickedCommand}">
+                                <Button.ImageSource>
+                                    <FontImageSource Glyph="&#xf00d;"
+                                                     FontFamily="FA6Solid"
+                                                     FontAutoScalingEnabled="True"
+                                                     Size="16"/>
+                                </Button.ImageSource>
+                            </Button>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                    <ActivityIndicator
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"
+                        Color="{StaticResource SSWRed}"
+                        IsEnabled="{Binding IsBusy}"
+                        IsRunning="{Binding IsBusy}"
+                        IsVisible="{Binding IsBusy}" />
+                </Grid>
+            </Border>
+
+            <!-- Close button -->
+            <Border
+                WidthRequest="40"
+                HeightRequest="40"
+                StrokeThickness="0"
+                TranslationX="20"
+                TranslationY="-20"
+                Padding="10"
+                StrokeShape="RoundRectangle 20"
+                BackgroundColor="{StaticResource primary}"
+                VerticalOptions="Start"
+                HorizontalOptions="End">
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding ClosePopupCommand}"/>
+                </Border.GestureRecognizers>
+                <Image Source="icon_close"/>
+            </Border>
+        </Grid>
+    </Grid>
 </pages:PopupPage>

--- a/src/MobileUI/PopupPages/RedeemReward.xaml
+++ b/src/MobileUI/PopupPages/RedeemReward.xaml
@@ -26,7 +26,6 @@
     <pages:PopupPage.Resources>
         <toolkit:IsStringNullOrEmptyConverter x:Key="IsStringNullOrEmpty" />
         <toolkit:IsStringNotNullOrEmptyConverter x:Key="IsStringNotNullOrEmpty" />
-        <toolkit:InvertedBoolConverter x:Key="InverseBool" />
         <Style TargetType="Label" x:Key="SelectedCheckLabelStyle">
             <Setter Property="VisualStateManager.VisualStateGroups">
                 <VisualStateGroupList>
@@ -348,6 +347,22 @@
                                 VerticalOptions="Center"
                                 HorizontalOptions="Center"
                                 Command="{Binding ConfirmClickedCommand}"/>
+                        
+                        <Button Background="{StaticResource SSWRed}"
+                                CornerRadius="4"
+                                Text="Cancel redemption"
+                                FontAttributes="Bold"
+                                VerticalOptions="Center"
+                                HorizontalOptions="Center"
+                                IsVisible="{Binding IsQrCodeVisible}"
+                                Command="{Binding CancelPendingRedemptionClickedCommand}">
+                            <Button.ImageSource>
+                                <FontImageSource Glyph="&#xf00d;" 
+                                                 FontFamily="FA6Solid"
+                                                 FontAutoScalingEnabled="True"
+                                                 Size="16"/>
+                            </Button.ImageSource>
+                        </Button>
                         
                         <Button Text="{Binding CloseButtonText}"
                                 Command="{Binding ClosePopupCommand}"

--- a/src/MobileUI/PopupPages/RedeemReward.xaml.cs
+++ b/src/MobileUI/PopupPages/RedeemReward.xaml.cs
@@ -20,4 +20,8 @@ public partial class RedeemReward
         base.OnAppearing();
         _viewModel.Initialise(_reward);
     }
+    
+    public event EventHandler<object> CallbackEvent;
+    
+    protected override void OnDisappearing() => CallbackEvent?.Invoke(this, EventArgs.Empty);
 }

--- a/src/MobileUI/Services/IRewardService.cs
+++ b/src/MobileUI/Services/IRewardService.cs
@@ -6,6 +6,7 @@ public interface IRewardService
 {
     Task<List<Reward>> GetRewards();
     Task <ClaimRewardResult> ClaimReward(ClaimRewardDto claim);
-    Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim);
+    Task<CreatePendingRedemptionResult> CreatePendingRedemption(CreatePendingRedemptionDto claim);
+    Task<CancelPendingRedemptionResult> CancelPendingRedemption(CancelPendingRedemptionDto claim);
     Task<ClaimRewardResult> ClaimRewardForUser(ClaimRewardDto claim);
 }

--- a/src/MobileUI/Services/IRewardService.cs
+++ b/src/MobileUI/Services/IRewardService.cs
@@ -6,4 +6,5 @@ public interface IRewardService
 {
     Task<List<Reward>> GetRewards();
     Task <ClaimRewardResult> ClaimReward(ClaimRewardDto claim);
+    Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim);
 }

--- a/src/MobileUI/Services/IRewardService.cs
+++ b/src/MobileUI/Services/IRewardService.cs
@@ -7,4 +7,5 @@ public interface IRewardService
     Task<List<Reward>> GetRewards();
     Task <ClaimRewardResult> ClaimReward(ClaimRewardDto claim);
     Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim);
+    Task<ClaimRewardResult> ClaimRewardForUser(ClaimRewardDto claim);
 }

--- a/src/MobileUI/Services/IUserService.cs
+++ b/src/MobileUI/Services/IUserService.cs
@@ -24,6 +24,8 @@ public interface IUserService
     Task<IEnumerable<Achievement>> GetProfileAchievementsAsync(int userId);
     Task<IEnumerable<Reward>> GetRewardsAsync();
     Task<IEnumerable<Reward>> GetRewardsAsync(int userId);
+    Task<IEnumerable<UserPendingRedemptionDto>> GetPendingRedemptionsAsync();
+    Task<IEnumerable<UserPendingRedemptionDto>> GetPendingRedemptionsAsync(int userId);
     Task<string> UploadImageAsync(Stream image, string fileName);
     Task<UserProfileDto> GetUserAsync(int userId);
     Task<bool> DeleteProfileAsync();

--- a/src/MobileUI/Services/IUserService.cs
+++ b/src/MobileUI/Services/IUserService.cs
@@ -12,6 +12,7 @@ public interface IUserService
     IObservable<int> MyBalanceObservable();
     IObservable<string> MyQrCodeObservable();
     IObservable<int> MyAllTimeRankObservable();
+    IObservable<bool> IsStaffObservable();
 
     // auth methods
 

--- a/src/MobileUI/Services/RewardService.cs
+++ b/src/MobileUI/Services/RewardService.cs
@@ -72,4 +72,25 @@ public class RewardService : IRewardService
 
         return result;
     }
+    
+    public async Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim)
+    {
+        var result = new CreatePendingRedemptionResult { status = RewardStatus.Error };
+
+        try
+        {
+            result = await _rewardClient.CreatePendingRedemption(claim, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            // TODO: Handle errors
+            if (! await ExceptionHandler.HandleApiException(e))
+            {
+            }
+        }
+
+        await _userService.UpdateMyDetailsAsync();
+
+        return result;
+    }
 }

--- a/src/MobileUI/Services/RewardService.cs
+++ b/src/MobileUI/Services/RewardService.cs
@@ -1,4 +1,5 @@
 ﻿
+using SSW.Rewards.ApiClient.Services;
 using SSW.Rewards.Enums;
 using SSW.Rewards.Shared.DTOs.Rewards;
 using IApiRewardService = SSW.Rewards.ApiClient.Services.IRewardService;
@@ -8,12 +9,14 @@ namespace SSW.Rewards.Mobile.Services;
 public class RewardService : IRewardService
 {
     private readonly IApiRewardService _rewardClient;
+    private readonly IRewardAdminService _adminRewardClient;
     private readonly IUserService _userService;
 
-    public RewardService(IApiRewardService rewardClient, IUserService userService)
+    public RewardService(IApiRewardService rewardClient, IUserService userService, IRewardAdminService adminRewardService)
     {
         _rewardClient = rewardClient;
         _userService = userService;
+        _adminRewardClient = adminRewardService;
     }
 
     public async Task<List<Reward>> GetRewards()
@@ -69,6 +72,25 @@ public class RewardService : IRewardService
         }
 
         await _userService.UpdateMyDetailsAsync();
+
+        return result;
+    }
+    
+    public async Task<ClaimRewardResult> ClaimRewardForUser(ClaimRewardDto claim)
+    {
+        var result = new ClaimRewardResult() { status = RewardStatus.Error };
+
+        try
+        {
+            result = await _adminRewardClient.ClaimForUser(claim.Code, claim.UserId, claim.IsPendingRedemption, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            // TODO: Handle errors
+            if (! await ExceptionHandler.HandleApiException(e))
+            {
+            }
+        }
 
         return result;
     }

--- a/src/MobileUI/Services/RewardService.cs
+++ b/src/MobileUI/Services/RewardService.cs
@@ -86,16 +86,13 @@ public class RewardService : IRewardService
         }
         catch (Exception e)
         {
-            // TODO: Handle errors
-            if (! await ExceptionHandler.HandleApiException(e))
-            {
-            }
+            await ExceptionHandler.HandleApiException(e);
         }
 
         return result;
     }
     
-    public async Task<CreatePendingRedemptionResult> CreatePendingRedemption(ClaimRewardDto claim)
+    public async Task<CreatePendingRedemptionResult> CreatePendingRedemption(CreatePendingRedemptionDto claim)
     {
         var result = new CreatePendingRedemptionResult { status = RewardStatus.Error };
 
@@ -105,13 +102,26 @@ public class RewardService : IRewardService
         }
         catch (Exception e)
         {
-            // TODO: Handle errors
-            if (! await ExceptionHandler.HandleApiException(e))
-            {
-            }
+            await ExceptionHandler.HandleApiException(e);
         }
 
         await _userService.UpdateMyDetailsAsync();
+
+        return result;
+    }
+    
+    public async Task<CancelPendingRedemptionResult> CancelPendingRedemption(CancelPendingRedemptionDto claim)
+    {
+        var result = new CancelPendingRedemptionResult { Status = RewardStatus.Error };
+
+        try
+        {
+            result = await _rewardClient.CancelPendingRedemption(claim, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            await ExceptionHandler.HandleApiException(e);
+        }
 
         return result;
     }

--- a/src/MobileUI/Services/ScannerService.cs
+++ b/src/MobileUI/Services/ScannerService.cs
@@ -11,12 +11,19 @@ public class ScannerService : IScannerService
 {
     private readonly IAchievementService _achievementClient;
 
-    private readonly IApiRewardService _rewardClient;
+    private readonly IRewardService _rewardService;
 
-    public ScannerService(IApiRewardService rewardClient, IAchievementService achievementClient)
+    private readonly IUserService _userService;
+
+    private bool _isStaff;
+
+    public ScannerService(IRewardService rewardService, IAchievementService achievementClient, IUserService userService)
     {
-        _rewardClient = rewardClient;
+        _rewardService = rewardService;
         _achievementClient = achievementClient;
+        _userService = userService;
+
+        _userService.IsStaffObservable().Subscribe(isStaff => _isStaff = isStaff);
     }
 
     private async Task<ScanResponseViewModel> PostAchievementAsync(string achievementString)
@@ -77,18 +84,18 @@ public class ScannerService : IScannerService
         return vm;
     }
 
-    private async Task<ScanResponseViewModel> PostRewardAsync(string rewardString)
+    private async Task<ScanResponseViewModel> PostRewardAsync(string rewardString, bool isPendingRedemption = false)
     {
         ScanResponseViewModel vm = new()
         {
             ScanType = ScanType.Reward
         };
 
-        ClaimRewardDto claim = new() { Code = rewardString, InPerson = true };
+        ClaimRewardDto claim = new() { Code = rewardString, InPerson = true, IsPendingRedemption = isPendingRedemption};
 
         try
         {
-            var response = await _rewardClient.RedeemReward(claim, CancellationToken.None);
+            var response = isPendingRedemption ? await _rewardService.ClaimRewardForUser(claim) : await _rewardService.ClaimReward(claim);
 
             if (response != null)
             {
@@ -117,6 +124,11 @@ public class ScannerService : IScannerService
                     case RewardStatus.NotEnoughPoints:
                         vm.result = ScanResult.InsufficientBalance;
                         vm.Title = "Not enough points";
+                        break;
+                    
+                    case RewardStatus.Confirmed:
+                        vm.result = ScanResult.Confirmed;
+                        vm.Title = "Pending redemption confirmed";
                         break;
 
                     default:
@@ -157,6 +169,20 @@ public class ScannerService : IScannerService
         if (decodedQR.StartsWith("rwd:"))
         {
             return await PostRewardAsync(qrCodeData);
+        }
+        
+        if (decodedQR.StartsWith("pnd:"))
+        {
+            if (!_isStaff)
+            {
+                return new ScanResponseViewModel
+                {
+                    result = ScanResult.Error,
+                    Title = "Only SSW staff can redeem pending rewards"
+                };
+            }
+            
+            return await PostRewardAsync(qrCodeData, true);
         }
 
         return new ScanResponseViewModel

--- a/src/MobileUI/Services/ScannerService.cs
+++ b/src/MobileUI/Services/ScannerService.cs
@@ -128,7 +128,7 @@ public class ScannerService : IScannerService
                     
                     case RewardStatus.Confirmed:
                         vm.result = ScanResult.Confirmed;
-                        vm.Title = "Pending redemption confirmed";
+                        vm.Title = response.Reward.Name;
                         break;
 
                     default:

--- a/src/MobileUI/Services/UserService.cs
+++ b/src/MobileUI/Services/UserService.cs
@@ -18,6 +18,7 @@ public class UserService : IUserService
     private readonly BehaviorSubject<int> _myBalance = new(0);
     private readonly BehaviorSubject<string> _myQrCode = new(string.Empty);
     private readonly BehaviorSubject<int> _myAllTimeRank = new(Int32.MaxValue);
+    private readonly BehaviorSubject<bool> _isStaff = new(false);
 
     public UserService(IApiUserService userService, IAuthenticationService authService)
     {
@@ -34,6 +35,7 @@ public class UserService : IUserService
     public IObservable<int> MyBalanceObservable() => _myBalance.AsObservable();
     public IObservable<string> MyQrCodeObservable() => _myQrCode.AsObservable();
     public IObservable<int> MyAllTimeRankObservable() => _myAllTimeRank.AsObservable();
+    public IObservable<bool> IsStaffObservable() => _isStaff.AsObservable();
 
     public async Task<UserProfileDto> GetUserAsync(int userId)
     {
@@ -63,6 +65,7 @@ public class UserService : IUserService
         _myPoints.OnNext(user.Points);
         _myBalance.OnNext(user.Balance);
         _myQrCode.OnNext(user.QRCode);
+        _isStaff.OnNext(user.IsStaff);
     }
 
     public void UpdateMyAllTimeRank(int newRank)

--- a/src/MobileUI/Services/UserService.cs
+++ b/src/MobileUI/Services/UserService.cs
@@ -143,18 +143,43 @@ public class UserService : IUserService
         List<Reward> rewards = [];
         var rewardsList = await _userClient.GetUserRewards(userId);
 
-        foreach (var userReward in rewardsList.UserRewards)
+        rewards.AddRange(rewardsList.UserRewards.Select(userReward => new Reward
         {
-            rewards.Add(new Reward
+            Awarded = userReward.Awarded,
+            Name = userReward.RewardName,
+            Cost = userReward.RewardCost,
+            AwardedAt = userReward.AwardedAt
+        }));
+
+        return rewards;
+    }
+    
+    public async Task<IEnumerable<UserPendingRedemptionDto>> GetPendingRedemptionsAsync()
+    {
+        return await GetPendingRedemptionsForUserAsync(_myUserId.Value);
+    }
+    
+    public async Task<IEnumerable<UserPendingRedemptionDto>> GetPendingRedemptionsAsync(int userId)
+    {
+        return await GetPendingRedemptionsForUserAsync(userId);
+    }
+
+    private async Task<IEnumerable<UserPendingRedemptionDto>> GetPendingRedemptionsForUserAsync(int userId)
+    {
+        List<UserPendingRedemptionDto> redemptions = [];
+        var redemptionsList = await _userClient.GetUserPendingRedemptions(userId);
+
+        foreach (var userRedemption in redemptionsList.PendingRedemptions)
+        {
+            redemptions.Add(new UserPendingRedemptionDto
             {
-                Awarded = userReward.Awarded,
-                Name = userReward.RewardName,
-                Cost = userReward.RewardCost,
-                AwardedAt = userReward.AwardedAt
+                RewardId = userRedemption.RewardId,
+                ClaimedAt = userRedemption.ClaimedAt,
+                Code = userRedemption.Code
             });
         }
 
-        return rewards;
+        return redemptions;
     }
 
     public async Task<bool> DeleteProfileAsync()

--- a/src/MobileUI/ViewModels/ProfileViewModels/MyProfileViewModel.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/MyProfileViewModel.cs
@@ -20,7 +20,7 @@ public class MyProfileViewModel(
         _userService.MyProfilePicObservable().Subscribe(myProfilePicture => ProfilePic = myProfilePicture);
         _userService.MyPointsObservable().Subscribe(myPoints => Points = myPoints);
         _userService.MyBalanceObservable().Subscribe(myBalance => Balance = myBalance);
-        _userService.MyQrCodeObservable().Subscribe(myQrCode => IsStaff = !string.IsNullOrWhiteSpace(myQrCode));
+        _userService.IsStaffObservable().Subscribe(isStaff => IsStaff = isStaff);
         _userService.MyAllTimeRankObservable().Subscribe(myRank => Rank = myRank);
 
         await _initialise();

--- a/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
+++ b/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
@@ -77,7 +77,22 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
         Description = reward.Description;
         Cost = reward.Cost;
 
+        if (reward.IsPendingRedemption)
+        {
+            ShowQrCode(reward.PendingRedemptionCode);
+        }
+
         userService.MyBalanceObservable().Subscribe(myBalance => UserBalance = myBalance);
+    }
+
+    private void ShowQrCode(string code)
+    {
+        IsBalanceVisible = false;
+        ConfirmEnabled = false;
+        Heading = "Ready to claim!";
+        QrCode = code;
+        IsQrCodeVisible = true;
+        CloseButtonText = "Close";
     }
 
     [RelayCommand]

--- a/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
+++ b/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
@@ -45,19 +45,19 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
     private Address? _selectedAddress;
 
     [ObservableProperty]
-    private bool _confirmEnabled = false;
+    private bool _confirmEnabled;
 
     [ObservableProperty]
-    private bool _isAddressEditExpanded = false;
+    private bool _isAddressEditExpanded;
 
     [ObservableProperty]
-    private bool _sendingClaim = false;
+    private bool _sendingClaim;
 
     [ObservableProperty]
-    private bool _claimError = false;
+    private bool _claimError;
 
     [ObservableProperty]
-    private bool _claimSuccess = false;
+    private bool _claimSuccess;
 
     [ObservableProperty]
     private string _closeButtonText = "Cancel";
@@ -103,7 +103,7 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
     }
 
     [RelayCommand]
-    private async Task ClosePopup()
+    private static async Task ClosePopup()
     {
         await MopupService.Instance.PopAsync();
     }

--- a/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
+++ b/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
@@ -79,18 +79,18 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
 
         if (reward.IsPendingRedemption)
         {
-            ShowQrCode(reward.PendingRedemptionCode);
+            ShowQrCode(reward);
         }
 
         userService.MyBalanceObservable().Subscribe(myBalance => UserBalance = myBalance);
     }
 
-    private void ShowQrCode(string code)
+    private void ShowQrCode(Reward reward)
     {
         IsBalanceVisible = false;
         ConfirmEnabled = false;
-        Heading = "Ready to claim!";
-        QrCode = code;
+        Heading = $"Ready to claim:{Environment.NewLine}{reward.Name}";
+        QrCode = reward.PendingRedemptionCode;
         IsQrCodeVisible = true;
         CloseButtonText = "Close";
     }
@@ -157,10 +157,9 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
         SendingClaim = true;
         Heading = "Claiming reward...";
 
-        var claimResult = await rewardService.CreatePendingRedemption(new ClaimRewardDto
+        var claimResult = await rewardService.CreatePendingRedemption(new CreatePendingRedemptionDto
         {
-            Id = _reward.Id,
-            InPerson = true,
+            Id = _reward.Id
         });
 
         SendingClaim = false;
@@ -179,6 +178,20 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
         }
 
         CloseButtonText = "Close";
+    }
+    
+    [RelayCommand]
+    private async Task CancelPendingRedemptionClicked()
+    {
+        IsBusy = true;
+        
+        await rewardService.CancelPendingRedemption(new CancelPendingRedemptionDto
+        {
+            Id = _reward.Id
+        });
+        
+        IsBusy = false;
+        await MopupService.Instance.PopAsync();
     }
 
     [RelayCommand]//(CanExecute = nameof(ConfirmClickedIsExecutable))]

--- a/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
+++ b/src/MobileUI/ViewModels/RedeemRewardViewModel.cs
@@ -32,6 +32,9 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
 
     [ObservableProperty]
     private bool _isBalanceVisible = true;
+    
+    [ObservableProperty]
+    private bool _isQrCodeVisible;
 
     [ObservableProperty]
     private bool _isAddressVisible;
@@ -61,6 +64,9 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
 
     [ObservableProperty]
     private string _closeButtonText = "Cancel";
+    
+    [ObservableProperty]
+    private string _qrCode;
 
 
     public void Initialise(Reward reward)
@@ -126,6 +132,38 @@ public partial class RedeemRewardViewModel(IUserService userService, IRewardServ
         }
 
         IsAddressVisible = false;
+    }
+    
+    [RelayCommand]
+    private async Task RedeemInPersonClicked()
+    {
+        IsBalanceVisible = false;
+        ConfirmEnabled = false;
+        SendingClaim = true;
+        Heading = "Claiming reward...";
+
+        var claimResult = await rewardService.CreatePendingRedemption(new ClaimRewardDto
+        {
+            Id = _reward.Id,
+            InPerson = true,
+        });
+
+        SendingClaim = false;
+
+        if (claimResult.status == RewardStatus.Pending)
+        {
+            Heading = "Ready to claim!";
+            QrCode = claimResult.Code;
+            IsQrCodeVisible = true;
+        }
+        else
+        {
+            Heading = "Error";
+            Description = "Something went wrong - please try again later";
+            ClaimError = true;
+        }
+
+        CloseButtonText = "Close";
     }
 
     [RelayCommand]//(CanExecute = nameof(ConfirmClickedIsExecutable))]

--- a/src/MobileUI/ViewModels/RewardsViewModel.cs
+++ b/src/MobileUI/ViewModels/RewardsViewModel.cs
@@ -81,7 +81,11 @@ public partial class RewardsViewModel : BaseViewModel
         if (reward != null)
         {
             var popup = new RedeemReward(new RedeemRewardViewModel(_userService, _rewardService, _addressService), reward);
-            popup.CallbackEvent += async (sender, args) => await LoadData();
+            popup.CallbackEvent += async (_, _) =>
+            {
+                await LoadData();
+                await _userService.UpdateMyDetailsAsync();
+            };
             await MopupService.Instance.PushAsync(popup);
         }
     }

--- a/src/MobileUI/ViewModels/RewardsViewModel.cs
+++ b/src/MobileUI/ViewModels/RewardsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Reactive.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mopups.Services;
@@ -29,6 +30,14 @@ public partial class RewardsViewModel : BaseViewModel
         _userService = userService;
         _addressService = addressService;
         _userService.MyBalanceObservable().Subscribe(balance => Credits = balance);
+        _userService.MyUserIdObservable().DistinctUntilChanged().Subscribe(OnUserChanged);
+    }
+
+    private void OnUserChanged(int userId)
+    {
+        Rewards.Clear();
+        CarouselRewards.Clear();
+        _isLoaded = false;
     }
 
     public async Task Initialise()

--- a/src/MobileUI/ViewModels/ScanResultViewModel.cs
+++ b/src/MobileUI/ViewModels/ScanResultViewModel.cs
@@ -79,6 +79,7 @@ public partial class ScanResultViewModel : BaseViewModel
                 ResultHeading = "Pending redemption confirmed";
                 ResultBody = "Please provide the reward to the user.";
                 AnimationRef = "trophy.json";
+                HeadingColour = Colors.White;
                 AchievementHeading = result.Title;
                 _wonPrize = true;
                 break;

--- a/src/MobileUI/ViewModels/ScanResultViewModel.cs
+++ b/src/MobileUI/ViewModels/ScanResultViewModel.cs
@@ -75,6 +75,14 @@ public partial class ScanResultViewModel : BaseViewModel
                 _wonPrize = true;
                 break;
 
+            case ScanResult.Confirmed:
+                ResultHeading = "Pending redemption confirmed";
+                ResultBody = "Please provide the reward to the user.";
+                AnimationRef = "trophy.json";
+                AchievementHeading = result.Title;
+                _wonPrize = true;
+                break;
+
             case ScanResult.Duplicate:
                 AnimationRef = "rapid-scan.json";
                 AnimationLoop = true;

--- a/src/SSW.Rewards.Enums/RewardStatus.cs
+++ b/src/SSW.Rewards.Enums/RewardStatus.cs
@@ -7,5 +7,6 @@ public enum RewardStatus
     NotEnoughPoints,
     Error,
     Pending,
-    Confirmed
+    Confirmed,
+    Cancelled
 }

--- a/src/SSW.Rewards.Enums/RewardStatus.cs
+++ b/src/SSW.Rewards.Enums/RewardStatus.cs
@@ -5,5 +5,6 @@ public enum RewardStatus
     NotFound,
     Duplicate,
     NotEnoughPoints,
-    Error
+    Error,
+    Pending
 }

--- a/src/SSW.Rewards.Enums/RewardStatus.cs
+++ b/src/SSW.Rewards.Enums/RewardStatus.cs
@@ -6,5 +6,6 @@ public enum RewardStatus
     Duplicate,
     NotEnoughPoints,
     Error,
-    Pending
+    Pending,
+    Confirmed
 }

--- a/src/WebAPI/Controllers/RewardController.cs
+++ b/src/WebAPI/Controllers/RewardController.cs
@@ -72,7 +72,7 @@ public class RewardController : ApiControllerBase
     }
 
     [HttpPost]
-    [Authorize(Roles = AuthorizationRoles.Staff)]
+    [Authorize(Roles = "Staff,Admin")]
     public async Task<ActionResult<ClaimRewardResult>> ClaimForUser(ClaimRewardForUserCommand claimRewardForUserCommand)
     {
         return Ok(await Mediator.Send(claimRewardForUserCommand));

--- a/src/WebAPI/Controllers/RewardController.cs
+++ b/src/WebAPI/Controllers/RewardController.cs
@@ -93,9 +93,19 @@ public class RewardController : ApiControllerBase
     
     [HttpPost]
     [Authorize(Policy = Policies.MobileApp)]
-    public async Task<ActionResult<CreatePendingRedemptionResult>> CreatePendingRedemption(ClaimRewardDto claim)
+    public async Task<ActionResult<CreatePendingRedemptionResult>> CreatePendingRedemption(CreatePendingRedemptionDto claim)
     {
         return Ok(await Mediator.Send(new CreatePendingRedemptionCommand()
+        {
+            Id = claim.Id,
+        }));
+    }
+    
+    [HttpPost]
+    [Authorize(Policy = Policies.MobileApp)]
+    public async Task<ActionResult<CancelPendingRedemptionResult>> CancelPendingRedemption(CancelPendingRedemptionDto claim)
+    {
+        return Ok(await Mediator.Send(new CancelPendingRedemptionCommand()
         {
             Id = claim.Id,
         }));

--- a/src/WebAPI/Controllers/RewardController.cs
+++ b/src/WebAPI/Controllers/RewardController.cs
@@ -72,7 +72,7 @@ public class RewardController : ApiControllerBase
     }
 
     [HttpPost]
-    [Authorize(Roles = AuthorizationRoles.Admin)]
+    [Authorize(Roles = AuthorizationRoles.Staff)]
     public async Task<ActionResult<ClaimRewardResult>> ClaimForUser(ClaimRewardForUserCommand claimRewardForUserCommand)
     {
         return Ok(await Mediator.Send(claimRewardForUserCommand));

--- a/src/WebAPI/Controllers/RewardController.cs
+++ b/src/WebAPI/Controllers/RewardController.cs
@@ -90,6 +90,16 @@ public class RewardController : ApiControllerBase
             ClaimInPerson = claim.InPerson
         }));
     }
+    
+    [HttpPost]
+    [Authorize(Policy = Policies.MobileApp)]
+    public async Task<ActionResult<CreatePendingRedemptionResult>> CreatePendingRedemption(ClaimRewardDto claim)
+    {
+        return Ok(await Mediator.Send(new CreatePendingRedemptionCommand()
+        {
+            Id = claim.Id,
+        }));
+    }
 
     [HttpDelete("{id}")]
     [Authorize(Roles = AuthorizationRoles.Admin)]

--- a/src/WebAPI/Controllers/UserController.cs
+++ b/src/WebAPI/Controllers/UserController.cs
@@ -17,6 +17,7 @@ using SSW.Rewards.Enums;
 using SSW.Rewards.WebAPI.Authorisation;
 using SSW.Rewards.Application.Users.Commands.AdminDeleteProfile;
 using SSW.Rewards.Application.Users.Queries.AdminGetProfileDeletionRequests;
+using SSW.Rewards.Application.Users.Queries.GetUserPendingRedemptions;
 using SSW.Rewards.Application.Users.Queries.GetUsers;
 
 namespace SSW.Rewards.WebAPI.Controllers;
@@ -45,6 +46,12 @@ public class UserController : ApiControllerBase
     public async Task<ActionResult<UserRewardsViewModel>> Rewards([FromQuery] int userId)
     {
         return Ok(await Mediator.Send(new GetUserRewardsQuery { UserId = userId }));
+    }
+    
+    [HttpGet]
+    public async Task<ActionResult<UserPendingRedemptionsViewModel>> GetUserPendingRedemptions([FromQuery] int userId)
+    {
+        return Ok(await Mediator.Send(new GetUserPendingRedemptionsQuery() { UserId = userId }));
     }
 
     [HttpGet]


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #858
Closes #314

> 2. What was changed?

Allows for user's to redeem rewards in-person, which generates a QR code which they must then show to SSW staff. SSW staff can then scan the code to confirm the redemption and provide the user with the reward.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/d3c16ce0-219e-46d4-bfa5-6c9902405037" width="400" />

**Figure: Users now have the option to redeem in-person**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/8039ab4d-02b2-460a-b727-4a643071275c" width="400" />

**Figure: Redeeming in-person will display a QR code which must be then scanned by SSW staff. The user can also cancel the redemption if they've changed their mind. (Note: points aren't deducted until the redemption is confirmed)**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/3bfce812-0a45-4c1c-9f09-1b23f1a01ba7" width="400" />

**Figure: If the user has closed the window of a pending redemption, they can tap the QR button to bring it up again**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/c62673ee-3c13-461f-86b9-2c09b2dac371" width="400" />

**Figure: When SSW staff scans the code it will then be confirmed and they can hand over the reward. Points get deducted at this point.**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->