### PR TITLE
✨ Mobile | Increase prize image size

### DIFF
--- a/src/MobileUI/Features/BaseViewModel.cs
+++ b/src/MobileUI/Features/BaseViewModel.cs
@@ -12,4 +12,6 @@ public partial class BaseViewModel : ObservableObject
     string title = string.Empty;
 
     public INavigation Navigation { get; set; }
+    
+    public Page ViewPage { get; set; }
 }

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -61,8 +61,8 @@
                         <VerticalStackLayout>
                             <!-- Header section -->
                             <VerticalStackLayout IsVisible="{Binding IsHeaderVisible}">
-                                <Border HeightRequest="80"
-                                    WidthRequest="80"
+                                <Border HeightRequest="250"
+                                    WidthRequest="250"
                                     BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                                     StrokeThickness="0"
                                     StrokeShape="RoundRectangle 6"
@@ -163,7 +163,7 @@
 
                             <!-- Pending redemption QR code -->
                             <Grid IsVisible="{Binding IsQrCodeVisible}"
-                                                 RowSpacing="10"
+                                                 RowSpacing="20"
                                                  Margin="0,0,0,30"
                                                  RowDefinitions="Auto,Auto">
                                 <Label Grid.Row="0"
@@ -331,7 +331,7 @@
                             </Grid>
 
                             <VerticalStackLayout HorizontalOptions="Center"
-                                                 Spacing="15">
+                                                 Spacing="20">
                                 <Button Background="{StaticResource SSWRed}"
                                         CornerRadius="10"
                                         IsVisible="{Binding ConfirmEnabled}"
@@ -343,7 +343,23 @@
 
                                 <Button Background="{StaticResource SSWRed}"
                                         CornerRadius="10"
-                                        Text="Cancel redemption"
+                                        Text="Confirm Scanned"
+                                        FontAttributes="Bold"
+                                        VerticalOptions="Center"
+                                        HorizontalOptions="Center"
+                                        IsVisible="{Binding IsQrCodeVisible}"
+                                        Command="{Binding ClosePopupCommand}">
+                                    <Button.ImageSource>
+                                        <FontImageSource Glyph="&#xf00c;"
+                                                         FontFamily="FA6Solid"
+                                                         FontAutoScalingEnabled="True"
+                                                         Size="16"/>
+                                    </Button.ImageSource>
+                                </Button>
+                                
+                                <Button Background="{StaticResource SSWRed}"
+                                        CornerRadius="10"
+                                        Text="Cancel"
                                         FontAttributes="Bold"
                                         VerticalOptions="Center"
                                         HorizontalOptions="Center"

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml.cs
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml.cs
@@ -18,6 +18,7 @@ public partial class RedeemRewardPage
         _viewModel = viewModel;
         _reward = reward;
         BindingContext = _viewModel;
+        _viewModel.ViewPage = this;
     }
 
     protected override void OnAppearing()

--- a/src/MobileUI/Features/Redeem/RedeemRewardViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemRewardViewModel.cs
@@ -208,6 +208,12 @@ public partial class RedeemRewardViewModel(
     [RelayCommand]
     private async Task CancelPendingRedemptionClicked()
     {
+        var isConfirmed = await ViewPage.DisplayAlert("Cancel",
+            "Are you sure you want to cancel the pending redemption?", "Yes", "No");
+
+        if (!isConfirmed)
+            return;
+        
         IsBusy = true;
 
         await rewardService.CancelPendingRedemption(new CancelPendingRedemptionDto


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1027 

> 2. What was changed?

Increases the size of prizes images when a user tries to redeem it.

Also helps make redeeming in-person less confusing by adding a "confirm redeemed" button which the user can tap to close the window once the QR code has been scanned, so they shouldn't try cancelling.

<img src="https://github.com/user-attachments/assets/5d1e5011-b6e6-458f-831a-ae454821f6e6" width="400" />

**Figure: Image size is much larger and easier to see**

<img src="https://github.com/user-attachments/assets/5000a1d3-7e88-4698-98f6-9c062d7493fd" width="400" />

**Figure: Users should be less confused about the cancel button after getting their code scanned**

> 3. Did you do pair or mob programming?

No

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
