### PR TITLE
🐛Mobile | Fix button not working on Android when text is tapped

### DIFF
--- a/src/MobileUI/Controls/MultiLineButton.xaml
+++ b/src/MobileUI/Controls/MultiLineButton.xaml
@@ -11,9 +11,10 @@
             MinimumWidthRequest="44"
             MinimumHeightRequest="44"
             Padding="14,10">
-        <Border.GestureRecognizers>
-            <TapGestureRecognizer Command="{Binding Command, Source={x:Reference this}}" />
-        </Border.GestureRecognizers>
+        <Border.Behaviors>
+            <toolkit:TouchBehavior PressedOpacity="0.5"
+                                   Command="{Binding Command, Source={x:Reference this}}"/>
+        </Border.Behaviors>
         <Label Text="{Binding Text, Source={x:Reference this}}"
                TextColor="{Binding TextColor, Source={x:Reference this}}"
                FontSize="{Binding FontSize, Source={x:Reference this}}"
@@ -21,10 +22,6 @@
                VerticalOptions="Center"
                HorizontalTextAlignment="Center"
                VerticalTextAlignment="Center"
-               LineBreakMode="WordWrap">
-            <Label.Behaviors>
-                <toolkit:TouchBehavior PressedOpacity="0.5" />
-            </Label.Behaviors>
-        </Label>
+               LineBreakMode="WordWrap" />
     </Border>
 </ContentView>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #905 

> 2. What was changed?

Moving the TouchBehaviour to the parent element of the MultiLineButton so that tapping just the text portion doesn't ignore the tap recognition on the button. This ensures the button works correctly when touching any part of the button on both platforms.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->