### PR TITLE
♻️ Mobile | Enlarge QR code on redemptions

### DIFF
--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -56,45 +56,48 @@
                 StrokeThickness="1"
                 StrokeShape="RoundRectangle 10"
                 BackgroundColor="{StaticResource Background}">
-                <Grid>
-                    <ScrollView>
+                <Grid RowDefinitions="Auto">
+                    <ScrollView Grid.Row="0">
                         <VerticalStackLayout>
-                            <Border HeightRequest="80"
+                            <!-- Header section -->
+                            <VerticalStackLayout IsVisible="{Binding IsHeaderVisible}">
+                                <Border HeightRequest="80"
                                     WidthRequest="80"
                                     BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                                     StrokeThickness="0"
                                     StrokeShape="RoundRectangle 6"
                                     Margin="0,0,0,30">
-                                <Grid>
-                                    <Image HorizontalOptions="Center"
-                                           VerticalOptions="Center"
-                                           Aspect="AspectFill"
-                                           Source="{Binding Image}"
-                                           IsVisible="{Binding Image, Converter={StaticResource IsStringNotNullOrEmpty}}" />
-                                    <Label FontFamily="FA6Solid"
-                                           FontAutoScalingEnabled="False"
-                                           VerticalOptions="Center"
-                                           HorizontalOptions="Center"
-                                           Text="&#xf06b;"
-                                           TextColor="{StaticResource Gray300}"
-                                           FontSize="28"
-                                           IsVisible="{Binding Image, Converter={StaticResource IsStringNullOrEmpty}}" />
-                                </Grid>
-                            </Border>
+                                    <Grid>
+                                        <Image HorizontalOptions="Center"
+                                               VerticalOptions="Center"
+                                               Aspect="AspectFill"
+                                               Source="{Binding Image}"
+                                               IsVisible="{Binding Image, Converter={StaticResource IsStringNotNullOrEmpty}}" />
+                                        <Label FontFamily="FA6Solid"
+                                               FontAutoScalingEnabled="False"
+                                               VerticalOptions="Center"
+                                               HorizontalOptions="Center"
+                                               Text="&#xf06b;"
+                                               TextColor="{StaticResource Gray300}"
+                                               FontSize="28"
+                                               IsVisible="{Binding Image, Converter={StaticResource IsStringNullOrEmpty}}" />
+                                    </Grid>
+                                </Border>
 
-                            <Label Text="{Binding Heading}"
-                                   FontSize="24"
-                                   HorizontalOptions="Center"
-                                   HorizontalTextAlignment="Center"
-                                   Style="{StaticResource LabelBold}" />
+                                <Label Text="{Binding Heading}"
+                                       FontSize="24"
+                                       HorizontalOptions="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Style="{StaticResource LabelBold}" />
 
-                            <Label Text="{Binding Description}"
-                                   FontSize="18"
-                                   TextColor="{StaticResource Gray300}"
-                                   HorizontalOptions="Center"
-                                   HorizontalTextAlignment="Center"
-                                   Margin="0,0,0,30" />
-
+                                <Label Text="{Binding Description}"
+                                       FontSize="18"
+                                       TextColor="{StaticResource Gray300}"
+                                       HorizontalOptions="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Margin="0,0,0,30" />
+                            </VerticalStackLayout>
+                            
                             <!-- Balance section -->
                             <Grid RowDefinitions="Auto,Auto"
                                   ColumnDefinitions="Auto,Auto"
@@ -159,22 +162,21 @@
                             </Grid>
 
                             <!-- Pending redemption QR code -->
-                            <VerticalStackLayout IsVisible="{Binding IsQrCodeVisible}"
-                                                 Spacing="10"
-                                                 Margin="0,0,0,30">
-                                <Label Text="Please show this code to SSW staff to claim your reward:"
+                            <Grid IsVisible="{Binding IsQrCodeVisible}"
+                                                 RowSpacing="10"
+                                                 Margin="0,0,0,30"
+                                                 RowDefinitions="Auto,Auto">
+                                <Label Grid.Row="0"
+                                       Text="Please show this code to SSW staff to claim your reward:"
                                        HorizontalOptions="Center"
                                        HorizontalTextAlignment="Center"/>
-                                <zxing:BarcodeGeneratorView
-                                                         Format="QrCode"
-                                                         Value="{Binding QrCode}"
-                                                         HorizontalOptions="Center"
-                                                         BackgroundColor="#DDDDDD"
-                                                         ForegroundColor="Transparent"
-                                                         WidthRequest="150"
-                                                         HeightRequest="150"
-                                                         VerticalOptions="Center"/>
-                            </VerticalStackLayout>
+                                <zxing:BarcodeGeneratorView Grid.Row="1"
+                                                            Format="QrCode"
+                                                            Value="{Binding QrCode}"
+                                                            WidthRequest="250"
+                                                            HeightRequest="250"
+                                                            VerticalOptions="Center"/>
+                            </Grid>
 
                             <!-- Address search -->
                             <VerticalStackLayout IsVisible="{Binding IsAddressVisible}"
@@ -359,6 +361,7 @@
                     </ScrollView>
 
                     <ActivityIndicator
+                        Grid.Row="0"
                         HorizontalOptions="Center"
                         VerticalOptions="Center"
                         Color="{StaticResource SSWRed}"

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml.cs
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml.cs
@@ -29,6 +29,7 @@ public partial class RedeemRewardPage
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
+        _viewModel.OnDisappearing();
         if (_viewModel.ShouldCallCallback)
             CallbackEvent?.Invoke(this, EventArgs.Empty);
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#968 

> 2. What was changed?

Updates the redeem in-person QR code to be larger and to also increase the screen's brightness to make it easier to scan.

<img src="https://github.com/user-attachments/assets/eeedcc0b-c06e-48fa-a506-7fe7e81e67cd" width="400" />


**Figure: Redemptions QR code is much larger**


> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->