### PR TITLE
♻️ Mobile | Improve code input when answering quizzes

### DIFF
--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -116,7 +116,8 @@
                                 AutoSize="TextChanges"
                                 Text="{Binding CurrentQuestion.Answer}"
                                 MinimumHeightRequest="150"
-                                Placeholder="Enter your answer here">
+                                Placeholder="Enter your answer here"
+                                Keyboard="Plain">
                                 <Editor.Behaviors>
                                     <toolkit:EventToCommandBehavior
                                         x:TypeArguments="TextChangedEventArgs"

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using SSW.Rewards.Mobile.Controls;
 using System.Collections.ObjectModel;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -280,7 +281,15 @@ namespace SSW.Rewards.Mobile.ViewModels
         [RelayCommand]
         private void AnswerChanged(TextChangedEventArgs args)
         {
-            CurrentQuestion.Answer = args.NewTextValue;
+            // Replace special characters due to Smart Punctuation on the keyboard
+            StringBuilder sb = new(args.NewTextValue);
+            sb.Replace("—", "--");
+            sb.Replace("‘", "'");
+            sb.Replace("’", "'");
+            sb.Replace("“", "\"");
+            sb.Replace("”", "\"");
+
+            CurrentQuestion.Answer = sb.ToString();
         }
     }
 

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using SSW.Rewards.Mobile.Controls;
 using System.Collections.ObjectModel;
-using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -281,15 +280,7 @@ namespace SSW.Rewards.Mobile.ViewModels
         [RelayCommand]
         private void AnswerChanged(TextChangedEventArgs args)
         {
-            // Replace special characters due to Smart Punctuation on the keyboard
-            StringBuilder sb = new(args.NewTextValue);
-            sb.Replace("—", "--");
-            sb.Replace("‘", "'");
-            sb.Replace("’", "'");
-            sb.Replace("“", "\"");
-            sb.Replace("”", "\"");
-
-            CurrentQuestion.Answer = sb.ToString();
+            CurrentQuestion.Answer = args.NewTextValue;
         }
     }
 

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -78,6 +78,8 @@ public static class MauiProgram
         Microsoft.Maui.Handlers.EditorHandler.Mapper.AppendToMapping(nameof(Editor), (handler, editor) =>
         {
             handler.PlatformView.TintColor = UIKit.UIColor.FromRGB(204,65,65);
+            handler.PlatformView.SmartDashesType = UIKit.UITextSmartDashesType.No;
+            handler.PlatformView.SmartQuotesType = UIKit.UITextSmartQuotesType.No;
         });
 
         Microsoft.Maui.Handlers.EntryHandler.Mapper.AppendToMapping(nameof(Entry), (handler, editor) =>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #925 

> 2. What was changed?

1. Sets the keyboard to "Plain" on the Editor for quizzes to make it easier to input code without autocorrect getting in the way.
2. Replaces special characters like em dashes and curly quotes in the inputted text as the keyboard's Smart Punctuation can insert these and cause issues when code is expected, like in the linked issue.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->