### PR TITLE
🐛 Mobile | Show correct bundle name on iOS

### DIFF
--- a/src/MobileUI/Platforms/iOS/Info.plist
+++ b/src/MobileUI/Platforms/iOS/Info.plist
@@ -42,5 +42,9 @@
 	</array>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
+	<key>CFBundleName</key>
+	<string>SSW Rewards</string>
+	<key>CFBundleDisplayName</key>
+	<string>SSW Rewards</string>
 </dict>
 </plist>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1014 

> 2. What was changed?

Updates the info.plist with the bundle name "SSW Rewards" so the auth popup no longer shows "MobileUI" 

<img src="https://github.com/user-attachments/assets/a433f254-1a68-45ca-a51e-c754d1a8ba23" width="400" />

**✅ Figure: Popup now shows "SSW Rewards"**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->