### PR TITLE
Adds a button to copy basic achievement details to clipboard.

### DIFF
--- a/src/AdminUI/Components/Dialogs/Achievements/AchievementEditDialog.razor
+++ b/src/AdminUI/Components/Dialogs/Achievements/AchievementEditDialog.razor
@@ -1,18 +1,22 @@
-@using Microsoft.AspNetCore.Components
 @using SSW.Rewards.Admin.UI.Components.Dialogs.Confirmations
 @using SSW.Rewards.Admin.UI.Models.Interfaces
 @using SSW.Rewards.Enums
 @using SSW.Rewards.Shared.DTOs.Achievements
 @using SSW.Rewards.Shared.DTOs.Leaderboard
 @using SSW.Rewards.ApiClient.Services
+@using Icons = MudBlazor.Icons
 
 @inject ILeaderboardService leaderboardService
 @inject IDialogService DialogService
+@inject IJSRuntime JsRuntime
 
 <MudDialog>
     <TitleContent>
         <div class="d-flex justify-center">
             <AdminQRCode Height="200" QRCodeString="@dto.Code"/>
+        </div>
+        <div class="d-flex justify-center">
+            <MudButton StartIcon="@Icons.TwoTone.CopyAll" OnClick="CopyToClipboard">Copy details</MudButton>
         </div>
     </TitleContent>
     <DialogContent>
@@ -115,5 +119,11 @@
         {
             AchievementId = dto.Id
         }));
+    }
+
+    async Task CopyToClipboard()
+    {
+        var achievementDetails = $"Achievement: {dto.Name} - {dto.Value} points";
+        await JsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", achievementDetails);
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #980 

> 2. What was changed?

Adds a Copy Details button to the Achievement Edit modal. Copies the Achievement name and the value of the achievement.

Does NOT copy the Achievement QR Code, as that can already be done by **Right Clicking | Copy Image** 

![image](https://github.com/user-attachments/assets/b56d6200-dd89-4a8f-afee-eb3ad9ce858d)

> 3. Did you do pair or mob programming?

✏️ 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->