### PR TITLE
🐛 Mobile | Fix incorrect time lapsed for activity

### DIFF
--- a/src/MobileUI/ViewModels/ActivityPageViewModel.cs
+++ b/src/MobileUI/ViewModels/ActivityPageViewModel.cs
@@ -107,7 +107,7 @@ public partial class ActivityPageViewModel(IActivityFeedService activityService,
             { TotalHours: < 1 } ts => $"{ts.Minutes}m ago",
             { TotalDays: < 1 } ts => $"{ts.Hours}h ago",
             { TotalDays: < 31 } ts => $"{ts.Days}d ago",
-            _ => occurredAt.ToString("dd MMMM yyyy"),
+            _ => occurredAt.ToLocalTime().ToString("dd MMMM yyyy"),
         };
     }
 

--- a/src/MobileUI/ViewModels/ActivityPageViewModel.cs
+++ b/src/MobileUI/ViewModels/ActivityPageViewModel.cs
@@ -101,7 +101,7 @@ public partial class ActivityPageViewModel(IActivityFeedService activityService,
     
     private static string GetTimeElapsed(DateTime occurredAt)
     {
-        return (DateTime.Now - occurredAt) switch
+        return (DateTime.UtcNow - occurredAt) switch
         {
             { TotalMinutes: < 5 } ts => "Just now",
             { TotalHours: < 1 } ts => $"{ts.Minutes}m ago",

--- a/src/MobileUI/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
@@ -287,7 +287,7 @@ public partial class ProfileViewModelBase : BaseViewModel
         {
             { TotalDays: < 1 } ts => $"{ts.Hours}h",
             { TotalDays: < 31 } ts => $"{ts.Days}d",
-            _ => occurredAt.ToString("dd MMMM yyyy"),
+            _ => occurredAt.ToLocalTime().ToString("dd MMMM yyyy"),
         };
     }
 

--- a/src/MobileUI/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
+++ b/src/MobileUI/ViewModels/ProfileViewModels/ProfileViewModelBase.cs
@@ -283,7 +283,7 @@ public partial class ProfileViewModelBase : BaseViewModel
 
     private static string GetTimeElapsed(DateTime occurredAt)
     {
-        return (DateTime.Now - occurredAt) switch
+        return (DateTime.UtcNow - occurredAt) switch
         {
             { TotalDays: < 1 } ts => $"{ts.Hours}h",
             { TotalDays: < 31 } ts => $"{ts.Days}d",


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Related to #782 

> 2. What was changed?

The time lapsed values on activity are incorrect as the data is in UTC unlike the methods used. This is a quick fix to update these methods to use UTC and show correct values.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/88320f6f-66bd-4c12-873e-3b31a5cc4b1e" width="400" />

**❌ Figure: The time lapsed values are incorrect and greater than they should be**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/7c882717-60fc-4dc3-832e-905a6efb30f8" width="400" />

**✅ Figure: The values are now correct**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->