### PR TITLE
🐛 Mobile | Don't open profile pic popup when tapping other user's photo

### DIFF
--- a/src/MobileUI/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
@@ -137,7 +137,7 @@ public partial class ProfileViewModelBase : BaseViewModel
     [RelayCommand]
     private async Task ChangeProfilePicture()
     {
-        if (IsLoading)
+        if (IsLoading || !IsMe)
             return;
 
         Application.Current.Resources.TryGetValue("Background", out var statusBarColor);


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Small bug noticed

> 2. What was changed?

Small change to fix an issue where tapping another user's profile pic opens the change profile pic popup.

> 3. Did you do pair or mob programming?

No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->