### PR TITLE
🐛 Mobile | Fix Confirm button being cut off

### DIFF
--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -333,7 +333,6 @@
                                                  Spacing="15">
                                 <Button Background="{StaticResource SSWRed}"
                                         CornerRadius="10"
-                                        WidthRequest="80"
                                         IsVisible="{Binding ConfirmEnabled}"
                                         Text="Confirm"
                                         FontAttributes="Bold"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #952 

> 2. What was changed?

Removes a set width on the Confirm button on the shipping modal to fix the text being cut off

<img src="https://github.com/user-attachments/assets/9e8cb8db-be11-4c05-aba1-2ec2d85b91eb" width="400" />

**Figure: Confirm button now shows correctly**

> 3. Did you do pair or mob programming?

No

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->