### PR TITLE
🐛 Mobile | Fix gap at bottom of Network page

### DIFF
--- a/src/MobileUI/Pages/NetworkPage.xaml
+++ b/src/MobileUI/Pages/NetworkPage.xaml
@@ -10,8 +10,8 @@
              x:Class="SSW.Rewards.Mobile.Pages.NetworkPage"
              x:Name="Networking"
              HideSoftInputOnTapped="True">
-    <Grid RowDefinitions="45, *" Padding="15,10, 15, 0" RowSpacing="15">
-        <Grid RowDefinitions="45">
+    <Grid RowDefinitions="45, *" Padding="0,10, 0, 0" RowSpacing="15">
+        <Grid RowDefinitions="45" Margin="15,0">
             <controls:SegmentedControl
                 Grid.Row="0"
                 Segments="{Binding Segments}"
@@ -26,68 +26,68 @@
         <RefreshView
             Command="{Binding RefreshNetworkCommand}"
             IsRefreshing="{Binding IsRefreshing}"
+            Margin="10,0"
             Grid.Row="1">
             <CollectionView
-            ItemsSource="{Binding SearchResults}"
-            ItemsUpdatingScrollMode="KeepItemsInView"
-            ItemSizingStrategy="{OnPlatform iOS='MeasureFirstItem', Android='MeasureAllItems'}"
-            IsVisible="True"
-            >
+                ItemsSource="{Binding SearchResults}"
+                ItemsUpdatingScrollMode="KeepItemsInView"
+                ItemSizingStrategy="{OnPlatform iOS='MeasureFirstItem', Android='MeasureAllItems'}"
+                IsVisible="True">
                 <CollectionView.ItemsLayout>
                     <GridItemsLayout Orientation="Vertical"
-                                     Span="3"
-                                     HorizontalItemSpacing="10"
-                                     VerticalItemSpacing="10"/>
+                                     Span="3"/>
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="users:NetworkProfileDto">
-                        <Border
-                            BackgroundColor="{StaticResource MainBackground}"
-                            Stroke="{StaticResource MainBackground}"
-                            StrokeShape="RoundRectangle 10,10,10,10 ">
-                            <Grid RowDefinitions="Auto, *" RowSpacing="5">
-                                <Grid.GestureRecognizers>
-                                    <TapGestureRecognizer NumberOfTapsRequired="1"
-                                      Command="{Binding Source={x:Reference Networking}, Path=BindingContext.UserTappedCommand}"
-                                      CommandParameter="{Binding  .}" />
-                                </Grid.GestureRecognizers>
-                                <Grid>
-                                    <Label
-                                        Grid.Row="0"
-                                        Padding="0,5,5,0"
-                                        Text="&#xf029;"
-                                        TextColor="{StaticResource Scanned}"
-                                        FontFamily="FA6Solid"
-                                        HorizontalOptions="End"
-                                        FontSize="10"
-                                        IsVisible="{Binding Scanned}"
-                                    />
-                                    <mct:AvatarView
-                                        ImageSource="{Binding ProfilePicture}"
-                                        WidthRequest="65"
-                                        HeightRequest="65"
-                                        CornerRadius="60"
-                                        Margin="0,15,0,0"
-                                        BorderWidth="2" />
+                        <Grid Padding="5,0,5,10">
+                            <Border
+                                BackgroundColor="{StaticResource MainBackground}"
+                                Stroke="{StaticResource MainBackground}"
+                                StrokeShape="RoundRectangle 10,10,10,10 ">
+                                <Grid RowDefinitions="Auto, *" RowSpacing="5">
+                                    <Grid.GestureRecognizers>
+                                        <TapGestureRecognizer NumberOfTapsRequired="1"
+                                          Command="{Binding Source={x:Reference Networking}, Path=BindingContext.UserTappedCommand}"
+                                          CommandParameter="{Binding  .}" />
+                                    </Grid.GestureRecognizers>
+                                    <Grid>
+                                        <Label
+                                            Grid.Row="0"
+                                            Padding="0,5,5,0"
+                                            Text="&#xf029;"
+                                            TextColor="{StaticResource Scanned}"
+                                            FontFamily="FA6Solid"
+                                            HorizontalOptions="End"
+                                            FontSize="10"
+                                            IsVisible="{Binding Scanned}"
+                                        />
+                                        <mct:AvatarView
+                                            ImageSource="{Binding ProfilePicture}"
+                                            WidthRequest="65"
+                                            HeightRequest="65"
+                                            CornerRadius="60"
+                                            Margin="0,15,0,0"
+                                            BorderWidth="2" />
+                                    </Grid>
+                                    <VerticalStackLayout
+                                        Grid.Row="2"
+                                        Margin="10,5,10,15"
+                                        Spacing="3">
+                                        <Label
+                                            VerticalTextAlignment="Center"
+                                            HorizontalTextAlignment="Center"
+                                            FontSize="11"
+                                            Style="{StaticResource LabelBold}"
+                                            Text="{Binding Name}" />
+                                        <Label
+                                            VerticalTextAlignment="End"
+                                            HorizontalTextAlignment="Center"
+                                            FontSize="9"
+                                            Text="{Binding Title}" />
+                                    </VerticalStackLayout>
                                 </Grid>
-                                <VerticalStackLayout
-                                    Grid.Row="2"
-                                    Margin="10,5,10,15"
-                                    Spacing="3">
-                                    <Label
-                                        VerticalTextAlignment="Center"
-                                        HorizontalTextAlignment="Center"
-                                        FontSize="11"
-                                        Style="{StaticResource LabelBold}"
-                                        Text="{Binding Name}" />
-                                    <Label
-                                        VerticalTextAlignment="End"
-                                        HorizontalTextAlignment="Center"
-                                        FontSize="9"
-                                        Text="{Binding Title}" />
-                                </VerticalStackLayout>
-                            </Grid>
-                        </Border>
+                            </Border>
+                        </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #915

> 2. What was changed?

There's an issue where setting ItemSpacing on CollectionView results in a large gap at the bottom of the collection. We've had to work around this on other pages by removing the spacing and using margins/paddings on the individual items. This brings that fix to the Network page.

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/7b54a03c-129a-42f7-aa40-a26502bca0e1" width="400" />

**❌ Figure: The Network page has a large gap at the bottom**

<img src="https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/eccd7ec4-7ac7-4c16-bbd3-b9b07dc5ac0b" width="400" />

**✅ Figure: Gap has been removed**

> 3. Did you do pair or mob programming?

No

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->