### PR TITLE
🐛 Mobile | Fix code unrecognised popup on first login on Android

### DIFF
--- a/src/MobileUI/Features/App.xaml.cs
+++ b/src/MobileUI/Features/App.xaml.cs
@@ -44,6 +44,11 @@ public partial class App : Application
     protected override async void OnAppLinkRequestReceived(Uri uri)
     {
         base.OnAppLinkRequestReceived(uri);
+        
+        if (uri.Scheme != "sswrewards")
+        {
+            return;
+        }
 
         var queryDictionary = System.Web.HttpUtility.ParseQueryString(uri.Query);
         var code = queryDictionary.Get("code");


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1084 

> 2. What was changed?

It seems on Android the login callback triggers the OnAppLinkRequestReceived method that we're using to capture links using our custom URL scheme. This updates this method to check for the correct URL scheme and only execute if it matches our own.

> 3. Did you do pair or mob programming?

No 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->