### PR TITLE
🐛 CI/CD | Pin to Android SDK 34.0.95

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
           dotnet workload install maui --ignore-failed-sources
-          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json
+          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file ./rollback.json
 
       - name: Restore Dependencies
         run: |

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install MAUI Workload
         run: |
           dotnet nuget locals all --clear
-          dotnet workload install maui --ignore-failed-sources
+          dotnet workload install maui --ignore-failed-sources --from-rollback-file rollback.json
           dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file rollback.json
 
       - name: Restore Dependencies

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
           dotnet workload install maui --ignore-failed-sources
-          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file ./rollback.json
+          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file rollback.json
 
       - name: Restore Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
           dotnet workload install maui --ignore-failed-sources
-          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file ./rollback.json
+          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file rollback.json
 
       - name: Restore Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
           dotnet workload install maui --ignore-failed-sources
-          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json
+          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file ./rollback.json
 
       - name: Restore Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install MAUI Workload
         run: |
           dotnet nuget locals all --clear
-          dotnet workload install maui --ignore-failed-sources
+          dotnet workload install maui --ignore-failed-sources --from-rollback-file rollback.json
           dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file rollback.json
 
       - name: Restore Dependencies

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Install MAUI Workload
         run: |
           dotnet nuget locals all --clear
-          dotnet workload install maui --ignore-failed-sources
-          dotnet workload install ios maui wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources
+          dotnet workload install maui --ignore-failed-sources --from-rollback-file rollback.json
+          dotnet workload install ios maui wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources --from-rollback-file rollback.json
 
       - name: Set XCode Version
         if: runner.os == 'macOS'

--- a/rollback.json
+++ b/rollback.json
@@ -1,0 +1,3 @@
+{
+  "microsoft.net.sdk.android": "34.0.95/8.0.100"
+}


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#995 

> 2. What was changed?

Creates a rollback.json file to pin the Android SDK to a previous version, as the current one might be causing a crash. See https://github.com/dotnet/android/issues/9039

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->