### PR TITLE
♻️ CI/CD | Update actions/upload-artifact and  actions/download-artifact to v4

### DIFF
--- a/.github/workflows/admin-build.yml
+++ b/.github/workflows/admin-build.yml
@@ -26,14 +26,14 @@ jobs:
           run: dotnet publish $PROJECT --no-build --configuration Release --output out
   
         - name: Upload a UI Artifact
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: ui
             path: out/wwwroot
             if-no-files-found: error
   
         - name: Upload a Infra Artifact
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: infra
             path: infra

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.bicep.outputs.storageAccountUrl }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Set appsettings.json
         if: ${{ inputs.environment == 'staging' }}

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -67,7 +67,7 @@ jobs:
           /p:AndroidSigningKeyAlias=${{ secrets.ANDROID_KEYSTOREALIAS }} `
           /p:AndroidSigningStorePass=${{ secrets.ANDROID_KEYSTOREPASSWORD }}
 
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts-android-${{ inputs.build_number }}
           path: |

--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: artifacts-android-${{ inputs.build_number }}
 

--- a/.github/workflows/api-az-deploy.yml
+++ b/.github/workflows/api-az-deploy.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Download artifacts from build
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
 
     # Log into Azure
     - name: Login

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -28,7 +28,7 @@ jobs:
       
       # api 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api
           path: ./api.zip
@@ -37,7 +37,7 @@ jobs:
 
       # infra
       - name: Upload Infra Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: infra
           path: ./infra

--- a/.github/workflows/az-deploy.yml
+++ b/.github/workflows/az-deploy.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Download artifacts from build
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
 
     # Log into Azure
     - name: Login

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -61,7 +61,7 @@ jobs:
         run: dotnet publish src/MobileUI/MobileUI.csproj -v:diag -f:net8.0-ios -c:Release /p:ArchiveOnBuild=true /p:RuntimeIdentifier=ios-arm64 /p:CodeSignKey="${{ secrets.APPLE_CERT_NAME }}" /p:CodesignProvision="${{ secrets.APPLE_PROFILE_NAME }}"
 
       - name: Upload iOS Artifact
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts-ios-${{ inputs.build_number }}
           path: | 

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: artifacts-ios-${{ inputs.build_number }}
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Failing workflows due to actions/upload-artifact and actions/download-artifact being deprecated.

> 2. What was changed?

Updates actions/upload-artifact and actions/download-artifact to the latest v4

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->