### PR TITLE
🐛 Mobile | Fix top bar alignment on newer iPhones

### DIFF
--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -5,25 +5,28 @@
                     xmlns:resolver="clr-namespace:Maui.Plugins.PageResolver;assembly=Maui.Plugins.PageResolver"
                     xmlns:vm="clr-namespace:SSW.Rewards.Mobile.ViewModels">
     <ControlTemplate x:Key="PageTemplate">
-        <Grid RowDefinitions="55,*"
+        <Grid RowDefinitions="60,*"
               Margin="0"
               Padding="0"
-              TranslationY="{OnPlatform iOS=-5, Default=0}">
+              TranslationY="{OnPlatform iOS=-10, Default=0}">
             <Grid.BindingContext>
                 <resolver:ResolveViewModel x:TypeArguments="vm:TopBarViewModel" />
             </Grid.BindingContext>
-            <Grid ColumnDefinitions="60,*,60"
-                  Margin="0"
+            <Grid Grid.Row="0"
+                  ColumnDefinitions="60,*,60"
+                  HeightRequest="60"
+                  Padding="10,5"
                   BackgroundColor="{StaticResource Background}"
+                  VerticalOptions="Start"
                   x:DataType="vm:TopBarViewModel">
                 <!-- Wrapping AvatarView in a Grid where IsVisible can be toggled to work around 
                      an odd animation that happens on iOS
                      See bug: https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/918 -->
                 <Grid Grid.Column="0"
                       IsVisible="{Binding ShowAvatar}"
-                      Margin="10,7,10,5"
                       HeightRequest="40"
-                      WidthRequest="40">
+                      WidthRequest="40"
+                      VerticalOptions="End">
                     <mct:AvatarView ImageSource="{Binding ProfilePic}"
                                     HeightRequest="40"
                                     WidthRequest="40"
@@ -44,12 +47,13 @@
                     CornerRadius="20"
                     MinimumHeightRequest="40"
                     MinimumWidthRequest="40"
+                    BorderWidth="2"
                     BorderColor="White"
                     BackgroundColor="{StaticResource SSWRed}"
-                    Margin="10,7,10,5"
                     Padding="0"
                     IsVisible="{Binding ShowBack}"
-                    Command="{Binding GoBackCommand}">
+                    Command="{Binding GoBackCommand}"
+                    VerticalOptions="End">
                     <Button.ImageSource>
                         <FontImageSource FontFamily="FluentIcons"
                                          Glyph="&#xf189;"
@@ -68,8 +72,8 @@
 
                 <ImageButton Grid.Column="2"
                              Command="{Binding OpenScannerCommand}"
-                             Margin="10,5"
-                             IsVisible="{Binding ShowScanner}">
+                             IsVisible="{Binding ShowScanner}"
+                             VerticalOptions="End">
                     <ImageButton.Source>
                         <FontImageSource FontFamily="FluentIcons"
                                          Glyph="&#xf636;"/>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1079

> 2. What was changed?

On new iPhone models such as the iPhone 16 Pro Max the top bar is displayed with a gap. This removes the gap to make it more consistent across devices.

<img src="https://github.com/user-attachments/assets/b4f33822-f4ca-412e-8189-6e06677220f4" width="400" />

**✅ Figure: Top bar now displaying correctly on iPhone 16 Pro Max**

For reference, this also remains consistent across other devices:

<img src="https://github.com/user-attachments/assets/f13799eb-d8ed-4c67-8f44-070ceb065299" width="400" />

**✅ Figure: Pixel 7**

<img src="https://github.com/user-attachments/assets/b8fd7dd3-9e34-4416-bfba-31561c576d69" width="400" />

**✅ Figure: iPhone SE**

<img src="https://github.com/user-attachments/assets/1b8a6a13-4e94-4ace-bcf9-282077b78d3c" width="400" />

**✅ Figure: iPhone 15 Pro Max**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->