### PR TITLE
🐛 Mobile | Improve iOS QR code scanning on newer devices

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanPage.xaml
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml
@@ -8,7 +8,7 @@
     <Grid>
         <zx:CameraBarcodeReaderView x:Name="scannerView"
                                     BarcodesDetected="Handle_OnScanResult"
-                                    IsDetecting="{Binding BarcodeReaderOptions, Source={x:Reference this}}"/>
+                                    Options="{Binding BarcodeReaderOptions, Source={x:Reference this}}"/>
 
         <Button Text="Close"
                 ContentLayout="Right, 10"

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml
@@ -8,7 +8,7 @@
     <Grid>
         <zx:CameraBarcodeReaderView x:Name="scannerView"
                                     BarcodesDetected="Handle_OnScanResult"
-                                    IsDetecting="True"/>
+                                    IsDetecting="{Binding BarcodeReaderOptions, Source={x:Reference this}}"/>
 
         <Button Text="Close"
                 ContentLayout="Right, 10"

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -95,7 +95,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         var focusDistance = captureDevice.MinimumFocusDistance.ToInt32();
         var deviceFieldOfView = captureDevice.ActiveFormat.VideoFieldOfView;
         const float previewFillPercentage = 0.6f; // fill 60% of preview window
-        const float minimumTargetObjectSize = 140.0f; // min width 140mm
+        const float minimumTargetObjectSize = 400.0f; // min width 400mm
         double radians = Double.DegreesToRadians(deviceFieldOfView);
         const float filledTargetObjectSize = minimumTargetObjectSize / previewFillPercentage;
         double minimumSubjectDistance = filledTargetObjectSize / Math.Tan(radians / 2.0); // Field of view

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -69,7 +69,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         {
             scannerView.IsDetecting = true;
             FlipCameras();
-            SetIosCameraZoom();
+            SetCameraZoom();
         }
         else
         {
@@ -77,7 +77,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         }
     }
     
-    private async void SetIosCameraZoom()
+    private async void SetCameraZoom()
     {
 #if IOS15_0_OR_GREATER
         // Delay is required to ensure the camera is ready

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -95,7 +95,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         var focusDistance = captureDevice.MinimumFocusDistance.ToInt32();
         var deviceFieldOfView = captureDevice.ActiveFormat.VideoFieldOfView;
         const float previewFillPercentage = 0.6f; // fill 60% of preview window
-        const float minimumTargetObjectSize = 400.0f; // min width 400mm
+        const float minimumTargetObjectSize = 40.0f; // min width 40mm
         double radians = Double.DegreesToRadians(deviceFieldOfView);
         const float filledTargetObjectSize = minimumTargetObjectSize / previewFillPercentage;
         double minimumSubjectDistance = filledTargetObjectSize / Math.Tan(radians / 2.0); // Field of view

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -86,8 +86,10 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         await Task.Delay(300);
         
         // Set camera zoom depending on device's minimum focus distance as per Apple's recommendation
+        // for scanning barcodes.
         // Adapted from https://stackoverflow.com/questions/74381985/choosing-suitable-camera-for-barcode-scanning-when-using-avcapturedevicetypebuil
         // and https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces?language=objc
+        //
         // Example final VideoZoomFactors:
         // iPhone 15 Pro (20cm focus distance): ~2.0
         // iPhone 14 Pro (~15cm focus distance): ~1.5

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -50,7 +50,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         WeakReferenceMessenger.Default.Unregister<EnableScannerMessage>(this);
     }
 
-    protected override async void OnAppearing()
+    protected override void OnAppearing()
     {
         base.OnAppearing();
         WeakReferenceMessenger.Default.Register(this);
@@ -88,7 +88,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         // Set camera zoom depending on device's minimum focus distance as per Apple's recommendation
         // for scanning barcodes.
         // Adapted from https://stackoverflow.com/questions/74381985/choosing-suitable-camera-for-barcode-scanning-when-using-avcapturedevicetypebuil
-        // and https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces?language=objc
+        // and https://forums.developer.apple.com/forums/thread/715568
         //
         // Example final VideoZoomFactors:
         // iPhone 15 Pro (20cm focus distance): ~2.0

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using AVFoundation;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Mopups.Services;
@@ -70,10 +69,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         {
             scannerView.IsDetecting = true;
             FlipCameras();
-            
-#if IOS15_0_OR_GREATER
             SetIosCameraZoom();
-#endif
         }
         else
         {
@@ -83,6 +79,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
     
     private async void SetIosCameraZoom()
     {
+#if IOS15_0_OR_GREATER
         // Delay is required to ensure the camera is ready
         await Task.Delay(300);
         
@@ -94,7 +91,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         // Example final VideoZoomFactors:
         // iPhone 15 Pro (20cm focus distance): ~2.0
         // iPhone 14 Pro (~15cm focus distance): ~1.5
-        var captureDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
+        var captureDevice = AVFoundation.AVCaptureDevice.GetDefaultDevice(AVFoundation.AVMediaTypes.Video);
         var focusDistance = captureDevice.MinimumFocusDistance.ToInt32();
         var deviceFieldOfView = captureDevice.ActiveFormat.VideoFieldOfView;
         const float previewFillPercentage = 0.6f; // fill 60% of preview window
@@ -109,6 +106,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
             captureDevice.VideoZoomFactor = (float)(focusDistance / minimumSubjectDistance);
             captureDevice.UnlockForConfiguration();
         }
+#endif
     }
 
     /// <summary>

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -70,6 +70,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         {
             scannerView.IsDetecting = true;
             FlipCameras();
+            
 #if IOS15_0_OR_GREATER
             SetIosCameraZoom();
 #endif

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -89,8 +89,9 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         // and https://forums.developer.apple.com/forums/thread/715568
         //
         // Example final VideoZoomFactors:
-        // iPhone 15 Pro (20cm focus distance): ~2.0
-        // iPhone 14 Pro (~15cm focus distance): ~1.5
+        // iPhone 14 Pro and 15 Pro (20cm focus distance): ~2.0
+        // iPhone 13 Pro (~15cm focus distance): ~1.5
+        // iPhone 12 and below: 1.0 - ~1.2
         var captureDevice = AVFoundation.AVCaptureDevice.GetDefaultDevice(AVFoundation.AVMediaTypes.Video);
         var focusDistance = captureDevice.MinimumFocusDistance.ToInt32();
         var deviceFieldOfView = captureDevice.ActiveFormat.VideoFieldOfView;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Part of #948

> 2. What was changed?

Newer iPhones have a larger minimum focus distance on the default camera, meaning to scan a QR code the user will need to move their phone farther away to get focus. Apple has example code for handling this (https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces?language=objc), which involves using the device's MinimumFocusDistance value to calculate the appropriate zoom level required to adequately focus on a subject at a certain percentage of the viewfinder, which is adapted here. Also see code here https://forums.developer.apple.com/forums/thread/715568

Note that the current QR code scanning library is limited and doesn't allow features like changing lenses or adjusting focus modes, meaning something like this is more of a workaround (we can only adjust the zoom when the library has started a capture session). A better solution here would probably be to move to a better library, but more work would be required for that. One that looks good is https://github.com/afriscic/BarcodeScanning.Native.Maui

It's also important to note that scanning will still require keeping newer iPhones some distance from the QR code to scan, so if it's out of focus the user will need to move back until it's in focus. But the increased zoom should make the code detection work better here.

> 3. Did you do pair or mob programming?

No 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->