### PR TITLE
🐛 Mobile | Fix crash on carousels

### DIFF
--- a/src/MobileUI/Features/Quiz/QuizViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizViewModel.cs
@@ -24,9 +24,9 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
     [ObservableProperty]
     private int _carouselPosition;
 
-    public ObservableCollection<QuizItemViewModel> Quizzes { get; set; } = new ();
+    public ObservableRangeCollection<QuizItemViewModel> Quizzes { get; set; } = [];
 
-    public ObservableCollection<QuizItemViewModel> CarouselQuizzes { get; set; } = new ();
+    public ObservableRangeCollection<QuizItemViewModel> CarouselQuizzes { get; set; } = [];
 
     public QuizViewModel(IQuizService quizService)
     {
@@ -52,24 +52,32 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
 
     private async Task UpdateQuizzes()
     {
-        var quizzes = await _quizService.GetQuizzes();
-        
-        Quizzes.Clear();
-        CarouselQuizzes.Clear();
         _timer.Stop();
-
-        foreach (var quiz in quizzes)
-        {
-            var vm = new QuizItemViewModel(quiz);
-            Quizzes.Add(vm);
-
-            if (quiz.IsCarousel)
-            {
-                CarouselQuizzes.Add(vm);
-            }
-        }
+        
+        var quizzes = await _quizService.GetQuizzes();
+        var quizDtos = quizzes.ToList();
         
         CarouselPosition = 0;
+
+        var quizzesList = new List<QuizItemViewModel>();
+        var carouselQuizzesList = new List<QuizItemViewModel>();
+
+        foreach (var quiz in quizDtos)
+        {
+            var quizItem = new QuizItemViewModel(quiz);
+            if (quiz.IsCarousel)
+            {
+                carouselQuizzesList.Add(quizItem);
+            }
+            else
+            {
+                quizzesList.Add(quizItem);
+            }
+        }
+
+        Quizzes.ReplaceRange(quizzesList);
+        CarouselQuizzes.ReplaceRange(carouselQuizzesList);
+
         _timer.Start();
     }
     


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1016 

> 2. What was changed?

Updates ObservableCollection to ObservableRangeCollection on the carousel pages as updating the data on the carousel can cause it to crash in certain instances - particularly when the list is cleared and new items are being added when the carousel position might be changing. This also improves performance on these pages when reloading as the lists don't trigger change detection on every item added, and just updates in one hit.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->