### PR TITLE
✨ Mobile | Update design of user stats in the flyout

### DIFF
--- a/src/MobileUI/Features/Flyout/FlyoutHeader.xaml
+++ b/src/MobileUI/Features/Flyout/FlyoutHeader.xaml
@@ -144,7 +144,7 @@
                 <Label Grid.Row="2"
                        HorizontalOptions="Center"
                        Style="{StaticResource LabelBold}"
-                       FontSize="16"
+                       FontSize="18"
                        TextColor="White"
                        Text="{Binding Path=Credits, StringFormat='{0:n0}'}" />
             </Grid>

--- a/src/MobileUI/Features/Flyout/FlyoutHeader.xaml
+++ b/src/MobileUI/Features/Flyout/FlyoutHeader.xaml
@@ -7,9 +7,10 @@
       xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
       HeightRequest="420"
       Margin="0"
-      Padding="20,0"
+      Padding="20,20"
       x:DataType="vm:FlyoutHeaderViewModel"
-      RowDefinitions="100,60,148,24,40">
+      RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+      RowSpacing="20">
     <Grid.BindingContext>
         <resolver:ResolveViewModel x:TypeArguments="vm:FlyoutHeaderViewModel"/>
     </Grid.BindingContext>
@@ -65,91 +66,88 @@
 
     <!-- User Stats -->
     <Grid Grid.Row="2"
-          RowSpacing="2"
-          RowDefinitions="40,40,40"
-          ColumnDefinitions="40,*">
+          ColumnSpacing="4"
+          RowDefinitions="Auto"
+          ColumnDefinitions="*,*,*">
         <Border Grid.Column="0"
                 Grid.Row="0"
                 BackgroundColor="{StaticResource RankingTableHeader}"
                 Stroke="{StaticResource RankingTableHeader}"
-                StrokeShape="RoundRectangle 4,0,4,0">
-            <Label VerticalOptions="Center"
-                   VerticalTextAlignment="Center"
-                   Margin="10,0,10,0"
-                   FontFamily="FA6Solid"
-                   TextColor="{StaticResource Coin}"
-                   Text="&#xf091;"/>
-        </Border>
-
-        <Border Grid.Column="1"
-                Grid.Row="0"
-                BackgroundColor="{StaticResource RankingTableBody}"
-                StrokeShape="RoundRectangle 0,4,0,4"
-                Padding="5">
-            <Label Style="{StaticResource LabelBold}"
-                   VerticalOptions="Center"
-                   VerticalTextAlignment="Center"
-                   FontSize="14"
-                   TextColor="White"
-                   Text="{Binding Path=Rank, StringFormat='#{0:n0}'}"/>
-        </Border>
-
-        <Border Grid.Column="0"
-                Grid.Row="1"
-                BackgroundColor="{StaticResource RankingTableHeader}"
-                Stroke="{StaticResource RankingTableHeader}"
-                StrokeShape="RoundRectangle 4,0,4,0">
-
-            <HorizontalStackLayout>
-                <Label VerticalOptions="Center"
-                       VerticalTextAlignment="Center"
-                       Margin="10,0,0,0"
+                StrokeShape="RoundRectangle 4">
+            <Grid RowSpacing="10" Margin="0,10" RowDefinitions="*,*,*">
+                <Label Grid.Row="0"
+                       HorizontalOptions="Center"
                        FontFamily="FA6Solid"
                        TextColor="{StaticResource Coin}"
+                       FontSize="18"
+                       Text="&#xf091;"/>
+                <Label Grid.Row="1"
+                       HorizontalOptions="Center"
+                       Style="{StaticResource LabelBold}"
+                       TextColor="{StaticResource Gray200}"
+                       FontSize="14"
+                       Text="Ranking"/>
+                <Label Grid.Row="2"
+                       HorizontalOptions="Center"
+                       Style="{StaticResource LabelBold}"
+                       FontSize="18"
+                       TextColor="White"
+                       Text="{Binding Path=Rank, StringFormat='#{0:n0}'}" />
+            </Grid>
+        </Border>
+        
+        <Border Grid.Column="1"
+                Grid.Row="0"
+                BackgroundColor="{StaticResource RankingTableHeader}"
+                Stroke="{StaticResource RankingTableHeader}"
+                StrokeShape="RoundRectangle 4">
+            <Grid RowSpacing="10" Margin="0,10" RowDefinitions="*,*,*">
+                <Label Grid.Row="0"
+                       HorizontalOptions="Center"
+                       FontFamily="FA6Solid"
+                       TextColor="{StaticResource Coin}"
+                       FontSize="18"
                        Text="&#x2b50;"/>
-            </HorizontalStackLayout>
+                <Label Grid.Row="1"
+                       HorizontalOptions="Center"
+                       Style="{StaticResource LabelBold}"
+                       TextColor="{StaticResource Gray200}"
+                       FontSize="14"
+                       Text="Points"/>
+                <Label Grid.Row="2"
+                       HorizontalOptions="Center"
+                       Style="{StaticResource LabelBold}"
+                       FontSize="18"
+                       TextColor="White"
+                       Text="{Binding Path=Points, StringFormat='{0:n0}'}" />
+            </Grid>
         </Border>
-
-        <Border Grid.Column="1"
-                Grid.Row="1"
-                BackgroundColor="{StaticResource RankingTableBody}"
-                StrokeShape="RoundRectangle 0,4,0,4"
-                Padding="5">
-            <Label Style="{StaticResource LabelBold}"
-                   VerticalOptions="Center"
-                   VerticalTextAlignment="Center"
-                   FontSize="18"
-                   TextColor="White"
-                   Text="{Binding Path=Points, StringFormat='{0:n0}'}" />
-        </Border>
-
-        <Border Grid.Column="0"
-                Grid.Row="2"
+        
+        <Border Grid.Column="2"
+                Grid.Row="0"
                 BackgroundColor="{StaticResource RankingTableHeader}"
                 Stroke="{StaticResource RankingTableHeader}"
-                StrokeShape="RoundRectangle 4,0,4,0">
-
-            <HorizontalStackLayout>
-                <Label VerticalOptions="Center"
-                       VerticalTextAlignment="Center"
-                       Margin="10,0,0,0"
+                StrokeShape="RoundRectangle 4">
+            <Grid RowSpacing="10" Margin="0,10" RowDefinitions="*,*,*">
+                <Label Grid.Row="0"
+                       HorizontalOptions="Center"
                        FontFamily="FA6Solid"
                        TextColor="{StaticResource Coin}"
+                       FontSize="18"
                        Text="&#xf51e;"/>
-            </HorizontalStackLayout>
-        </Border>
-
-        <Border Grid.Column="1"
-                Grid.Row="2"
-                BackgroundColor="{StaticResource RankingTableBody}"
-                StrokeShape="RoundRectangle 0,4,0,4"
-                Padding="5">
-            <Label Style="{StaticResource LabelBold}"
-                   VerticalOptions="Center"
-                   VerticalTextAlignment="Center"
-                   FontSize="14"
-                   TextColor="White"
-                   Text="{Binding Path=Credits, StringFormat='{0:n0}'}" />
+                <Label Grid.Row="1"
+                       HorizontalOptions="Center"
+                       Style="{StaticResource LabelBold}"
+                       TextColor="{StaticResource Gray200}"
+                       FontSize="14"
+                       Text="Coins"/>
+                <Label Grid.Row="2"
+                       HorizontalOptions="Center"
+                       Style="{StaticResource LabelBold}"
+                       FontSize="16"
+                       TextColor="White"
+                       Text="{Binding Path=Credits, StringFormat='{0:n0}'}" />
+            </Grid>
         </Border>
     </Grid>
 

--- a/src/MobileUI/Features/Flyout/FlyoutHeader.xaml
+++ b/src/MobileUI/Features/Flyout/FlyoutHeader.xaml
@@ -79,7 +79,7 @@
                        HorizontalOptions="Center"
                        FontFamily="FA6Solid"
                        TextColor="{StaticResource Coin}"
-                       FontSize="18"
+                       FontSize="20"
                        Text="&#xf091;"/>
                 <Label Grid.Row="1"
                        HorizontalOptions="Center"
@@ -106,7 +106,7 @@
                        HorizontalOptions="Center"
                        FontFamily="FA6Solid"
                        TextColor="{StaticResource Coin}"
-                       FontSize="18"
+                       FontSize="20"
                        Text="&#x2b50;"/>
                 <Label Grid.Row="1"
                        HorizontalOptions="Center"
@@ -133,7 +133,7 @@
                        HorizontalOptions="Center"
                        FontFamily="FA6Solid"
                        TextColor="{StaticResource Coin}"
-                       FontSize="18"
+                       FontSize="20"
                        Text="&#xf51e;"/>
                 <Label Grid.Row="1"
                        HorizontalOptions="Center"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1049 

> 2. What was changed?

Implements Ken's design for the stats section of the flyout.

<img src="https://github.com/user-attachments/assets/8ec77a94-fe49-4f23-8c47-05cb211b0859" width="400" />

**✅ Figure: Improved stats section in the flyout**

> 3. Did you do pair or mob programming?

No

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->