### PR TITLE
♻️ Mobile | Move ObservableCollections to ObservableRangeCollection

### DIFF
--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -10,12 +10,11 @@ public partial class LeaderboardViewModel : BaseViewModel
 {
     private int _myUserId;
 
-    private ILeaderService _leaderService;
+    private readonly ILeaderService _leaderService;
     private readonly IUserService _userService;
     private bool _loaded;
-
-    [ObservableProperty]
-    private ObservableCollection<LeaderViewModel> searchResults = new ();
+    
+    public ObservableRangeCollection<LeaderViewModel> SearchResults { get; set; } = [];
 
     public LeaderboardViewModel(ILeaderService leaderService, IUserService userService)
     {
@@ -144,7 +143,7 @@ public partial class LeaderboardViewModel : BaseViewModel
         var newList = new ObservableCollection<LeaderViewModel>(sortedLeaders);
         await App.Current.MainPage.Dispatcher.DispatchAsync(() =>
         {
-            SearchResults = newList;
+            SearchResults.ReplaceRange(newList);
         });
     }
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

Moves all ObservableCollections annotated with [ObservableProperty] to ObservableRangeCollection for better, more optimised collection handling.
Fixes up some of the handling on the activity page.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->