### PR TITLE
🐛 Mobile | Fix quiz alert not showing and shorten timeout

### DIFF
--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -183,7 +183,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                 maxAttempts--;
                 var completion = await _quizService.CheckQuizCompletion(_submissionId);
 
-                if (completion == null || maxAttempts == 0)
+                if (completion == null || (completion == false && maxAttempts == 0))
                 {
                     return false;
                 }

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -155,9 +155,9 @@ namespace SSW.Rewards.Mobile.ViewModels
 
                 if (!isComplete)
                 {
-                    await App.Current.MainPage.DisplayAlert("Pending Results", $"Your quiz results are still being processed. Please try again.", "OK");
                     IsBusy = false;
                     await MopupService.Instance.RemovePageAsync(popup);
+                    await App.Current.MainPage.DisplayAlert("Pending Results", $"Your quiz results are still being processed. Please try again soon.", "OK");
                     return;
                 }
 
@@ -174,7 +174,7 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         private async Task<bool> AwaitQuizCompletion()
         {
-            var maxAttempts = 100;
+            var maxAttempts = 30;
             var delay = 2000;
             bool isComplete = false;
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing the app

> 2. What was changed?

Fixes a small bug where if the quiz result check times out it can get stuck as the popup never closes.
Also shortens the timeout.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->