### PR TITLE
🐛 API | Fix network query

### DIFF
--- a/src/Application/Network/Queries/GetNetworkProfileList/GetNetworkProfileListQuery.cs
+++ b/src/Application/Network/Queries/GetNetworkProfileList/GetNetworkProfileListQuery.cs
@@ -75,7 +75,9 @@ public class GetNetworkProfileListHandler : IRequestHandler<GetNetworkProfileLis
             }
             else
             {
-                userMatch = await _dbContext.Users.Include(u => u.Achievement).Where(u => u.Achievement != null)
+                userMatch = await _dbContext.Users
+                    .Include(u => u.Achievement)
+                    .Where(u => u.Achievement != null)
                     .FirstOrDefaultAsync(ua => ua.Achievement!.Id == scannedUserAchievement, cancellationToken: cancellationToken);
             }
             

--- a/src/Application/Network/Queries/GetNetworkProfileList/GetNetworkProfileListQuery.cs
+++ b/src/Application/Network/Queries/GetNetworkProfileList/GetNetworkProfileListQuery.cs
@@ -25,7 +25,7 @@ public class GetNetworkProfileListHandler : IRequestHandler<GetNetworkProfileLis
         var user = await _userService.GetCurrentUser(cancellationToken);
         int currentUserAchievementId;
         
-        // 1. Get all staff
+        // 1. Get all staff and get user's achievement
         var staff = await _dbContext.StaffMembers
             .Include(u => u.StaffAchievement)
             .Where(s => !s.IsDeleted && s.StaffAchievement != null)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1026

> 2. What was changed?

Currently the Network tab is returning incorrect data and crashing when tapping a user as the user ID isn't returned.

This fixes those issues by updating the query and making sure the ID is returned. Also fixes the Activity feed to use the correct Friends feed.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->