### PR TITLE
✨ Mobile | Update quiz results design

### DIFF
--- a/src/Common/DTOs/Quizzes/QuestionResultDto.cs
+++ b/src/Common/DTOs/Quizzes/QuestionResultDto.cs
@@ -2,6 +2,7 @@
 
 public class QuestionResultDto
 {
+    public int Index { get; set; }
     public int QuestionId { get; set; }
     public bool Correct { get; set; }
 

--- a/src/MobileUI/Common/Messages/TopBarAvatarMessage.cs
+++ b/src/MobileUI/Common/Messages/TopBarAvatarMessage.cs
@@ -10,7 +10,6 @@ public class TopBarAvatarMessage : ValueChangedMessage<AvatarOptions>
 
 public enum AvatarOptions
 {
-    Done,
     Back,
     Original
 }

--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -14,377 +14,420 @@
     <ContentPage.Resources>
         <converters:AllTrueConverter x:Key="AllTrueConverter" />
     </ContentPage.Resources>
-    <ScrollView>
-        <Grid>
-            <!-- Questions -->
-            <Grid BackgroundColor="{StaticResource QuizDescriptionBackground}">
-                <Grid.IsVisible>
-                    <MultiBinding Converter="{StaticResource AllTrueConverter}">
-                        <Binding Path="QuestionsVisible" />
-                        <Binding Path="IsLoadingQuestions" Converter="{toolkit:InvertedBoolConverter}" />
-                    </MultiBinding>
-                </Grid.IsVisible>
-                <Border
-                    StrokeThickness="0"
-                    StrokeShape="RoundRectangle 8"
-                    Margin="{OnPlatform '15', iOS='15,15,15,95'}"
-                    BackgroundColor="{StaticResource Background}">
-                    <Grid RowDefinitions="120, Auto, Auto, 40, 40, *, 60">
+    <Grid>
+        <ScrollView>
+            <Grid>
+                <!-- Questions -->
+                <Grid BackgroundColor="{StaticResource QuizDescriptionBackground}">
+                    <Grid.IsVisible>
+                        <MultiBinding Converter="{StaticResource AllTrueConverter}">
+                            <Binding Path="QuestionsVisible" />
+                            <Binding Path="IsLoadingQuestions" Converter="{toolkit:InvertedBoolConverter}" />
+                        </MultiBinding>
+                    </Grid.IsVisible>
+                    <Border
+                        StrokeThickness="0"
+                        StrokeShape="RoundRectangle 8"
+                        Margin="{OnPlatform '15', iOS='15,15,15,95'}"
+                        BackgroundColor="{StaticResource Background}">
+                        <Grid RowDefinitions="120, Auto, Auto, 40, 40, *, 60">
 
-                        <Border Grid.Row="0"
-                                HeightRequest="80"
-                                WidthRequest="80"
-                                BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                StrokeThickness="0"
-                                StrokeShape="RoundRectangle 6">
-                            <Image Source="{Binding ThumbnailImage}"
-                                   HorizontalOptions="Center"
-                                   VerticalOptions="Center"
-                                   HeightRequest="80"
-                                   WidthRequest="80"
-                                   Aspect="AspectFill" />
-                        </Border>
-
-                        <Label Grid.Row="1"
-                               Text="{Binding QuizTitle}"
-                               Style="{StaticResource LabelBold}"
-                               Margin="10,0"
-                               FontSize="24"
-                               HorizontalTextAlignment="Center" />
-
-                        <Label Grid.Row="2"
-                               Text="{Binding QuizDescription}"
-                               TextColor="{StaticResource Gray300}"
-                               Margin="10,0"
-                               FontSize="18"
-                               HorizontalTextAlignment="Center" />
-
-                        <!-- Reward amount -->
-                        <Border Grid.Row="3"
-                                StrokeThickness="0"
-                                StrokeShape="RoundRectangle 8"
-                                WidthRequest="80"
-                                Margin="0,10,0,0"
-                                BackgroundColor="{StaticResource FlyoutBackgroundColour}">
-                            <Grid ColumnDefinitions="30,*">
-                                <Label
-                                    Grid.Column="0"
-                                    TextColor="{StaticResource Coin}"
-                                    Text="&#xf51e;"
-                                    FontFamily="FA6Solid"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center"
-                                    FontSize="11"
-                                    Style="{StaticResource LabelBold}"
-                                    InputTransparent="True" />
-                                <Label Grid.Column="1" Text="{Binding Points}"
-                                       TextColor="White"
-                                       FontSize="18"
-                                       HorizontalOptions="Center"
-                                       VerticalOptions="Center" />
-                            </Grid>
-                        </Border>
-
-                        <IndicatorView Grid.Row="4"
-                                       InputTransparent="True"
-                                       SelectedIndicatorColor="{StaticResource SSWRed}"
-                                       IndicatorColor="{StaticResource IndicatorColor}"
-                                       IndicatorSize="4.5"
-                                       Position="{Binding CurrentQuestionIndex}"
-                                       Count="{Binding Questions.Count}"
-                                       HorizontalOptions="Center"
-                                       VerticalOptions="End" />
-
-                        <!-- Question & Answer -->
-                        <Grid Grid.Row="5" RowDefinitions="Auto,Auto" Margin="20">
-                            <Label Grid.Row="0"
-                                   HorizontalOptions="FillAndExpand"
-                                   VerticalOptions="FillAndExpand"
-                                   HorizontalTextAlignment="Start"
-                                   VerticalTextAlignment="End"
-                                   Style="{StaticResource LabelBold}"
-                                   TextColor="White"
-                                   FontSize="Large"
-                                   Margin="0,0,0,40"
-                                   Text="{Binding CurrentQuestion.Text, StringFormat='Q: {0}'}" />
-                            <Border
-                                Grid.Row="1"
-                                Stroke="{StaticResource White}"
-                                StrokeShape="RoundRectangle 8"
-                                IsVisible="{Binding CurrentQuestion.IsSubmitted, Converter={toolkit:InvertedBoolConverter}}">
-                                <Editor
-                                    TextColor="{StaticResource White}"
-                                    VerticalTextAlignment="Start"
-                                    AutoSize="TextChanges"
-                                    Text="{Binding CurrentQuestion.Answer}"
-                                    MinimumHeightRequest="150"
-                                    Placeholder="Enter your answer here"
-                                    Keyboard="Plain">
-                                    <Editor.Behaviors>
-                                        <toolkit:EventToCommandBehavior
-                                            x:TypeArguments="TextChangedEventArgs"
-                                            EventName="TextChanged"
-                                            Command="{Binding AnswerChangedCommand}" />
-                                    </Editor.Behaviors>
-                                </Editor>
-                            </Border>
-                            <Label Grid.Row="1"
-                                   IsVisible="{Binding CurrentQuestion.IsSubmitted}"
-                                   Text="{Binding CurrentQuestion.Answer, StringFormat='A: {0}'}"
-                                   FontSize="Medium"
-                                   TextColor="{StaticResource White}" />
-                        </Grid>
-
-                        <!-- Quiz navigation -->
-                        <Grid Grid.Row="6"
-                              ColumnDefinitions="*,*"
-                              Margin="20,0,20,10"
-                              IsEnabled="{Binding IsBusy, Converter={toolkit:InvertedBoolConverter}}">
-                            <Button Grid.Column="0"
-                                    IsVisible="{Binding IsFirstQuestion, Converter={toolkit:InvertedBoolConverter}}"
-                                    Text="&#xf060;"
-                                    Command="{Binding MoveBackCommand}"
-                                    FontFamily="FA6Solid"
-                                    TextColor="White"
-                                    HeightRequest="40"
-                                    VerticalOptions="End"
-                                    HorizontalOptions="Start"
-                                    Padding="0"
-                                    CornerRadius="10"
-                                    BackgroundColor="{StaticResource SSWRed}"
-                                    WidthRequest="40" />
-
-                            <Button Grid.Column="1"
-                                    IsVisible="{Binding IsLastQuestion, Converter={toolkit:InvertedBoolConverter}}"
-                                    Text="&#xf061;"
-                                    Command="{Binding MoveForwardCommand}"
-                                    FontFamily="FA6Solid"
-                                    TextColor="White"
-                                    HeightRequest="40"
-                                    VerticalOptions="End"
-                                    HorizontalOptions="End"
-                                    Padding="0"
-                                    CornerRadius="10"
-                                    BackgroundColor="{StaticResource SSWRed}"
-                                    WidthRequest="40" />
-
-                            <Button Grid.Column="1"
-                                    IsVisible="{Binding IsLastQuestion}"
-                                    Text="Submit"
-                                    Command="{Binding SubmitResponsesCommand}"
-                                    Style="{StaticResource LabelBold}"
-                                    FontSize="12"
-                                    TextColor="White"
-                                    HeightRequest="40"
-                                    VerticalOptions="End"
-                                    HorizontalOptions="End"
-                                    Padding="0"
-                                    CornerRadius="10"
-                                    BackgroundColor="{StaticResource SSWRed}"
-                                    WidthRequest="80" />
-                        </Grid>
-
-                        <ActivityIndicator HorizontalOptions="Center"
-                                           VerticalOptions="Center"
-                                           Color="{StaticResource SSWRed}"
-                                           IsVisible="{Binding IsBusy}"
-                                           IsRunning="{Binding IsBusy}"
-                                           Grid.Row="5" />
-                    </Grid>
-                </Border>
-            </Grid>
-
-            <!-- Results -->
-            <Grid IsVisible="{Binding ResultsVisible}"
-                  BackgroundColor="{StaticResource QuizDescriptionBackground}"
-                  RowDefinitions="Auto, *">
-                <VerticalStackLayout Grid.Row="0"
-                                     BackgroundColor="{StaticResource Background}"
-                                     Padding="0,0,0,20">
-                    <Border BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                            HorizontalOptions="Center"
-                            StrokeThickness="0"
-                            StrokeShape="RoundRectangle 6"
-                            WidthRequest="50"
-                            HeightRequest="50"
-                            Margin="0,0,0,20">
-                        <Label Text="😥"
-                               VerticalOptions="Center"
-                               HorizontalOptions="Center"
-                               FontSize="26"
-                               FontAutoScalingEnabled="False">
-                            <Label.Triggers>
-                                <DataTrigger TargetType="Label"
-                                             Binding="{Binding TestPassed}"
-                                             Value="True">
-                                    <Setter Property="Text" Value="🎉" />
-                                </DataTrigger>
-                            </Label.Triggers>
-                        </Label>
-                    </Border>
-
-                    <Label Text="{Binding ResultsTitle}"
-                           HorizontalOptions="Center"
-                           HorizontalTextAlignment="Center"
-                           VerticalOptions="Center"
-                           Style="{StaticResource LabelBold}"
-                           FontSize="22"
-                           TextColor="White" />
-
-                    <Label FontSize="14"
-                           TextColor="{StaticResource Gray300}"
-                           HorizontalOptions="Center"
-                           VerticalOptions="Center"
-                           HorizontalTextAlignment="Center"
-                           VerticalTextAlignment="Center">
-                        <Label.FormattedText>
-                            <FormattedString>
-                                <Span Text="You got " />
-                                <Span Text="{Binding Score}" TextColor="{StaticResource SSWRed}" FontAttributes="Bold" />
-                                <Span Text=" questions right." />
-                            </FormattedString>
-                        </Label.FormattedText>
-                    </Label>
-
-                    <Label IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
-                           Text="Try again once you are ready!"
-                           FontSize="14"
-                           TextColor="{StaticResource Gray300}"
-                           HorizontalOptions="Center"
-                           VerticalOptions="Center"
-                           HorizontalTextAlignment="Center"
-                           VerticalTextAlignment="Center" />
-                </VerticalStackLayout>
-                
-                <lottie:SKConfettiView
-                    Grid.Row="0"
-                    IsAnimationEnabled="{Binding ShowConfetti}" />
-
-                <VerticalStackLayout Grid.Row="1"
-                                     BindableLayout.ItemsSource="{Binding Results}"
-                                     BackgroundColor="{StaticResource QuizDescriptionBackground}"
-                                     Padding="15"
-                                     Spacing="15">
-                    <BindableLayout.ItemTemplate>
-                        <DataTemplate x:DataType="quizzes:QuestionResultDto">
-                            <Border BackgroundColor="{StaticResource Background}"
+                            <Border Grid.Row="0"
+                                    HeightRequest="80"
+                                    WidthRequest="80"
+                                    BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                                     StrokeThickness="0"
-                                    StrokeShape="RoundRectangle 6"
-                                    Padding="15">
-                                <Border.Triggers>
-                                    <DataTrigger TargetType="Border"
-                                                 Binding="{Binding Correct}"
-                                                 Value="False">
-                                        <Setter Property="Stroke" Value="{StaticResource SSWRed}" />
-                                    </DataTrigger>
-                                </Border.Triggers>
-                                <VerticalStackLayout Spacing="5">
-                                    <Label Text="{Binding Index, StringFormat='Question {0}'}"
-                                           FontSize="12">
-                                        <Label.FormattedText>
-                                            <FormattedString>
-                                                <Span Text="Question " />
-                                                <Span Text="{Binding Index}" />
-                                                <Span Text="/" />
-                                                <Span Text="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizDetailsViewModel}}, Path=Questions.Count}" />
-                                            </FormattedString>
-                                        </Label.FormattedText>
-                                    </Label>
-                                    
-                                    <Label Text="{Binding QuestionText}"
-                                           FontSize="16"/>
-                                    
-                                    <Border BackgroundColor="{StaticResource QuizDescriptionBackground}"
-                                            StrokeThickness="0"
-                                            StrokeShape="RoundRectangle 6"
-                                            Padding="10"
-                                            Margin="0,10,0,0">
-                                        <toolkit:Expander
-                                            x:Name="Expander"
-                                            IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
-                                            <toolkit:Expander.Header>
-                                                <Grid
-                                                    ColumnDefinitions="20, *, 20"
-                                                    RowDefinitions="Auto">
-                                                    <Label Grid.Column="0"
-                                                           FontFamily="FA6Regular"
-                                                           TextColor="{StaticResource QuizCheckColor}"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           FontSize="14"
-                                                           Text="&#xf058;"
-                                                           IsVisible="{Binding Correct}" />
-                                                    <Label Grid.Column="0"
-                                                           FontFamily="FA6Regular"
-                                                           TextColor="{StaticResource SSWRed}"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           FontSize="14"
-                                                           Text="&#xf057;"
-                                                           IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
-                                                    
-                                                    <Label Grid.Column="1"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           Text="Correct"
-                                                           IsVisible="{Binding Correct}"
-                                                           TextColor="{StaticResource QuizCheckColor}"
-                                                           FontSize="14" />
-                                                    <Label Grid.Column="1"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           Text="Incorrect"
-                                                           IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}"
-                                                           TextColor="{StaticResource SSWRed}"
-                                                           FontSize="14" />
-
-                                                    <Image Grid.Column="2"
-                                                           IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}"
-                                                           HeightRequest="12"
-                                                           WidthRequest="12"
-                                                           Source="icon_chevron_right" />
-                                                    <Image Grid.Column="2"
-                                                           IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}"
-                                                           HeightRequest="12"
-                                                           WidthRequest="12"
-                                                           Source="icon_chevron_down" />
-                                                </Grid>
-                                            </toolkit:Expander.Header>
-                                            <VerticalStackLayout Padding="20,10">
-                                                <Label Text="Your response:"
-                                                       FontSize="14"
-                                                       Style="{StaticResource LabelBold}"
-                                                       TextColor="{StaticResource Gray300}" />
-                                                <Label Text="{Binding AnswerText}"
-                                                       FontSize="14"
-                                                       TextColor="{StaticResource Gray300}"/>
-                                                <Label Text="Explanation:"
-                                                       Margin="0,8,0,0"
-                                                       FontSize="14"
-                                                       Style="{StaticResource LabelBold}"
-                                                       TextColor="{StaticResource Gray300}"/>
-                                                <Label Text="{Binding ExplanationText}"
-                                                       FontSize="14"
-                                                       TextColor="{StaticResource Gray300}"/>
-                                            </VerticalStackLayout>
-                                        </toolkit:Expander>
-                                    </Border>
-
-                                </VerticalStackLayout>
-
+                                    StrokeShape="RoundRectangle 6">
+                                <Image Source="{Binding ThumbnailImage}"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       HeightRequest="80"
+                                       WidthRequest="80"
+                                       Aspect="AspectFill" />
                             </Border>
-                        </DataTemplate>
-                    </BindableLayout.ItemTemplate>
-                </VerticalStackLayout>
-            </Grid>
 
-            <ActivityIndicator
-                HorizontalOptions="Center"
-                VerticalOptions="Center"
-                Color="{StaticResource SSWRed}"
-                IsEnabled="{Binding IsLoadingQuestions}"
-                IsRunning="{Binding IsLoadingQuestions}"
-                IsVisible="{Binding IsLoadingQuestions}" />
-        </Grid>
-    </ScrollView>
+                            <Label Grid.Row="1"
+                                   Text="{Binding QuizTitle}"
+                                   Style="{StaticResource LabelBold}"
+                                   Margin="10,0"
+                                   FontSize="24"
+                                   HorizontalTextAlignment="Center" />
+
+                            <Label Grid.Row="2"
+                                   Text="{Binding QuizDescription}"
+                                   TextColor="{StaticResource Gray300}"
+                                   Margin="10,0"
+                                   FontSize="18"
+                                   HorizontalTextAlignment="Center" />
+
+                            <!-- Reward amount -->
+                            <Border Grid.Row="3"
+                                    StrokeThickness="0"
+                                    StrokeShape="RoundRectangle 8"
+                                    WidthRequest="80"
+                                    Margin="0,10,0,0"
+                                    BackgroundColor="{StaticResource FlyoutBackgroundColour}">
+                                <Grid ColumnDefinitions="30,*">
+                                    <Label
+                                        Grid.Column="0"
+                                        TextColor="{StaticResource Coin}"
+                                        Text="&#xf51e;"
+                                        FontFamily="FA6Solid"
+                                        HorizontalOptions="Center"
+                                        VerticalOptions="Center"
+                                        FontSize="11"
+                                        Style="{StaticResource LabelBold}"
+                                        InputTransparent="True" />
+                                    <Label Grid.Column="1" Text="{Binding Points}"
+                                           TextColor="White"
+                                           FontSize="18"
+                                           HorizontalOptions="Center"
+                                           VerticalOptions="Center" />
+                                </Grid>
+                            </Border>
+
+                            <IndicatorView Grid.Row="4"
+                                           InputTransparent="True"
+                                           SelectedIndicatorColor="{StaticResource SSWRed}"
+                                           IndicatorColor="{StaticResource IndicatorColor}"
+                                           IndicatorSize="4.5"
+                                           Position="{Binding CurrentQuestionIndex}"
+                                           Count="{Binding Questions.Count}"
+                                           HorizontalOptions="Center"
+                                           VerticalOptions="End" />
+
+                            <!-- Question & Answer -->
+                            <Grid Grid.Row="5" RowDefinitions="Auto,Auto" Margin="20">
+                                <Label Grid.Row="0"
+                                       HorizontalOptions="FillAndExpand"
+                                       VerticalOptions="FillAndExpand"
+                                       HorizontalTextAlignment="Start"
+                                       VerticalTextAlignment="End"
+                                       Style="{StaticResource LabelBold}"
+                                       TextColor="White"
+                                       FontSize="Large"
+                                       Margin="0,0,0,40"
+                                       Text="{Binding CurrentQuestion.Text, StringFormat='Q: {0}'}" />
+                                <Border
+                                    Grid.Row="1"
+                                    Stroke="{StaticResource White}"
+                                    StrokeShape="RoundRectangle 8"
+                                    IsVisible="{Binding CurrentQuestion.IsSubmitted, Converter={toolkit:InvertedBoolConverter}}">
+                                    <Editor
+                                        TextColor="{StaticResource White}"
+                                        VerticalTextAlignment="Start"
+                                        AutoSize="TextChanges"
+                                        Text="{Binding CurrentQuestion.Answer}"
+                                        MinimumHeightRequest="150"
+                                        Placeholder="Enter your answer here"
+                                        Keyboard="Plain">
+                                        <Editor.Behaviors>
+                                            <toolkit:EventToCommandBehavior
+                                                x:TypeArguments="TextChangedEventArgs"
+                                                EventName="TextChanged"
+                                                Command="{Binding AnswerChangedCommand}" />
+                                        </Editor.Behaviors>
+                                    </Editor>
+                                </Border>
+                                <Label Grid.Row="1"
+                                       IsVisible="{Binding CurrentQuestion.IsSubmitted}"
+                                       Text="{Binding CurrentQuestion.Answer, StringFormat='A: {0}'}"
+                                       FontSize="Medium"
+                                       TextColor="{StaticResource White}" />
+                            </Grid>
+
+                            <!-- Quiz navigation -->
+                            <Grid Grid.Row="6"
+                                  ColumnDefinitions="*,*"
+                                  Margin="20,0,20,10"
+                                  IsEnabled="{Binding IsBusy, Converter={toolkit:InvertedBoolConverter}}">
+                                <Button Grid.Column="0"
+                                        IsVisible="{Binding IsFirstQuestion, Converter={toolkit:InvertedBoolConverter}}"
+                                        Text="&#xf060;"
+                                        Command="{Binding MoveBackCommand}"
+                                        FontFamily="FA6Solid"
+                                        TextColor="White"
+                                        HeightRequest="40"
+                                        VerticalOptions="End"
+                                        HorizontalOptions="Start"
+                                        Padding="0"
+                                        CornerRadius="10"
+                                        BackgroundColor="{StaticResource SSWRed}"
+                                        WidthRequest="40" />
+
+                                <Button Grid.Column="1"
+                                        IsVisible="{Binding IsLastQuestion, Converter={toolkit:InvertedBoolConverter}}"
+                                        Text="&#xf061;"
+                                        Command="{Binding MoveForwardCommand}"
+                                        FontFamily="FA6Solid"
+                                        TextColor="White"
+                                        HeightRequest="40"
+                                        VerticalOptions="End"
+                                        HorizontalOptions="End"
+                                        Padding="0"
+                                        CornerRadius="10"
+                                        BackgroundColor="{StaticResource SSWRed}"
+                                        WidthRequest="40" />
+
+                                <Button Grid.Column="1"
+                                        IsVisible="{Binding IsLastQuestion}"
+                                        Text="Submit"
+                                        Command="{Binding SubmitResponsesCommand}"
+                                        Style="{StaticResource LabelBold}"
+                                        FontSize="12"
+                                        TextColor="White"
+                                        HeightRequest="40"
+                                        VerticalOptions="End"
+                                        HorizontalOptions="End"
+                                        Padding="0"
+                                        CornerRadius="10"
+                                        BackgroundColor="{StaticResource SSWRed}"
+                                        WidthRequest="80" />
+                            </Grid>
+
+                            <ActivityIndicator HorizontalOptions="Center"
+                                               VerticalOptions="Center"
+                                               Color="{StaticResource SSWRed}"
+                                               IsVisible="{Binding IsBusy}"
+                                               IsRunning="{Binding IsBusy}"
+                                               Grid.Row="5" />
+                        </Grid>
+                    </Border>
+                </Grid>
+
+                <!-- Results -->
+                <Grid IsVisible="{Binding ResultsVisible}"
+                      BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                      RowDefinitions="Auto, *"
+                      Padding="0,0,0,80">
+                    <VerticalStackLayout Grid.Row="0"
+                                         BackgroundColor="{StaticResource Background}"
+                                         Padding="0,0,0,20">
+                        <Border BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                                HorizontalOptions="Center"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 6"
+                                WidthRequest="50"
+                                HeightRequest="50"
+                                Margin="0,0,0,20">
+                            <Label Text="😥"
+                                   VerticalOptions="Center"
+                                   HorizontalOptions="Center"
+                                   FontSize="26"
+                                   FontAutoScalingEnabled="False">
+                                <Label.Triggers>
+                                    <DataTrigger TargetType="Label"
+                                                 Binding="{Binding TestPassed}"
+                                                 Value="True">
+                                        <Setter Property="Text" Value="🎉" />
+                                    </DataTrigger>
+                                </Label.Triggers>
+                            </Label>
+                        </Border>
+
+                        <Label Text="{Binding ResultsTitle}"
+                               HorizontalOptions="Center"
+                               HorizontalTextAlignment="Center"
+                               VerticalOptions="Center"
+                               Style="{StaticResource LabelBold}"
+                               FontSize="22"
+                               TextColor="White" />
+
+                        <Label FontSize="14"
+                               TextColor="{StaticResource Gray300}"
+                               HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               HorizontalTextAlignment="Center"
+                               VerticalTextAlignment="Center">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="You got " />
+                                    <Span Text="{Binding Score}" TextColor="{StaticResource SSWRed}"
+                                          FontAttributes="Bold" />
+                                    <Span Text=" questions right." />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+
+                        <Label IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
+                               Text="Try again once you are ready!"
+                               FontSize="14"
+                               TextColor="{StaticResource Gray300}"
+                               HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               HorizontalTextAlignment="Center"
+                               VerticalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                    <lottie:SKConfettiView
+                        Grid.Row="0"
+                        IsAnimationEnabled="{Binding ShowConfetti}" />
+
+                    <VerticalStackLayout Grid.Row="1"
+                                         BindableLayout.ItemsSource="{Binding Results}"
+                                         BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                                         Padding="15"
+                                         Spacing="15">
+                        <BindableLayout.ItemTemplate>
+                            <DataTemplate x:DataType="quizzes:QuestionResultDto">
+                                <Border BackgroundColor="{StaticResource Background}"
+                                        StrokeThickness="0"
+                                        StrokeShape="RoundRectangle 6"
+                                        Padding="15">
+                                    <Border.Triggers>
+                                        <DataTrigger TargetType="Border"
+                                                     Binding="{Binding Correct}"
+                                                     Value="False">
+                                            <Setter Property="Stroke" Value="{StaticResource SSWRed}" />
+                                        </DataTrigger>
+                                    </Border.Triggers>
+                                    <VerticalStackLayout Spacing="5">
+                                        <Label Text="{Binding Index, StringFormat='Question {0}'}"
+                                               FontSize="12">
+                                            <Label.FormattedText>
+                                                <FormattedString>
+                                                    <Span Text="Question " />
+                                                    <Span Text="{Binding Index}" />
+                                                    <Span Text="/" />
+                                                    <Span
+                                                        Text="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizDetailsViewModel}}, Path=Questions.Count}" />
+                                                </FormattedString>
+                                            </Label.FormattedText>
+                                        </Label>
+
+                                        <Label Text="{Binding QuestionText}"
+                                               FontSize="16" />
+
+                                        <Border BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                                                StrokeThickness="0"
+                                                StrokeShape="RoundRectangle 6"
+                                                Padding="10"
+                                                Margin="0,10,0,0">
+                                            <toolkit:Expander
+                                                x:Name="Expander"
+                                                IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
+                                                <toolkit:Expander.Header>
+                                                    <Grid
+                                                        ColumnDefinitions="20, *, 20"
+                                                        RowDefinitions="Auto">
+                                                        <Label Grid.Column="0"
+                                                               FontFamily="FA6Regular"
+                                                               TextColor="{StaticResource QuizCheckColor}"
+                                                               VerticalTextAlignment="Center"
+                                                               VerticalOptions="Center"
+                                                               FontSize="14"
+                                                               Text="&#xf058;"
+                                                               IsVisible="{Binding Correct}" />
+                                                        <Label Grid.Column="0"
+                                                               FontFamily="FA6Regular"
+                                                               TextColor="{StaticResource SSWRed}"
+                                                               VerticalTextAlignment="Center"
+                                                               VerticalOptions="Center"
+                                                               FontSize="14"
+                                                               Text="&#xf057;"
+                                                               IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
+
+                                                        <Label Grid.Column="1"
+                                                               VerticalTextAlignment="Center"
+                                                               VerticalOptions="Center"
+                                                               Text="Correct"
+                                                               IsVisible="{Binding Correct}"
+                                                               TextColor="{StaticResource QuizCheckColor}"
+                                                               FontSize="14" />
+                                                        <Label Grid.Column="1"
+                                                               VerticalTextAlignment="Center"
+                                                               VerticalOptions="Center"
+                                                               Text="Incorrect"
+                                                               IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}"
+                                                               TextColor="{StaticResource SSWRed}"
+                                                               FontSize="14" />
+
+                                                        <Image Grid.Column="2"
+                                                               IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}"
+                                                               HeightRequest="12"
+                                                               WidthRequest="12"
+                                                               Source="icon_chevron_right" />
+                                                        <Image Grid.Column="2"
+                                                               IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}"
+                                                               HeightRequest="12"
+                                                               WidthRequest="12"
+                                                               Source="icon_chevron_down" />
+                                                    </Grid>
+                                                </toolkit:Expander.Header>
+                                                <VerticalStackLayout Padding="20,10">
+                                                    <Label Text="Your response:"
+                                                           FontSize="14"
+                                                           Style="{StaticResource LabelBold}"
+                                                           TextColor="{StaticResource Gray300}" />
+                                                    <Label Text="{Binding AnswerText}"
+                                                           FontSize="14"
+                                                           TextColor="{StaticResource Gray300}" />
+                                                    <Label Text="Explanation:"
+                                                           Margin="0,8,0,0"
+                                                           FontSize="14"
+                                                           Style="{StaticResource LabelBold}"
+                                                           TextColor="{StaticResource Gray300}" />
+                                                    <Label Text="{Binding ExplanationText}"
+                                                           FontSize="14"
+                                                           TextColor="{StaticResource Gray300}" />
+                                                </VerticalStackLayout>
+                                            </toolkit:Expander>
+                                        </Border>
+
+                                    </VerticalStackLayout>
+
+                                </Border>
+                            </DataTemplate>
+                        </BindableLayout.ItemTemplate>
+                    </VerticalStackLayout>
+                </Grid>
+
+
+                <ActivityIndicator
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    Color="{StaticResource SSWRed}"
+                    IsEnabled="{Binding IsLoadingQuestions}"
+                    IsRunning="{Binding IsLoadingQuestions}"
+                    IsVisible="{Binding IsLoadingQuestions}" />
+            </Grid>
+        </ScrollView>
+
+        <!-- Bottom bar -->
+        <Border IsVisible="{Binding ResultsVisible}"
+                BackgroundColor="{StaticResource Background}"
+                VerticalOptions="End"
+                StrokeThickness="0"
+                StrokeShape="RoundRectangle 6"
+                Padding="15">
+            <Grid ColumnDefinitions="Auto, *, Auto">
+                <Button Grid.Column="0"
+                        IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
+                        Text="Try Again"
+                        Command="{Binding RestartCommand}"
+                        Style="{StaticResource LabelBold}"
+                        TextColor="White"
+                        HeightRequest="40"
+                        VerticalOptions="Center"
+                        HorizontalOptions="Start"
+                        Padding="10"
+                        CornerRadius="6"
+                        BackgroundColor="{StaticResource SSWRed}" />
+                
+                <Button Grid.Column="2"
+                        IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
+                        Text="Done"
+                        Command="{Binding DoneCommand}"
+                        Style="{StaticResource LabelBold}"
+                        TextColor="White"
+                        HeightRequest="40"
+                        VerticalOptions="Center"
+                        HorizontalOptions="Start"
+                        Padding="10"
+                        CornerRadius="6"
+                        BackgroundColor="{StaticResource SSWRed}" />
+            </Grid>
+        </Border>
+    </Grid>
+
 </ContentPage>

--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -64,10 +64,12 @@
                             <Border Grid.Row="3"
                                     StrokeThickness="0"
                                     StrokeShape="RoundRectangle 8"
-                                    WidthRequest="80"
+                                    HorizontalOptions="Center"
+                                    Padding="10,8"
                                     Margin="0,10,0,0"
                                     BackgroundColor="{StaticResource FlyoutBackgroundColour}">
-                                <Grid ColumnDefinitions="30,*">
+                                <Grid ColumnDefinitions="Auto,*"
+                                      ColumnSpacing="10">
                                     <Label
                                         Grid.Column="0"
                                         TextColor="{StaticResource Coin}"
@@ -257,6 +259,33 @@
                                VerticalOptions="Center"
                                HorizontalTextAlignment="Center"
                                VerticalTextAlignment="Center" />
+                        
+                        <Border IsVisible="{Binding TestPassed}"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 8"
+                                HorizontalOptions="Center"
+                                Padding="10,8"
+                                Margin="0,10,0,0"
+                                BackgroundColor="{StaticResource FlyoutBackgroundColour}">
+                            <Grid ColumnDefinitions="Auto,*"
+                                  ColumnSpacing="10">
+                                <Label
+                                    Grid.Column="0"
+                                    TextColor="{StaticResource Coin}"
+                                    Text="&#xf51e;"
+                                    FontFamily="FA6Solid"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    FontSize="11"
+                                    Style="{StaticResource LabelBold}"
+                                    InputTransparent="True" />
+                                <Label Grid.Column="1" Text="{Binding Points, StringFormat='+{0}'}"
+                                       TextColor="White"
+                                       FontSize="18"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center" />
+                            </Grid>
+                        </Border>
                     </VerticalStackLayout>
 
                     <lottie:SKConfettiView
@@ -415,7 +444,6 @@
                         BackgroundColor="{StaticResource SSWRed}" />
                 
                 <Button Grid.Column="2"
-                        IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
                         Text="Done"
                         Command="{Binding DoneCommand}"
                         Style="{StaticResource LabelBold}"

--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -431,24 +431,29 @@
                 Padding="15">
             <Grid ColumnDefinitions="Auto, *, Auto">
                 <Button Grid.Column="0"
-                        IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
                         Text="Try Again"
+                        IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
                         Command="{Binding RestartCommand}"
                         Style="{StaticResource LabelBold}"
                         TextColor="White"
-                        HeightRequest="40"
                         VerticalOptions="Center"
                         HorizontalOptions="Start"
                         Padding="10"
                         CornerRadius="6"
-                        BackgroundColor="{StaticResource SSWRed}" />
+                        BackgroundColor="{StaticResource SSWRed}"
+                        ContentLayout="Left">
+                    <Button.ImageSource>
+                        <FontImageSource Glyph="&#xf01e;"
+                                         FontFamily="FA6Solid"
+                                         Size="12"/>
+                    </Button.ImageSource>
+                </Button>
                 
                 <Button Grid.Column="2"
                         Text="Done"
                         Command="{Binding DoneCommand}"
                         Style="{StaticResource LabelBold}"
                         TextColor="White"
-                        HeightRequest="40"
                         VerticalOptions="Center"
                         HorizontalOptions="Start"
                         Padding="10"

--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -7,302 +7,382 @@
              xmlns:viewModels="clr-namespace:SSW.Rewards.Mobile.ViewModels"
              xmlns:quizzes="clr-namespace:SSW.Rewards.Shared.DTOs.Quizzes;assembly=Shared"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             BackgroundColor="{StaticResource QuizDescriptionBackground}"
+             BackgroundColor="{StaticResource Background}"
              ControlTemplate="{DynamicResource PageTemplate}"
              x:DataType="viewModels:QuizDetailsViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.QuizDetailsPage">
     <ContentPage.Resources>
-        <converters:AllTrueConverter x:Key="AllTrueConverter"/>
+        <converters:AllTrueConverter x:Key="AllTrueConverter" />
     </ContentPage.Resources>
     <ScrollView>
-        <Border
-            StrokeThickness="0"
-            StrokeShape="RoundRectangle 8"
-            Margin="{OnPlatform '15', iOS='15,15,15,95'}"
-            BackgroundColor="{StaticResource Background}">
-            <Grid>
-                <Grid RowDefinitions="120, Auto, Auto, 40, 40, *, 60">
-                    <Grid.IsVisible>
-                        <MultiBinding Converter="{StaticResource AllTrueConverter}">
-                            <Binding Path="QuestionsVisible"/>
-                            <Binding Path="IsLoadingQuestions" Converter="{toolkit:InvertedBoolConverter}"/>
-                        </MultiBinding>
-                    </Grid.IsVisible>
+        <Grid>
+            <!-- Questions -->
+            <Grid BackgroundColor="{StaticResource QuizDescriptionBackground}">
+                <Grid.IsVisible>
+                    <MultiBinding Converter="{StaticResource AllTrueConverter}">
+                        <Binding Path="QuestionsVisible" />
+                        <Binding Path="IsLoadingQuestions" Converter="{toolkit:InvertedBoolConverter}" />
+                    </MultiBinding>
+                </Grid.IsVisible>
+                <Border
+                    StrokeThickness="0"
+                    StrokeShape="RoundRectangle 8"
+                    Margin="{OnPlatform '15', iOS='15,15,15,95'}"
+                    BackgroundColor="{StaticResource Background}">
+                    <Grid RowDefinitions="120, Auto, Auto, 40, 40, *, 60">
 
-                    <Border Grid.Row="0"
-                            HeightRequest="80"
-                            WidthRequest="80"
-                            BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                            StrokeThickness="0"
-                            StrokeShape="RoundRectangle 6">
-                        <Image Source="{Binding ThumbnailImage}"
-                               HorizontalOptions="Center"
-                               VerticalOptions="Center"
-                               HeightRequest="80"
-                               WidthRequest="80"
-                               Aspect="AspectFill" />
-                    </Border>
-
-                    <Label Grid.Row="1"
-                           Text="{Binding QuizTitle}"
-                           Style="{StaticResource LabelBold}"
-                           Margin="10,0"
-                           FontSize="24"
-                           HorizontalTextAlignment="Center" />
-
-                    <Label Grid.Row="2"
-                           Text="{Binding QuizDescription}"
-                           TextColor="{StaticResource Gray300}"
-                           Margin="10,0"
-                           FontSize="18"
-                           HorizontalTextAlignment="Center" />
-
-                    <!-- Reward amount -->
-                    <Border Grid.Row="3"
-                            StrokeThickness="0"
-                            StrokeShape="RoundRectangle 8"
-                            WidthRequest="80"
-                            Margin="0,10,0,0"
-                            BackgroundColor="{StaticResource FlyoutBackgroundColour}">
-                        <Grid ColumnDefinitions="30,*">
-                            <Label
-                                Grid.Column="0"
-                                TextColor="{StaticResource Coin}"
-                                Text="&#xf51e;"
-                                FontFamily="FA6Solid"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                FontSize="11"
-                                Style="{StaticResource LabelBold}"
-                                InputTransparent="True" />
-                            <Label Grid.Column="1" Text="{Binding Points}"
-                                   TextColor="White"
-                                   FontSize="18"
+                        <Border Grid.Row="0"
+                                HeightRequest="80"
+                                WidthRequest="80"
+                                BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 6">
+                            <Image Source="{Binding ThumbnailImage}"
                                    HorizontalOptions="Center"
-                                   VerticalOptions="Center" />
-                        </Grid>
-                    </Border>
-
-                    <IndicatorView Grid.Row="4"
-                                   InputTransparent="True"
-                                   SelectedIndicatorColor="{StaticResource SSWRed}"
-                                   IndicatorColor="{StaticResource IndicatorColor}"
-                                   IndicatorSize="4.5"
-                                   Position="{Binding CurrentQuestionIndex}"
-                                   Count="{Binding Questions.Count}"
-                                   HorizontalOptions="Center"
-                                   VerticalOptions="End"/>
-
-                    <!-- Question & Answer -->
-                    <Grid Grid.Row="5" RowDefinitions="Auto,Auto" Margin="20">
-                        <Label Grid.Row="0"
-                               HorizontalOptions="FillAndExpand"
-                               VerticalOptions="FillAndExpand"
-                               HorizontalTextAlignment="Start"
-                               VerticalTextAlignment="End"
-                               Style="{StaticResource LabelBold}"
-                               TextColor="White"
-                               FontSize="Large"
-                               Margin="0,0,0,40"
-                               Text="{Binding CurrentQuestion.Text, StringFormat='Q: {0}'}" />
-                        <Border
-                            Grid.Row="1"
-                            Stroke="{StaticResource White}"
-                            StrokeShape="RoundRectangle 8"
-                            IsVisible="{Binding CurrentQuestion.IsSubmitted, Converter={toolkit:InvertedBoolConverter}}">
-                            <Editor
-                                TextColor="{StaticResource White}"
-                                VerticalTextAlignment="Start"
-                                AutoSize="TextChanges"
-                                Text="{Binding CurrentQuestion.Answer}"
-                                MinimumHeightRequest="150"
-                                Placeholder="Enter your answer here"
-                                Keyboard="Plain">
-                                <Editor.Behaviors>
-                                    <toolkit:EventToCommandBehavior
-                                        x:TypeArguments="TextChangedEventArgs"
-                                        EventName="TextChanged"
-                                        Command="{Binding AnswerChangedCommand}"/>
-                                </Editor.Behaviors>
-                            </Editor>
+                                   VerticalOptions="Center"
+                                   HeightRequest="80"
+                                   WidthRequest="80"
+                                   Aspect="AspectFill" />
                         </Border>
+
                         <Label Grid.Row="1"
-                               IsVisible="{Binding CurrentQuestion.IsSubmitted}"
-                               Text="{Binding CurrentQuestion.Answer, StringFormat='A: {0}'}"
-                               FontSize="Medium"
-                               TextColor="{StaticResource White}" />
+                               Text="{Binding QuizTitle}"
+                               Style="{StaticResource LabelBold}"
+                               Margin="10,0"
+                               FontSize="24"
+                               HorizontalTextAlignment="Center" />
+
+                        <Label Grid.Row="2"
+                               Text="{Binding QuizDescription}"
+                               TextColor="{StaticResource Gray300}"
+                               Margin="10,0"
+                               FontSize="18"
+                               HorizontalTextAlignment="Center" />
+
+                        <!-- Reward amount -->
+                        <Border Grid.Row="3"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 8"
+                                WidthRequest="80"
+                                Margin="0,10,0,0"
+                                BackgroundColor="{StaticResource FlyoutBackgroundColour}">
+                            <Grid ColumnDefinitions="30,*">
+                                <Label
+                                    Grid.Column="0"
+                                    TextColor="{StaticResource Coin}"
+                                    Text="&#xf51e;"
+                                    FontFamily="FA6Solid"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    FontSize="11"
+                                    Style="{StaticResource LabelBold}"
+                                    InputTransparent="True" />
+                                <Label Grid.Column="1" Text="{Binding Points}"
+                                       TextColor="White"
+                                       FontSize="18"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center" />
+                            </Grid>
+                        </Border>
+
+                        <IndicatorView Grid.Row="4"
+                                       InputTransparent="True"
+                                       SelectedIndicatorColor="{StaticResource SSWRed}"
+                                       IndicatorColor="{StaticResource IndicatorColor}"
+                                       IndicatorSize="4.5"
+                                       Position="{Binding CurrentQuestionIndex}"
+                                       Count="{Binding Questions.Count}"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="End" />
+
+                        <!-- Question & Answer -->
+                        <Grid Grid.Row="5" RowDefinitions="Auto,Auto" Margin="20">
+                            <Label Grid.Row="0"
+                                   HorizontalOptions="FillAndExpand"
+                                   VerticalOptions="FillAndExpand"
+                                   HorizontalTextAlignment="Start"
+                                   VerticalTextAlignment="End"
+                                   Style="{StaticResource LabelBold}"
+                                   TextColor="White"
+                                   FontSize="Large"
+                                   Margin="0,0,0,40"
+                                   Text="{Binding CurrentQuestion.Text, StringFormat='Q: {0}'}" />
+                            <Border
+                                Grid.Row="1"
+                                Stroke="{StaticResource White}"
+                                StrokeShape="RoundRectangle 8"
+                                IsVisible="{Binding CurrentQuestion.IsSubmitted, Converter={toolkit:InvertedBoolConverter}}">
+                                <Editor
+                                    TextColor="{StaticResource White}"
+                                    VerticalTextAlignment="Start"
+                                    AutoSize="TextChanges"
+                                    Text="{Binding CurrentQuestion.Answer}"
+                                    MinimumHeightRequest="150"
+                                    Placeholder="Enter your answer here"
+                                    Keyboard="Plain">
+                                    <Editor.Behaviors>
+                                        <toolkit:EventToCommandBehavior
+                                            x:TypeArguments="TextChangedEventArgs"
+                                            EventName="TextChanged"
+                                            Command="{Binding AnswerChangedCommand}" />
+                                    </Editor.Behaviors>
+                                </Editor>
+                            </Border>
+                            <Label Grid.Row="1"
+                                   IsVisible="{Binding CurrentQuestion.IsSubmitted}"
+                                   Text="{Binding CurrentQuestion.Answer, StringFormat='A: {0}'}"
+                                   FontSize="Medium"
+                                   TextColor="{StaticResource White}" />
+                        </Grid>
+
+                        <!-- Quiz navigation -->
+                        <Grid Grid.Row="6"
+                              ColumnDefinitions="*,*"
+                              Margin="20,0,20,10"
+                              IsEnabled="{Binding IsBusy, Converter={toolkit:InvertedBoolConverter}}">
+                            <Button Grid.Column="0"
+                                    IsVisible="{Binding IsFirstQuestion, Converter={toolkit:InvertedBoolConverter}}"
+                                    Text="&#xf060;"
+                                    Command="{Binding MoveBackCommand}"
+                                    FontFamily="FA6Solid"
+                                    TextColor="White"
+                                    HeightRequest="40"
+                                    VerticalOptions="End"
+                                    HorizontalOptions="Start"
+                                    Padding="0"
+                                    CornerRadius="10"
+                                    BackgroundColor="{StaticResource SSWRed}"
+                                    WidthRequest="40" />
+
+                            <Button Grid.Column="1"
+                                    IsVisible="{Binding IsLastQuestion, Converter={toolkit:InvertedBoolConverter}}"
+                                    Text="&#xf061;"
+                                    Command="{Binding MoveForwardCommand}"
+                                    FontFamily="FA6Solid"
+                                    TextColor="White"
+                                    HeightRequest="40"
+                                    VerticalOptions="End"
+                                    HorizontalOptions="End"
+                                    Padding="0"
+                                    CornerRadius="10"
+                                    BackgroundColor="{StaticResource SSWRed}"
+                                    WidthRequest="40" />
+
+                            <Button Grid.Column="1"
+                                    IsVisible="{Binding IsLastQuestion}"
+                                    Text="Submit"
+                                    Command="{Binding SubmitResponsesCommand}"
+                                    Style="{StaticResource LabelBold}"
+                                    FontSize="12"
+                                    TextColor="White"
+                                    HeightRequest="40"
+                                    VerticalOptions="End"
+                                    HorizontalOptions="End"
+                                    Padding="0"
+                                    CornerRadius="10"
+                                    BackgroundColor="{StaticResource SSWRed}"
+                                    WidthRequest="80" />
+                        </Grid>
+
+                        <ActivityIndicator HorizontalOptions="Center"
+                                           VerticalOptions="Center"
+                                           Color="{StaticResource SSWRed}"
+                                           IsVisible="{Binding IsBusy}"
+                                           IsRunning="{Binding IsBusy}"
+                                           Grid.Row="5" />
                     </Grid>
+                </Border>
+            </Grid>
 
-                    <!-- Quiz navigation -->
-                    <Grid Grid.Row="6"
-                          ColumnDefinitions="*,*"
-                          Margin="20,0,20,10"
-                          IsEnabled="{Binding IsBusy, Converter={toolkit:InvertedBoolConverter}}">
-                        <Button Grid.Column="0"
-                                IsVisible="{Binding IsFirstQuestion, Converter={toolkit:InvertedBoolConverter}}"
-                                Text="&#xf060;"
-                                Command="{Binding MoveBackCommand}"
-                                FontFamily="FA6Solid"
-                                TextColor="White"
-                                HeightRequest="40"
-                                VerticalOptions="End"
-                                HorizontalOptions="Start"
-                                Padding="0"
-                                CornerRadius="10"
-                                BackgroundColor="{StaticResource SSWRed}"
-                                WidthRequest="40" />
-
-                        <Button Grid.Column="1"
-                                IsVisible="{Binding IsLastQuestion, Converter={toolkit:InvertedBoolConverter}}"
-                                Text="&#xf061;"
-                                Command="{Binding MoveForwardCommand}"
-                                FontFamily="FA6Solid"
-                                TextColor="White"
-                                HeightRequest="40"
-                                VerticalOptions="End"
-                                HorizontalOptions="End"
-                                Padding="0"
-                                CornerRadius="10"
-                                BackgroundColor="{StaticResource SSWRed}"
-                                WidthRequest="40" />
-
-                        <Button Grid.Column="1"
-                                IsVisible="{Binding IsLastQuestion}"
-                                Text="Submit"
-                                Command="{Binding SubmitResponsesCommand}"
-                                Style="{StaticResource LabelBold}"
-                                FontSize="12"
-                                TextColor="White"
-                                HeightRequest="40"
-                                VerticalOptions="End"
-                                HorizontalOptions="End"
-                                Padding="0"
-                                CornerRadius="10"
-                                BackgroundColor="{StaticResource SSWRed}"
-                                WidthRequest="80" />
-                    </Grid>
-
-                    <ActivityIndicator HorizontalOptions="Center"
-                                       VerticalOptions="Center"
-                                       Color="{StaticResource SSWRed}"
-                                       IsVisible="{Binding IsBusy}"
-                                       IsRunning="{Binding IsBusy}"
-                                       Grid.Row="5" />
-                </Grid>
-
-                <!-- Results -->
-                <Grid RowDefinitions="70, 50, *"
-                      IsVisible="{Binding ResultsVisible}">
+            <!-- Results -->
+            <VerticalStackLayout IsVisible="{Binding ResultsVisible}"
+                                 BackgroundColor="{StaticResource QuizDescriptionBackground}">
+                <VerticalStackLayout BackgroundColor="{StaticResource Background}"
+                                     Padding="0,0,0,20">
+                    <Border BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                            HorizontalOptions="Center"
+                            StrokeThickness="0"
+                            StrokeShape="RoundRectangle 6"
+                            WidthRequest="50"
+                            HeightRequest="50"
+                            Margin="0,0,0,20">
+                        <Label Text="😢"
+                               VerticalOptions="Center"
+                               HorizontalOptions="Center"
+                               FontSize="26"
+                               FontAutoScalingEnabled="False">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label"
+                                             Binding="{Binding TestPassed}"
+                                             Value="True">
+                                    <Setter Property="Text" Value="🎉" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+                    </Border>
 
                     <Label Text="{Binding ResultsTitle}"
-                           TextTransform="Uppercase"
                            HorizontalOptions="Center"
                            HorizontalTextAlignment="Center"
                            VerticalOptions="Center"
-                           FontSize="Title"
-                           TextColor="White"
-                           Grid.Row="0" />
+                           Style="{StaticResource LabelBold}"
+                           FontSize="22"
+                           TextColor="White" />
 
-                    <Border Grid.Row="1"
-                            BackgroundColor="{Binding ScoreBackground}"
-                            WidthRequest="150"
-                            HeightRequest="40"
-                            StrokeShape="RoundRectangle 6"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center">
-                        <Label Text="{Binding Score}"
-                               TextColor="White"
-                               FontSize="Title"
-                               HorizontalOptions="Center"
-                               VerticalOptions="Center"
-                               HorizontalTextAlignment="Center"
-                               VerticalTextAlignment="Center" />
-                    </Border>
+                    <Label FontSize="14"
+                           TextColor="{StaticResource Gray300}"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           HorizontalTextAlignment="Center"
+                           VerticalTextAlignment="Center">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="You got " />
+                                <Span Text="{Binding Score}" TextColor="{StaticResource SSWRed}" FontAttributes="Bold" />
+                                <Span Text=" questions right." />
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
 
+                    <Label IsVisible="{Binding TestPassed, Converter={toolkit:InvertedBoolConverter}}"
+                           Text="Try again once you are ready!"
+                           FontSize="14"
+                           TextColor="{StaticResource Gray300}"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           HorizontalTextAlignment="Center"
+                           VerticalTextAlignment="Center" />
+                </VerticalStackLayout>
 
-                    <VerticalStackLayout BindableLayout.ItemsSource="{Binding Results}"
-                                         Margin="10"
-                                         Grid.Row="2"
-                                         Spacing="8">
-                        <BindableLayout.ItemTemplate>
-                            <DataTemplate x:DataType="quizzes:QuestionResultDto">
-                                <Border BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                                        StrokeThickness="2"
-                                        StrokeShape="RoundRectangle 6"
-                                        Padding="5,10">
-                                    <Border.Triggers>
-                                        <DataTrigger TargetType="Border"
-                                                     Binding="{Binding Correct}"
-                                                     Value="False">
-                                            <Setter Property="Stroke" Value="{StaticResource SSWRed}"/>
-                                        </DataTrigger>
-                                    </Border.Triggers>
-                                    <toolkit:Expander
-                                        x:Name="Expander"
-                                        IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
-                                        <toolkit:Expander.Header>
-                                            <Grid
-                                                ColumnDefinitions="40, *, Auto"
-                                                RowDefinitions="Auto"
-                                                ColumnSpacing="6">
-                                                <lottie:SKLottieView Grid.Column="0"
-                                                                     Source="pass.json"
-                                                                     IsAnimationEnabled="True"
-                                                                     WidthRequest="30"
-                                                                     HeightRequest="30"
-                                                                     IsVisible="{Binding Correct}" />
-                                                <lottie:SKLottieView Grid.Column="0"
-                                                                     Source="fail.json"
-                                                                     IsAnimationEnabled="True"
-                                                                     WidthRequest="30"
-                                                                     HeightRequest="30"
-                                                                     IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
-                                                <Label Grid.Column="1"
-                                                       VerticalTextAlignment="Center"
-                                                       Text="{Binding QuestionText}"
-                                                       FontSize="Medium" />
-                                                <Image Grid.Column="2"
-                                                       Margin="0,0,10,0"
-                                                       IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}"
-                                                       HeightRequest="20"
-                                                       WidthRequest="20"
-                                                       Source="icon_chevron_right"/>
-                                                <Image Grid.Column="2"
-                                                       Margin="0,0,10,0"
-                                                       IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}"
-                                                       HeightRequest="20"
-                                                       WidthRequest="20"
-                                                       Source="icon_chevron_down"/>
-                                            </Grid>
-                                        </toolkit:Expander.Header>
-                                        <VerticalStackLayout Padding="10">
-                                            <Label Text="Your response:"
-                                                   FontSize="Medium"
-                                                   Style="{StaticResource LabelBold}"/>
-                                            <Label Text="{Binding AnswerText}"
-                                                   FontSize="Medium"/>
-                                            <Label Text="Explanation:"
-                                                   Margin="0,8,0,0"
-                                                   FontSize="Medium"
-                                                   Style="{StaticResource LabelBold}"/>
-                                            <Label Text="{Binding ExplanationText}"
-                                                   FontSize="Medium"/>
-                                        </VerticalStackLayout>
-                                    </toolkit:Expander>
-                                </Border>
-                            </DataTemplate>
-                        </BindableLayout.ItemTemplate>
-                    </VerticalStackLayout>
-                </Grid>
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Results}"
+                                     BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                                     Padding="15"
+                                     Spacing="15">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="quizzes:QuestionResultDto">
+                            <Border BackgroundColor="{StaticResource Background}"
+                                    StrokeThickness="0"
+                                    StrokeShape="RoundRectangle 6"
+                                    Padding="15">
+                                <Border.Triggers>
+                                    <DataTrigger TargetType="Border"
+                                                 Binding="{Binding Correct}"
+                                                 Value="False">
+                                        <Setter Property="Stroke" Value="{StaticResource SSWRed}" />
+                                    </DataTrigger>
+                                </Border.Triggers>
+                                <VerticalStackLayout Spacing="5">
+                                    <Label Text="{Binding Index, StringFormat='Question {0}'}"
+                                           FontSize="12">
+                                        <Label.FormattedText>
+                                            <FormattedString>
+                                                <Span Text="Question " />
+                                                <Span Text="{Binding Index}" />
+                                                <Span Text="/" />
+                                                <Span Text="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizDetailsViewModel}}, Path=Questions.Count}" />
+                                            </FormattedString>
+                                        </Label.FormattedText>
+                                    </Label>
+                                    
+                                    <Label Text="{Binding QuestionText}"
+                                           FontSize="14"/>
+                                    
+                                    <Border BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                                            StrokeThickness="0"
+                                            StrokeShape="RoundRectangle 6"
+                                            Padding="5"
+                                            Margin="0,10,0,0">
+                                        <toolkit:Expander
+                                            x:Name="Expander"
+                                            IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
+                                            <toolkit:Expander.Header>
+                                                <Grid
+                                                    ColumnDefinitions="20, *, Auto"
+                                                    RowDefinitions="Auto"
+                                                    ColumnSpacing="6">
+                                                    <Label Grid.Column="0"
+                                                           FontFamily="FA6Regular"
+                                                           TextColor="{StaticResource QuizCheckColor}"
+                                                           VerticalTextAlignment="Center"
+                                                           VerticalOptions="Center"
+                                                           HorizontalOptions="Center"
+                                                           FontSize="14"
+                                                           Text="&#xf058;"
+                                                           IsVisible="{Binding Correct}" />
+                                                    <Label Grid.Column="0"
+                                                           FontFamily="FA6Regular"
+                                                           TextColor="{StaticResource SSWRed}"
+                                                           VerticalTextAlignment="Center"
+                                                           VerticalOptions="Center"
+                                                           HorizontalOptions="Center"
+                                                           FontSize="14"
+                                                           Text="&#xf057;"
+                                                           IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
+                                                    
+                                                    <Label Grid.Column="1"
+                                                           VerticalTextAlignment="Center"
+                                                           VerticalOptions="Center"
+                                                           Text="Correct"
+                                                           IsVisible="{Binding Correct}"
+                                                           TextColor="{StaticResource QuizCheckColor}"
+                                                           FontSize="14" />
+                                                    <Label Grid.Column="1"
+                                                           VerticalTextAlignment="Center"
+                                                           VerticalOptions="Center"
+                                                           Text="Incorrect"
+                                                           IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}"
+                                                           TextColor="{StaticResource SSWRed}"
+                                                           FontSize="14" />
 
-                <ActivityIndicator
-                   HorizontalOptions="Center"
-                   VerticalOptions="Center"
-                   Color="{StaticResource SSWRed}"
-                   IsEnabled="{Binding IsLoadingQuestions}"
-                   IsRunning="{Binding IsLoadingQuestions}"
-                   IsVisible="{Binding IsLoadingQuestions}" />
-            </Grid>
-        </Border>
+                                                    <Image Grid.Column="2"
+                                                           Margin="0,0,10,0"
+                                                           IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}"
+                                                           HeightRequest="12"
+                                                           WidthRequest="12"
+                                                           Source="icon_chevron_right" />
+                                                    <Image Grid.Column="2"
+                                                           Margin="0,0,10,0"
+                                                           IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}"
+                                                           HeightRequest="12"
+                                                           WidthRequest="12"
+                                                           Source="icon_chevron_down" />
+                                                </Grid>
+                                            </toolkit:Expander.Header>
+                                            <VerticalStackLayout Padding="26,10,10,10">
+                                                <Label Text="Your response:"
+                                                       FontSize="14"
+                                                       Style="{StaticResource LabelBold}"
+                                                       TextColor="{StaticResource Gray300}" />
+                                                <Label Text="{Binding AnswerText}"
+                                                       FontSize="14"
+                                                       TextColor="{StaticResource Gray300}"/>
+                                                <Label Text="Explanation:"
+                                                       Margin="0,8,0,0"
+                                                       FontSize="14"
+                                                       Style="{StaticResource LabelBold}"
+                                                       TextColor="{StaticResource Gray300}"/>
+                                                <Label Text="{Binding ExplanationText}"
+                                                       FontSize="14"
+                                                       TextColor="{StaticResource Gray300}"/>
+                                            </VerticalStackLayout>
+                                        </toolkit:Expander>
+                                    </Border>
+
+                                </VerticalStackLayout>
+
+                            </Border>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+            </VerticalStackLayout>
+
+            <ActivityIndicator
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                Color="{StaticResource SSWRed}"
+                IsEnabled="{Binding IsLoadingQuestions}"
+                IsRunning="{Binding IsLoadingQuestions}"
+                IsVisible="{Binding IsLoadingQuestions}" />
+        </Grid>
     </ScrollView>
 </ContentPage>

--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -195,9 +195,11 @@
             </Grid>
 
             <!-- Results -->
-            <VerticalStackLayout IsVisible="{Binding ResultsVisible}"
-                                 BackgroundColor="{StaticResource QuizDescriptionBackground}">
-                <VerticalStackLayout BackgroundColor="{StaticResource Background}"
+            <Grid IsVisible="{Binding ResultsVisible}"
+                  BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                  RowDefinitions="Auto, *">
+                <VerticalStackLayout Grid.Row="0"
+                                     BackgroundColor="{StaticResource Background}"
                                      Padding="0,0,0,20">
                     <Border BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                             HorizontalOptions="Center"
@@ -206,7 +208,7 @@
                             WidthRequest="50"
                             HeightRequest="50"
                             Margin="0,0,0,20">
-                        <Label Text="😢"
+                        <Label Text="😥"
                                VerticalOptions="Center"
                                HorizontalOptions="Center"
                                FontSize="26"
@@ -253,8 +255,13 @@
                            HorizontalTextAlignment="Center"
                            VerticalTextAlignment="Center" />
                 </VerticalStackLayout>
+                
+                <lottie:SKConfettiView
+                    Grid.Row="0"
+                    IsAnimationEnabled="{Binding ShowConfetti}" />
 
-                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Results}"
+                <VerticalStackLayout Grid.Row="1"
+                                     BindableLayout.ItemsSource="{Binding Results}"
                                      BackgroundColor="{StaticResource QuizDescriptionBackground}"
                                      Padding="15"
                                      Spacing="15">
@@ -285,27 +292,25 @@
                                     </Label>
                                     
                                     <Label Text="{Binding QuestionText}"
-                                           FontSize="14"/>
+                                           FontSize="16"/>
                                     
                                     <Border BackgroundColor="{StaticResource QuizDescriptionBackground}"
                                             StrokeThickness="0"
                                             StrokeShape="RoundRectangle 6"
-                                            Padding="5"
+                                            Padding="10"
                                             Margin="0,10,0,0">
                                         <toolkit:Expander
                                             x:Name="Expander"
                                             IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
                                             <toolkit:Expander.Header>
                                                 <Grid
-                                                    ColumnDefinitions="20, *, Auto"
-                                                    RowDefinitions="Auto"
-                                                    ColumnSpacing="6">
+                                                    ColumnDefinitions="20, *, 20"
+                                                    RowDefinitions="Auto">
                                                     <Label Grid.Column="0"
                                                            FontFamily="FA6Regular"
                                                            TextColor="{StaticResource QuizCheckColor}"
                                                            VerticalTextAlignment="Center"
                                                            VerticalOptions="Center"
-                                                           HorizontalOptions="Center"
                                                            FontSize="14"
                                                            Text="&#xf058;"
                                                            IsVisible="{Binding Correct}" />
@@ -314,7 +319,6 @@
                                                            TextColor="{StaticResource SSWRed}"
                                                            VerticalTextAlignment="Center"
                                                            VerticalOptions="Center"
-                                                           HorizontalOptions="Center"
                                                            FontSize="14"
                                                            Text="&#xf057;"
                                                            IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
@@ -335,20 +339,18 @@
                                                            FontSize="14" />
 
                                                     <Image Grid.Column="2"
-                                                           Margin="0,0,10,0"
                                                            IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}"
                                                            HeightRequest="12"
                                                            WidthRequest="12"
                                                            Source="icon_chevron_right" />
                                                     <Image Grid.Column="2"
-                                                           Margin="0,0,10,0"
                                                            IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}"
                                                            HeightRequest="12"
                                                            WidthRequest="12"
                                                            Source="icon_chevron_down" />
                                                 </Grid>
                                             </toolkit:Expander.Header>
-                                            <VerticalStackLayout Padding="26,10,10,10">
+                                            <VerticalStackLayout Padding="20,10">
                                                 <Label Text="Your response:"
                                                        FontSize="14"
                                                        Style="{StaticResource LabelBold}"
@@ -374,7 +376,7 @@
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>
                 </VerticalStackLayout>
-            </VerticalStackLayout>
+            </Grid>
 
             <ActivityIndicator
                 HorizontalOptions="Center"

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -212,7 +212,6 @@ namespace SSW.Rewards.Mobile.ViewModels
         {
             QuestionsVisible = false;
             ResultsVisible = true;
-            WeakReferenceMessenger.Default.Send(new TopBarAvatarMessage(AvatarOptions.Done));
 
             var total = result.Results.Count;
             var correct = result.Results.Count(r => r.Correct);
@@ -299,6 +298,22 @@ namespace SSW.Rewards.Mobile.ViewModels
         private void AnswerChanged(TextChangedEventArgs args)
         {
             CurrentQuestion.Answer = args.NewTextValue;
+        }
+        
+        [RelayCommand]
+        private async Task Restart()
+        {
+            Questions.Clear();
+            ResultsVisible = false;
+            QuestionsVisible = true;
+            await Initialise(_quizId);
+            MoveTo(0);
+        }
+        
+        [RelayCommand]
+        private static async Task Done()
+        {
+            await Shell.Current.GoToAsync("..");
         }
     }
 

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -212,8 +212,8 @@ namespace SSW.Rewards.Mobile.ViewModels
             WeakReferenceMessenger.Default.Send(new TopBarAvatarMessage(AvatarOptions.Done));
 
             var total = result.Results.Count;
-
             var correct = result.Results.Count(r => r.Correct);
+            int index = 1;
 
             Score = $"{correct}/{total}";
 
@@ -221,6 +221,7 @@ namespace SSW.Rewards.Mobile.ViewModels
 
             foreach (var questionResult in result.Results.OrderBy(r => r.QuestionId))
             {
+                questionResult.Index = index++;
                 Results.Add(questionResult);
             }
 
@@ -230,7 +231,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                 App.Current.Resources.TryGetValue("SuccessGreen", out object successGreen);
 
                 ScoreBackground = (Color)successGreen!;
-                ResultsTitle = "Test Passed!";
+                ResultsTitle = "Good job!";
                 TestPassed = true;
                 SnackOptions = new SnackbarOptions
                 {
@@ -251,7 +252,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                 App.Current.Resources.TryGetValue("SSWRed", out object sswRed);
 
                 ScoreBackground = (Color)sswRed!;
-                ResultsTitle = "Test Failed";
+                ResultsTitle = "Don't give up!";
                 TestPassed = false;
             }
         }

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -52,6 +52,9 @@ namespace SSW.Rewards.Mobile.ViewModels
 
         [ObservableProperty]
         private bool _testPassed;
+        
+        [ObservableProperty]
+        private bool _showConfetti;
 
         [ObservableProperty]
         private string _icon;
@@ -233,6 +236,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                 ScoreBackground = (Color)successGreen!;
                 ResultsTitle = "Good job!";
                 TestPassed = true;
+                ShowConfetti = true;
                 SnackOptions = new SnackbarOptions
                 {
                     ActionCompleted = true,
@@ -254,6 +258,7 @@ namespace SSW.Rewards.Mobile.ViewModels
                 ScoreBackground = (Color)sswRed!;
                 ResultsTitle = "Don't give up!";
                 TestPassed = false;
+                ShowConfetti = false;
             }
         }
 

--- a/src/MobileUI/Features/TopBar/TopBarViewModel.cs
+++ b/src/MobileUI/Features/TopBar/TopBarViewModel.cs
@@ -23,9 +23,6 @@ public partial class TopBarViewModel : ObservableObject
     private bool _showBack;
 
     [ObservableProperty]
-    private bool _showDone;
-
-    [ObservableProperty]
     private bool _showScanner = true;
     
     [ObservableProperty]
@@ -40,9 +37,6 @@ public partial class TopBarViewModel : ObservableObject
         {
             switch (m.Value)
             {
-                case AvatarOptions.Done:
-                    SetDoneButton();
-                    break;
                 case AvatarOptions.Back:
                     SetBackButton();
                     break;
@@ -87,7 +81,6 @@ public partial class TopBarViewModel : ObservableObject
 
     private void SetDefaultAvatar()
     {
-        ShowDone = false;
         ShowBack = false;
         ShowAvatar = true;
         ShowScanner = true;
@@ -95,16 +88,7 @@ public partial class TopBarViewModel : ObservableObject
 
     private void SetBackButton()
     {
-        ShowDone = false;
         ShowBack = true;
-        ShowAvatar = false;
-        ShowScanner = false;
-    }
-
-    private void SetDoneButton()
-    {
-        ShowDone = true;
-        ShowBack = false;
         ShowAvatar = false;
         ShowScanner = false;
     }

--- a/src/MobileUI/Resources/Styles/Colors.xaml
+++ b/src/MobileUI/Resources/Styles/Colors.xaml
@@ -71,7 +71,7 @@
     <Color x:Key="HighlightedText">#dbdbdb</Color>
     <Color x:Key="PassedQuiz">#818181</Color>
     <Color x:Key="Quiz">#f7f7f7</Color>
-    <Color x:Key="QuizCheckColor">#1d4c39</Color>
+    <Color x:Key="QuizCheckColor">#679506</Color>
     <Color x:Key="PassedQuizIcon">#181818</Color>
     <Color x:Key="QuizDescriptionBackground">#2f2f2f</Color>
     <Color x:Key="ProfileGridBorder">#A0A0A0</Color>

--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -57,17 +57,6 @@
                                          Color="White"/>
                     </Button.ImageSource>
                 </Button>
-
-                <Button Grid.Column="0"
-                        HeightRequest="40"
-                        CornerRadius="5"
-                        BorderColor="White"
-                        BackgroundColor="{StaticResource SSWRed}"
-                        Margin="10,7.5"
-                        Padding="10,3"
-                        IsVisible="{Binding ShowDone}"
-                        Text="Done"
-                        Command="{Binding GoBackCommand}" />
                 
                 <Label Grid.Column="1"
                        Text="{Binding Title}"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #844 

> 2. What was changed?

Updates the quiz results page to use Ken's design.

<img src="https://github.com/user-attachments/assets/6d3212f2-55ea-4b0d-af88-7f34050ae73e" width="400" />

**✅ Figure: Quiz results page when test passed**

<img src="https://github.com/user-attachments/assets/583e3d97-0f44-4e88-8112-5b8f92b1b247" width="400" />

**✅ Figure: Quiz results page when test failed**


> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->