### PR TITLE
🐛 Mobile | Fix odd animation when Settings page closed on iOS

### DIFF
--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -16,6 +16,9 @@
                         Margin="0"
                         BackgroundColor="{StaticResource Background}"
                         x:DataType="vm:TopBarViewModel">
+                <!-- Wrapping AvatarView in a Grid where IsVisible can be toggled to work around 
+                     an odd animation that happens on iOS
+                     See bug: https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/918 -->
                 <Grid IsVisible="{Binding ShowAvatar}"
                       Margin="10,7,10,5"
                       HeightRequest="40"

--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -16,18 +16,22 @@
                         Margin="0"
                         BackgroundColor="{StaticResource Background}"
                         x:DataType="vm:TopBarViewModel">
-                <mct:AvatarView ImageSource="{Binding ProfilePic}"
-                                HeightRequest="40"
-                                WidthRequest="40"
-                                CornerRadius="20"
-                                BorderColor="White"
-                                BorderWidth="2"
-                                Margin="10,7,10,5"
-                                IsVisible="{Binding ShowAvatar}">
-                    <mct:AvatarView.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ToggleFlyoutCommand}" />
-                    </mct:AvatarView.GestureRecognizers>
-                </mct:AvatarView>
+                <Grid IsVisible="{Binding ShowAvatar}"
+                      Margin="10,7,10,5"
+                      HeightRequest="40"
+                      WidthRequest="40">
+                    <mct:AvatarView ImageSource="{Binding ProfilePic}"
+                                    HeightRequest="40"
+                                    WidthRequest="40"
+                                    CornerRadius="20"
+                                    BorderColor="White"
+                                    BorderWidth="2">
+                        <mct:AvatarView.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ToggleFlyoutCommand}" />
+                        </mct:AvatarView.GestureRecognizers>
+                    </mct:AvatarView>
+                </Grid>
+
 
                 <Button
                     HeightRequest="40"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #918 

> 2. What was changed?

Fixes the weird animation when closing the Settings page on iOS by nesting the AvatarView in an outer element that contains the IsVisible flag. Seems like it's an issue with the sizing of the AvatarView when IsVisible is toggled on the element itself.


https://github.com/SSWConsulting/SSW.Rewards.Mobile/assets/11418832/0e17c03b-a7b0-4fc7-87ef-adfec7b5187f

**✅ Video: The issue is no longer happening**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->