### PR TITLE
🛠️ Fix Android build in pipeline

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Install MAUI Workload
         run: |
           dotnet nuget locals all --clear
-          dotnet workload install maui --ignore-failed-sources --from-rollback-file rollback.json
-          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json --from-rollback-file rollback.json
+          dotnet workload install maui --ignore-failed-sources
+          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json
 
       - name: Restore Dependencies
         run: |

--- a/rollback.json
+++ b/rollback.json
@@ -1,3 +1,0 @@
-{
-  "microsoft.net.sdk.android": "34.0.95/8.0.100"
-}

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -22,6 +22,9 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+
+        <!-- Workaround for HttpClient disposed crashes on Android -->
+        <UseNativeHttpHandler Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">false</UseNativeHttpHandler>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Failing Android build in pipeline

> 2. What was changed?

We had set a rollback file to pin to a specific Android SDK as we were getting HttpClient disposed crashes. This is now clashing with global.json and causing the Android build to fail in the pipeline. See here for the issue: https://github.com/dotnet/android/issues/9039

It appears the issue still persists on newer versions, however a workaround is to disable the native HTTP handler. This seems to all work okay for me locally.

This PR removes the rollback file and disables the native HTTP handler on Android in the .csproj file.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->