### PR TITLE
🐛 Mobile | Fix permission check on Android when taking photo

### DIFF
--- a/src/MobileUI/ViewModels/ProfilePictureViewModel.cs
+++ b/src/MobileUI/ViewModels/ProfilePictureViewModel.cs
@@ -32,10 +32,6 @@ public partial class ProfilePictureViewModel : BaseViewModel
     [RelayCommand]
     private async Task TakePhoto()
     {
-        var storageGranted = await _permissionsService.CheckAndRequestPermission<Permissions.StorageWrite>();
-        if (!storageGranted)
-            return;
-
         var cameraGranted = await _permissionsService.CheckAndRequestPermission<Permissions.Camera>();
         if (!cameraGranted)
             return;

--- a/src/MobileUI/ViewModels/ProfilePictureViewModel.cs
+++ b/src/MobileUI/ViewModels/ProfilePictureViewModel.cs
@@ -32,6 +32,14 @@ public partial class ProfilePictureViewModel : BaseViewModel
     [RelayCommand]
     private async Task TakePhoto()
     {
+        // Permissions.StorageWrite gone and no longer needed on Android SDK 33 and above
+        if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+        {
+            var storageGranted = await _permissionsService.CheckAndRequestPermission<Permissions.StorageWrite>();
+            if (!storageGranted)
+                return;
+        }
+        
         var cameraGranted = await _permissionsService.CheckAndRequestPermission<Permissions.Camera>();
         if (!cameraGranted)
             return;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #908 

> 2. What was changed?

Permissions.StorageWrite doesn't exist and always returns false on Android SDK 33 and above. This checks for the SDK version and only does this check if it's an older version that still has and requires this.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->