### PR TITLE
🐛 Mobile | Change LaunchMode to SingleTop to fix "Window was already created" issue

### DIFF
--- a/src/MobileUI/Platforms/Android/MainActivity.cs
+++ b/src/MobileUI/Platforms/Android/MainActivity.cs
@@ -10,7 +10,10 @@ using Color = Microsoft.Maui.Graphics.Color;
 
 namespace SSW.Rewards.Mobile;
 
-[Activity(Theme = "@style/MyTheme.Splash", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density, ScreenOrientation = ScreenOrientation.Portrait)]
+[Activity(Theme = "@style/MyTheme.Splash", MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
+                           ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density,
+    ScreenOrientation = ScreenOrientation.Portrait, LaunchMode = LaunchMode.SingleTop)]
 public class MainActivity : MauiAppCompatActivity
 {
     internal static readonly string Channel_ID = "General";


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #734 

> 2. What was changed?

Sets LaunchMode = SingleTop to fix an issue where the app could sometimes crash on Android when reopened from the background.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->