### PR TITLE
🛠️ Fix iOS build in pipeline

### DIFF
--- a/.github/workflows/admin-build.yml
+++ b/.github/workflows/admin-build.yml
@@ -11,7 +11,9 @@ jobs:
         - uses: actions/checkout@v2
   
         - name: Setup .NET
-          uses: actions/setup-dotnet@v3
+          uses: actions/setup-dotnet@v4
+          with:
+            global-json-file: global.json
 
         - name: Install Workload
           run: |

--- a/.github/workflows/admin-build.yml
+++ b/.github/workflows/admin-build.yml
@@ -12,6 +12,11 @@ jobs:
   
         - name: Setup .NET
           uses: actions/setup-dotnet@v3
+
+        - name: Install Workload
+          run: |
+            dotnet nuget locals all --clear
+            dotnet workload install wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources
   
         - name: Restore
           shell: bash

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -38,9 +38,9 @@ jobs:
           echo ${{ vars.GOOGLE_SERVICES_JSON }} | base64 --decode > src/MobileUI/Platforms/Android/google-services.json
 
       - name: Setup DotNet Environment
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          global-json-file: global.json
 
       - name: Install MAUI Workload
         run: |

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -13,6 +13,11 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: '8.0.x'
+          
+      - name: Install Workload
+        run: |
+          dotnet nuget locals all --clear
+          dotnet workload install wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources
       
       - name: Install dependencies
         run: dotnet restore $PROJECT

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          global-json-file: global.json
           
       - name: Install Workload
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
 
+      - name: Restore Workload
+        run: dotnet workload restore
+
       - name: Restore
         run: dotnet restore ${{ inputs.project_path }}
 
@@ -56,7 +59,7 @@ jobs:
           path: test-results.trx
           reporter: dotnet-trx
 
-  build_and_test_mobile:
+  build_and_test_android:
     name: Build & Test Android
     runs-on: windows-latest
     if: ${{ inputs.test_mobile != 'false' && inputs.test_mobile != '' }}
@@ -86,6 +89,73 @@ jobs:
 
       - name: Build and sign Android
         run: dotnet build src/MobileUI/MobileUI.csproj -f:net8.0-android --configuration Release
+
+      - name: Test
+        run: dotnet test ${{ inputs.project_path }} --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"
+
+      - name: Check file existence
+        id: check_files
+        if: success() || failure()
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "test-results.trx"
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: steps.check_files.outputs.files_exists == 'true'
+        with:
+          name: Tests Results
+          path: test-results.trx
+          reporter: dotnet-trx
+
+  build_and_test_ios:
+    name: Build & Test iOS
+    runs-on: macos-14
+    if: ${{ inputs.test_mobile != 'false' && inputs.test_mobile != '' }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Build Number
+        run: sed -i '' "s|<ApplicationVersion>.*</ApplicationVersion>|<ApplicationVersion>${{ inputs.build_number }}</ApplicationVersion>|g" src/MobileUI/MobileUI.csproj
+
+      - name: Update GoogleService-Info.plist
+        shell: bash
+        run: |
+          echo ${{ vars.GOOGLESERVICE_INFO_PLIST }} | base64 --decode > src/MobileUI/Platforms/iOS/GoogleService-Info.plist
+
+      - name: Setup DotNet Environment
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Install MAUI Workload
+        run: |
+          dotnet nuget locals all --clear
+          dotnet workload install maui --ignore-failed-sources
+          dotnet workload install ios maui wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources
+
+      - name: Set XCode Version
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_15.1.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.1.app" >> $GITHUB_ENV
+
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERT }}
+          p12-password: ${{ secrets.APPLE_CERT_PASSWORD }}
+
+      - name: Import Provisioning Profile
+        run: |
+          echo ${{ secrets.APPLE_PROFILE }} | base64 --decode > SSW_Rewards_iOS_Distribution.mobileprovision
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp SSW_Rewards_iOS_Distribution.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
+
+      - name: Build and sign
+        run: dotnet build src/MobileUI/MobileUI.csproj -f:net8.0-ios --configuration Release
 
       - name: Test
         run: dotnet test ${{ inputs.project_path }} --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "8.0.x"
 
       - name: Restore Workload
         run: dotnet workload restore
@@ -139,20 +141,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          sudo xcode-select -s "/Applications/Xcode_15.1.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.1.app" >> $GITHUB_ENV
-
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v2
-        with:
-          p12-file-base64: ${{ secrets.APPLE_CERT }}
-          p12-password: ${{ secrets.APPLE_CERT_PASSWORD }}
-
-      - name: Import Provisioning Profile
-        run: |
-          echo ${{ secrets.APPLE_PROFILE }} | base64 --decode > SSW_Rewards_iOS_Distribution.mobileprovision
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp SSW_Rewards_iOS_Distribution.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
+          sudo xcode-select -s "/Applications/Xcode_15.4.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.4.app" >> $GITHUB_ENV
 
       - name: Build and sign
         run: dotnet build src/MobileUI/MobileUI.csproj -f:net8.0-ios --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          global-json-file: global.json
 
       - name: Install Workload
         run: |
@@ -72,9 +72,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup DotNet Environment
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          global-json-file: global.json
 
       - name: Install MAUI Workload
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
         with:
           dotnet-version: "8.0.x"
 
-      - name: Restore Workload
-        run: dotnet workload restore
+      - name: Install Workload
+        run: |
+          dotnet nuget locals all --clear
+          dotnet workload install wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources
 
       - name: Restore
         run: dotnet restore ${{ inputs.project_path }}
@@ -61,7 +63,7 @@ jobs:
           path: test-results.trx
           reporter: dotnet-trx
 
-  build_and_test_android:
+  build_and_test_mobile:
     name: Build & Test Android
     runs-on: windows-latest
     if: ${{ inputs.test_mobile != 'false' && inputs.test_mobile != '' }}
@@ -91,61 +93,6 @@ jobs:
 
       - name: Build and sign Android
         run: dotnet build src/MobileUI/MobileUI.csproj -f:net8.0-android --configuration Release
-
-      - name: Test
-        run: dotnet test ${{ inputs.project_path }} --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"
-
-      - name: Check file existence
-        id: check_files
-        if: success() || failure()
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "test-results.trx"
-
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: steps.check_files.outputs.files_exists == 'true'
-        with:
-          name: Tests Results
-          path: test-results.trx
-          reporter: dotnet-trx
-
-  build_and_test_ios:
-    name: Build & Test iOS
-    runs-on: macos-14
-    if: ${{ inputs.test_mobile != 'false' && inputs.test_mobile != '' }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Update Build Number
-        run: sed -i '' "s|<ApplicationVersion>.*</ApplicationVersion>|<ApplicationVersion>${{ inputs.build_number }}</ApplicationVersion>|g" src/MobileUI/MobileUI.csproj
-
-      - name: Update GoogleService-Info.plist
-        shell: bash
-        run: |
-          echo ${{ vars.GOOGLESERVICE_INFO_PLIST }} | base64 --decode > src/MobileUI/Platforms/iOS/GoogleService-Info.plist
-
-      - name: Setup DotNet Environment
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: "8.0.x"
-
-      - name: Install MAUI Workload
-        run: |
-          dotnet nuget locals all --clear
-          dotnet workload install maui --ignore-failed-sources
-          dotnet workload install ios maui wasm-tools --source https://api.nuget.org/v3/index.json --ignore-failed-sources
-
-      - name: Set XCode Version
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_15.4.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.4.app" >> $GITHUB_ENV
-
-      - name: Build and sign
-        run: dotnet build src/MobileUI/MobileUI.csproj -f:net8.0-ios --configuration Release
 
       - name: Test
         run: dotnet test ${{ inputs.project_path }} --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -42,8 +42,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          sudo xcode-select -s "/Applications/Xcode_15.1.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.1.app" >> $GITHUB_ENV
+          sudo xcode-select -s "/Applications/Xcode_15.4.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.4.app" >> $GITHUB_ENV
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -28,9 +28,9 @@ jobs:
           echo ${{ vars.GOOGLESERVICE_INFO_PLIST }} | base64 --decode > src/MobileUI/Platforms/iOS/GoogleService-Info.plist
 
       - name: Setup DotNet Environment
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          global-json-file: global.json
 
       - name: Install MAUI Workload
         run: |

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     environment: ${{ inputs.environment }}
     name: iOS Build
 

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-ios:
     name: Deploy iOS to TestFlight
-    runs-on: macos-13
+    runs-on: macos-14
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact

--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestMinor"
+    "version": "8.0.402",
+    "workloadVersion": "8.0.402.0",
+    "rollForward": "disable",
+    "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
     "version": "8.0.402",
-    "workloadVersion": "8.0.402",
-    "rollForward": "disable",
-    "allowPrerelease": false
+    "workloadVersion": "8.0.402.0",
+    "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.402",
-    "workloadVersion": "8.0.402.0",
+    "workloadVersion": "8.0.402",
     "rollForward": "disable",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.403",
-    "workloadVersion": "8.0.403",
+    "version": "8.0.402",
+    "workloadVersion": "8.0.402.0",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.402",
-    "workloadVersion": "8.0.402.0",
+    "version": "8.0.403",
+    "workloadVersion": "8.0.403",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.402",
-    "workloadVersion": "8.0.402.0",
-    "rollForward": "latestMinor"
+    "workloadVersion": "8.0.402",
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Failing build and deploy for iOS

> 2. What was changed?

It seems that some change in the build pipeline has caused iOS builds to fail recently. Pinning the dotnet version to 8.0.402 and using macos-14 in the build seems to be a common workaround, so giving this a go here.

See: https://developercommunity.visualstudio.com/t/iOS-MAUI-The-type-UIKitNSAdaptiveImage/10754377

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->