### PR TITLE
♻️ Mobile | Hide zoom buttons on camera if not zoomable

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanPage.xaml
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml
@@ -2,11 +2,22 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:scanner="clr-namespace:BarcodeScanning;assembly=BarcodeScanning.Native.Maui"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              BackgroundColor="{StaticResource Background}"
              x:Class="SSW.Rewards.Mobile.Pages.ScanPage"
              x:Name="this">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <x:Single x:Key="Threshold">1</x:Single>
+
+            <toolkit:CompareConverter
+                x:Key="GreaterThanOne"
+                ComparisonOperator="Greater"
+                ComparingValue="{StaticResource Threshold}" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <Grid>
-        <scanner:CameraView x:Name="scannerView"
+        <scanner:CameraView x:Name="ScannerView"
                             OnDetectionFinished="Handle_OnScanResult"
                             BarcodeSymbologies="QRCode"
                             ViewfinderMode="True"
@@ -32,8 +43,10 @@
         <Grid VerticalOptions="End"
               RowDefinitions="Auto,*">
             <Grid Grid.Row="0"
+                  x:Name="ZoomButtons"
                   ColumnDefinitions="Auto,Auto"
                   HorizontalOptions="Center"
+                  IsVisible="{Binding MaxZoomFactor, Converter={StaticResource GreaterThanOne}, Source={x:Reference ScannerView}, Path=MaxZoomFactor}"
                   ColumnSpacing="40">
                 <Button Grid.Column="0"
                         CornerRadius="30"

--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -24,7 +24,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         // the handler is called on a thread-pool thread
         App.Current.Dispatcher.Dispatch(() =>
         {
-            if (!scannerView.CameraEnabled || e.BarcodeResults.Length == 0)
+            if (!ScannerView.CameraEnabled || e.BarcodeResults.Length == 0)
             {
                 return;
             }
@@ -43,9 +43,9 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
         base.OnDisappearing();
         
         // Reset zoom when exiting camera
-        if (scannerView.CurrentZoomFactor > -1)
+        if (ScannerView.CurrentZoomFactor > -1)
         {
-            scannerView.RequestZoomFactor = scannerView.MinZoomFactor;
+            ScannerView.RequestZoomFactor = ScannerView.MinZoomFactor;
         }
         
         ToggleScanner(false);
@@ -69,7 +69,7 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
 
     private void ToggleScanner(bool toggleOn)
     {
-        scannerView.CameraEnabled = toggleOn;
+        ScannerView.CameraEnabled = toggleOn;
     }
     
     [RelayCommand]
@@ -85,18 +85,18 @@ public partial class ScanPage : IRecipient<EnableScannerMessage>
     private void ZoomIn()
     {
         // CurrentZoomFactor can default to -1, so we start at the MinZoomFactor in this case
-        var currentZoom = Math.Max(scannerView.CurrentZoomFactor, scannerView.MinZoomFactor);
-        var maxZoom = scannerView.MaxZoomFactor;
+        var currentZoom = Math.Max(ScannerView.CurrentZoomFactor, ScannerView.MinZoomFactor);
+        var maxZoom = ScannerView.MaxZoomFactor;
         
-        scannerView.RequestZoomFactor = Math.Min(currentZoom + ZoomFactorStep, maxZoom);
+        ScannerView.RequestZoomFactor = Math.Min(currentZoom + ZoomFactorStep, maxZoom);
     }
     
     [RelayCommand]
     private void ZoomOut()
     {
-        var currentZoom = scannerView.CurrentZoomFactor;
-        var minZoom = scannerView.MinZoomFactor;
+        var currentZoom = ScannerView.CurrentZoomFactor;
+        var minZoom = ScannerView.MinZoomFactor;
         
-        scannerView.RequestZoomFactor = Math.Max(currentZoom - ZoomFactorStep, minZoom);
+        ScannerView.RequestZoomFactor = Math.Max(currentZoom - ZoomFactorStep, minZoom);
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

Shows/hides the zoom buttons on the scanner depending on whether the user's device is capable of zoom or not.
Also cleans up the naming of the current scanner view variable.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->