### PR TITLE
♻️ Mobile | Updates to quiz results page

### DIFF
--- a/src/MobileUI/Pages/EarnDetailsPage.xaml
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml
@@ -205,7 +205,7 @@
                            Grid.Row="0" />
 
                     <Border Grid.Row="1"
-                            BackgroundColor="{StaticResource SSWRed}"
+                            BackgroundColor="{Binding ScoreBackground}"
                             WidthRequest="150"
                             HeightRequest="40"
                             StrokeShape="RoundRectangle 6"

--- a/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
+++ b/src/MobileUI/Pages/EarnDetailsPage.xaml.cs
@@ -1,14 +1,11 @@
 ﻿namespace SSW.Rewards.Mobile.Pages;
 
 [QueryProperty(nameof(QuizId), nameof(QuizId))]
-[QueryProperty(nameof(QuizIcon), nameof(QuizIcon))]
 public partial class EarnDetailsPage
 {
     private EarnDetailsViewModel _viewModel;
 
     public string QuizId { get; set; }
-
-    public string QuizIcon { get; set; }
 
     public EarnDetailsPage(EarnDetailsViewModel viewModel)
     {
@@ -21,6 +18,6 @@ public partial class EarnDetailsPage
     {
         base.OnAppearing();
         int quizId = int.Parse(QuizId);
-        await _viewModel.Initialise(quizId, QuizIcon);
+        await _viewModel.Initialise(quizId);
     }
 }

--- a/src/MobileUI/Resources/Styles/Colors.xaml
+++ b/src/MobileUI/Resources/Styles/Colors.xaml
@@ -87,6 +87,8 @@
     <Color x:Key="CorrectColor">#52B5AA</Color>
     <Color x:Key="TextSecondary">#A0A0A0</Color>
     
+    <Color x:Key="SuccessGreen">#198754</Color>
+    
     <LinearGradientBrush x:Key="BrandBrush" EndPoint="0,1">
         <GradientStop Offset="0.1" Color="{StaticResource SSWRed}"></GradientStop>
         <GradientStop Offset="1.0" Color="{StaticResource BrandEnd}"></GradientStop>

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -174,8 +174,8 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         private async Task<bool> AwaitQuizCompletion()
         {
-            var maxAttempts = 60;
-            var delay = 2000;
+            var maxAttempts = 30;
+            var delay = 5000;
             bool isComplete = false;
 
             while (!isComplete)

--- a/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnDetailsViewModel.cs
@@ -16,7 +16,6 @@ namespace SSW.Rewards.Mobile.ViewModels
         private readonly ISnackbarService _snackbarService;
         private readonly IUserService _userService;
         private int _quizId;
-        private string _quizIcon;
         private int _submissionId;
 
         [ObservableProperty]
@@ -34,6 +33,9 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         [ObservableProperty]
         private string _quizDescription;
+        
+        [ObservableProperty]
+        private Color _scoreBackground;
 
         [ObservableProperty]
         private string _score;
@@ -86,11 +88,10 @@ namespace SSW.Rewards.Mobile.ViewModels
             _userService = userService;
         }
 
-        public async Task Initialise(int quizId, string icon)
+        public async Task Initialise(int quizId)
         {
             IsBusy = true;
             _quizId = quizId;
-            _quizIcon = icon;
             IsLoadingQuestions = true;
 
             var quiz = await _quizService.GetQuizDetails(_quizId);
@@ -173,8 +174,8 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         private async Task<bool> AwaitQuizCompletion()
         {
-            var maxAttempts = 30;
-            var delay = 5000;
+            var maxAttempts = 60;
+            var delay = 2000;
             bool isComplete = false;
 
             while (!isComplete)
@@ -200,7 +201,7 @@ namespace SSW.Rewards.Mobile.ViewModels
             ResultsVisible = true;
             WeakReferenceMessenger.Default.Send(new TopBarAvatarMessage(AvatarOptions.Done));
 
-            var total = result.Results.Count();
+            var total = result.Results.Count;
 
             var correct = result.Results.Count(r => r.Correct);
 
@@ -215,14 +216,17 @@ namespace SSW.Rewards.Mobile.ViewModels
 
             if (result.Passed)
             {
+                App.Current.Resources.TryGetValue("SuccessGreen", out object successGreen);
+
+                ScoreBackground = (Color)successGreen!;
                 ResultsTitle = "Test Passed!";
                 TestPassed = true;
                 SnackOptions = new SnackbarOptions
                 {
                     ActionCompleted = true,
-                    GlyphIsBrand = true,
-                    Glyph = _quizIcon,
-                    Message = $"You have completed the {QuizTitle} quiz",
+                    GlyphIsBrand = false,
+                    Glyph = "\uf837", // Trophy icon
+                    Message = $"You have completed the {QuizTitle}",
                     Points = Points,
                     ShowPoints = true
                 };
@@ -232,6 +236,9 @@ namespace SSW.Rewards.Mobile.ViewModels
             }
             else
             {
+                App.Current.Resources.TryGetValue("SSWRed", out object sswRed);
+
+                ScoreBackground = (Color)sswRed!;
                 ResultsTitle = "Test Failed";
                 TestPassed = false;
             }

--- a/src/MobileUI/ViewModels/EarnViewModel.cs
+++ b/src/MobileUI/ViewModels/EarnViewModel.cs
@@ -65,8 +65,7 @@ public partial class EarnViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
     [RelayCommand]
     private async Task OpenQuiz(int quizId)
     {
-        var quiz = Quizzes.First(q => q.Id == quizId);
-        await AppShell.Current.GoToAsync($"{quizDetailsPageUrl}?QuizId={quiz.Id}&QuizIcon={quiz.Icon}");
+        await AppShell.Current.GoToAsync($"{quizDetailsPageUrl}?QuizId={quizId}");
     }
 
     private bool CanOpenQuiz(int quizId)


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #874

> 2. What was changed?

1. Sets the default snackbar glyph to a trophy when a quiz is complete as we're not really using the glyphs here.
2. Updates the achievement wording so the text doesn't double the word "quiz".
3. Sets the score background colour to green when passing the quiz.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/33ca66ce-0e8b-4e9d-bc4b-668a8498ee24" width="400" />

**Figure: Updated quiz results page with trophy icon, fixed text, and green background colour on the score**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->