### PR TITLE
🐛 Mobile | Fix multi-line buttons on iOS

### DIFF
--- a/src/MobileUI/Controls/MultiLineButton.xaml
+++ b/src/MobileUI/Controls/MultiLineButton.xaml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SSW.Rewards.Mobile.Controls.MultiLineButton"
+             x:Name="this">
+    <Border BackgroundColor="{StaticResource SSWRed}"
+            StrokeThickness="0"
+            StrokeShape="RoundRectangle 10"
+            MinimumWidthRequest="44"
+            MinimumHeightRequest="44"
+            Padding="14,10">
+        <Border.GestureRecognizers>
+            <TapGestureRecognizer Command="{Binding Command, Source={x:Reference this}}" />
+        </Border.GestureRecognizers>
+        <Label Text="{Binding Text, Source={x:Reference this}}"
+               TextColor="White"
+               FontSize="14"
+               HorizontalOptions="Center"
+               VerticalOptions="Center"
+               HorizontalTextAlignment="Center"
+               VerticalTextAlignment="Center"
+               LineBreakMode="WordWrap">
+        </Label>
+    </Border>
+</ContentView>

--- a/src/MobileUI/Controls/MultiLineButton.xaml
+++ b/src/MobileUI/Controls/MultiLineButton.xaml
@@ -2,6 +2,7 @@
 
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="SSW.Rewards.Mobile.Controls.MultiLineButton"
              x:Name="this">
     <Border BackgroundColor="{Binding BackgroundColor, Source={x:Reference this}}"
@@ -21,6 +22,9 @@
                HorizontalTextAlignment="Center"
                VerticalTextAlignment="Center"
                LineBreakMode="WordWrap">
+            <Label.Behaviors>
+                <toolkit:TouchBehavior PressedOpacity="0.5" />
+            </Label.Behaviors>
         </Label>
     </Border>
 </ContentView>

--- a/src/MobileUI/Controls/MultiLineButton.xaml
+++ b/src/MobileUI/Controls/MultiLineButton.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SSW.Rewards.Mobile.Controls.MultiLineButton"
              x:Name="this">
-    <Border BackgroundColor="{StaticResource SSWRed}"
+    <Border BackgroundColor="{Binding BackgroundColor, Source={x:Reference this}}"
             StrokeThickness="0"
             StrokeShape="RoundRectangle 10"
             MinimumWidthRequest="44"
@@ -14,8 +14,8 @@
             <TapGestureRecognizer Command="{Binding Command, Source={x:Reference this}}" />
         </Border.GestureRecognizers>
         <Label Text="{Binding Text, Source={x:Reference this}}"
-               TextColor="White"
-               FontSize="14"
+               TextColor="{Binding TextColor, Source={x:Reference this}}"
+               FontSize="{Binding FontSize, Source={x:Reference this}}"
                HorizontalOptions="Center"
                VerticalOptions="Center"
                HorizontalTextAlignment="Center"

--- a/src/MobileUI/Controls/MultiLineButton.xaml.cs
+++ b/src/MobileUI/Controls/MultiLineButton.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System.Windows.Input;
+
+namespace SSW.Rewards.Mobile.Controls;
+
+public partial class MultiLineButton
+{
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public static readonly BindableProperty TextProperty =
+        BindableProperty.Create(
+            nameof(Text),
+            typeof(string),
+            typeof(MultiLineButton),
+            string.Empty
+        );
+    
+    public ICommand Command
+    {
+        get => (ICommand)GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    public static readonly BindableProperty CommandProperty =
+        BindableProperty.Create(
+            nameof(Command),
+            typeof(ICommand),
+            typeof(MultiLineButton)
+        );
+    
+    public MultiLineButton()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/MobileUI/Controls/MultiLineButton.xaml.cs
+++ b/src/MobileUI/Controls/MultiLineButton.xaml.cs
@@ -18,6 +18,48 @@ public partial class MultiLineButton
             string.Empty
         );
     
+    public Color TextColor
+    {
+        get => (Color)GetValue(TextColorProperty);
+        set => SetValue(TextColorProperty, value);
+    }
+
+    public static readonly BindableProperty TextColorProperty =
+        BindableProperty.Create(
+            nameof(TextColor),
+            typeof(Color),
+            typeof(MultiLineButton),
+            Colors.White
+        );
+    
+    public int FontSize
+    {
+        get => (int)GetValue(FontSizeProperty);
+        set => SetValue(FontSizeProperty, value);
+    }
+
+    public static readonly BindableProperty FontSizeProperty =
+        BindableProperty.Create(
+            nameof(FontSize),
+            typeof(int),
+            typeof(MultiLineButton),
+            14
+        );
+    
+    public new Color BackgroundColor
+    {
+        get => (Color)GetValue(BackgroundColorProperty);
+        set => SetValue(BackgroundColorProperty, value);
+    }
+
+    public new static readonly BindableProperty BackgroundColorProperty =
+        BindableProperty.Create(
+            nameof(BackgroundColor),
+            typeof(Color),
+            typeof(MultiLineButton),
+            App.Current.Resources["SSWRed"] as Color
+        );
+    
     public ICommand Command
     {
         get => (ICommand)GetValue(CommandProperty);

--- a/src/MobileUI/Controls/Search.xaml
+++ b/src/MobileUI/Controls/Search.xaml
@@ -16,6 +16,7 @@
         <controls:BorderlessEntry
             Grid.Column="0"
             x:Name="SearchEntry"
+            PlaceholderColor="{StaticResource Gray500}"
             android:Entry.ImeOptions="Search"
             Margin="{OnPlatform Android='10,3,0,0', iOS='10,0,0,0'}" 
             TextChanged="SearchEntry_OnTextChanged">

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -98,6 +98,10 @@
         <PackageReference Include="Xamarin.Google.Dagger" Version="2.48.1.2" />
         <Compile Update="Platforms\Android\Services\RewardsFirebaseMessagingService.cs">
         </Compile>
+        <Compile Update="Controls\MultiLineButton.xaml.cs">
+          <DependentUpon>MultiLineButton.xaml</DependentUpon>
+          <SubType>Code</SubType>
+        </Compile>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -228,6 +232,10 @@
 		</MauiXaml>
 		<MauiXaml Update="Pages\SettingsPage.xaml">
 		  <SubType>Designer</SubType>
+		</MauiXaml>
+		<MauiXaml Update="Controls\MultiLineButton.xaml">
+		  <SubType>Designer</SubType>
+		  <Generator>MSBuild:Compile</Generator>
 		</MauiXaml>
 	</ItemGroup>
 

--- a/src/MobileUI/PopupPages/ProfilePicturePage.xaml
+++ b/src/MobileUI/PopupPages/ProfilePicturePage.xaml
@@ -5,6 +5,7 @@
                  xmlns:animations="clr-namespace:Mopups.Animations;assembly=Mopups"
                  xmlns:viewModels="clr-namespace:SSW.Rewards.Mobile.ViewModels"
                  xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+                 xmlns:controls="clr-namespace:SSW.Rewards.Mobile.Controls"
                  BackgroundColor="#b3000000"
                  CloseWhenBackgroundIsClicked="False"
                  x:DataType="viewModels:ProfilePictureViewModel"
@@ -61,21 +62,18 @@
                     RowDefinitions="*,15,*"
                     ColumnDefinitions="*,15,*"
                     VerticalOptions="Center">
-                    <Button
-                        Grid.Row="0"
-                        Grid.Column="0"
+                    
+                    <controls:MultiLineButton
                         Text="Take a new photo"
-                        LineBreakMode="WordWrap"
-                        CornerRadius="10"
-                        Command="{Binding TakePhotoCommand}"/>
-
-                    <Button
+                        Command="{Binding TakePhotoCommand}"
                         Grid.Row="0"
-                        Grid.Column="3"
+                        Grid.Column="0" />
+                    
+                    <controls:MultiLineButton
                         Text="Choose a new photo"
-                        LineBreakMode="WordWrap"
-                        CornerRadius="10"
-                        Command="{Binding ChoosePhotoCommand}"/>
+                        Command="{Binding ChoosePhotoCommand}"
+                        Grid.Row="0"
+                        Grid.Column="3" />
 
                     <Button
                         Grid.Row="3"

--- a/src/MobileUI/PopupPages/RedeemRewardPage.xaml
+++ b/src/MobileUI/PopupPages/RedeemRewardPage.xaml
@@ -309,21 +309,15 @@
                             ColumnDefinitions="*,15,*"
                             Margin="0,0,0,30"
                             IsVisible="{Binding IsBalanceVisible}">
-                            <Button Grid.Column="0"
-                                    Background="{StaticResource SSWRed}"
-                                    CornerRadius="10"
-                                    Text="Redeem in-person"
-                                    FontAttributes="Bold"
-                                    LineBreakMode="WordWrap"
-                                    Command="{Binding RedeemInPersonClickedCommand}"/>
-
-                            <Button Grid.Column="2"
-                                    Background="{StaticResource SSWRed}"
-                                    CornerRadius="10"
-                                    Text="Ship to my address"
-                                    FontAttributes="Bold"
-                                    LineBreakMode="WordWrap"
-                                    Command="{Binding NextClickedCommand}"/>
+                            <controls:MultiLineButton
+                                Text="Redeem in-person"
+                                Command="{Binding RedeemInPersonClickedCommand}"
+                                Grid.Column="0" />
+                            
+                            <controls:MultiLineButton
+                                Text="Ship to my address"
+                                Command="{Binding NextClickedCommand}"
+                                Grid.Column="2" />
                         </Grid>
 
                         <VerticalStackLayout HorizontalOptions="Center"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #898 

> 2. What was changed?

We recently implemented word wrapping on buttons with lots of text, which looks nice and centred on Android but on iOS is left-aligned with no option to adjust. This works around this by implementing a custom multi-line button.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/d0d18372-f289-44bb-9cb1-0e7bf01ea783" width="400" />

**❌ Figure: Buttons with multi-line text are left-aligned on iOS**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/83ab5445-42da-45d7-a9c1-5a347815932f" width="400" />

**✅ Figure: Multi-line buttons look nicer now with our custom button**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->