### PR TITLE
🐛 Mobile | Social media fixes

### DIFF
--- a/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
+++ b/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
@@ -194,7 +194,7 @@ public partial class ProfileViewModelBase : BaseViewModel
             }
 
             Application.Current.Resources.TryGetValue("Background", out var statusBarColor);
-            var page = ActivatorUtilities.CreateInstance<AddSocialMediaPage>(_provider, socialMediaPlatformId, statusBarColor as Color);
+            var page = ActivatorUtilities.CreateInstance<AddSocialMediaPage>(_provider, socialMediaPlatformId, string.Empty, statusBarColor as Color);
             await MopupService.Instance.PushAsync(page);
             return;
         }

--- a/src/MobileUI/Features/Settings/SettingsViewModel.cs
+++ b/src/MobileUI/Features/Settings/SettingsViewModel.cs
@@ -15,6 +15,12 @@ public partial class SettingsViewModel : BaseViewModel
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
     private readonly IServiceProvider _provider;
     
+    private int _myUserId;
+    private string _linkedInUrl;
+    private string _gitHubUrl;
+    private string _twitterUrl;
+    private string _companyUrl;
+    
     [ObservableProperty]
     private bool _isStaff;
 
@@ -27,7 +33,12 @@ public partial class SettingsViewModel : BaseViewModel
         _provider = provider;
         Title = "Settings";
         
+        _userService.MyUserIdObservable().Subscribe(myUserId => _myUserId = myUserId);
         _userService.IsStaffObservable().Subscribe(isStaff => IsStaff = isStaff);
+        _userService.LinkedInProfileObservable().Subscribe(linkedIn => _linkedInUrl = linkedIn);
+        _userService.GitHubProfileObservable().Subscribe(gitHub => _gitHubUrl = gitHub);
+        _userService.TwitterProfileObservable().Subscribe(twitter => _twitterUrl = twitter);
+        _userService.CompanyUrlObservable().Subscribe(company => _companyUrl = company);
     }
 
     public static void Initialise()
@@ -53,30 +64,34 @@ public partial class SettingsViewModel : BaseViewModel
     [RelayCommand]
     private async Task AddLinkedIn()
     {
-        await EditProfile(Constants.SocialMediaPlatformIds.LinkedIn);
+        await _userService.LoadSocialMedia(_myUserId);
+        await EditProfile(Constants.SocialMediaPlatformIds.LinkedIn, _linkedInUrl);
     }
     
     [RelayCommand]
     private async Task AddGitHub()
     {
-        await EditProfile(Constants.SocialMediaPlatformIds.GitHub);
+        await _userService.LoadSocialMedia(_myUserId);
+        await EditProfile(Constants.SocialMediaPlatformIds.GitHub, _gitHubUrl);
     }
     
     [RelayCommand]
     private async Task AddTwitter()
     {
-        await EditProfile(Constants.SocialMediaPlatformIds.Twitter);
+        await _userService.LoadSocialMedia(_myUserId);
+        await EditProfile(Constants.SocialMediaPlatformIds.Twitter, _twitterUrl);
     }
     
     [RelayCommand]
     private async Task AddCompany()
     {
-        await EditProfile(Constants.SocialMediaPlatformIds.Company);
+        await _userService.LoadSocialMedia(_myUserId);
+        await EditProfile(Constants.SocialMediaPlatformIds.Company, _companyUrl);
     }
     
-    private async Task EditProfile(int socialMediaPlatformId) {
+    private async Task EditProfile(int socialMediaPlatformId, string currentUrl = null) {
         Application.Current.Resources.TryGetValue("Background", out var statusBarColor);
-        var page = ActivatorUtilities.CreateInstance<AddSocialMediaPage>(_provider, socialMediaPlatformId, statusBarColor as Color);
+        var page = ActivatorUtilities.CreateInstance<AddSocialMediaPage>(_provider, socialMediaPlatformId, currentUrl, statusBarColor as Color);
         await MopupService.Instance.PushAsync(page);
     }
 

--- a/src/MobileUI/Features/Settings/SettingsViewModel.cs
+++ b/src/MobileUI/Features/Settings/SettingsViewModel.cs
@@ -89,7 +89,7 @@ public partial class SettingsViewModel : BaseViewModel
         await EditProfile(Constants.SocialMediaPlatformIds.Company, _companyUrl);
     }
     
-    private async Task EditProfile(int socialMediaPlatformId, string currentUrl = null) {
+    private async Task EditProfile(int socialMediaPlatformId, string currentUrl) {
         Application.Current.Resources.TryGetValue("Background", out var statusBarColor);
         var page = ActivatorUtilities.CreateInstance<AddSocialMediaPage>(_provider, socialMediaPlatformId, currentUrl, statusBarColor as Color);
         await MopupService.Instance.PushAsync(page);

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -40,7 +40,15 @@
                         <Label HorizontalTextAlignment="Center"
                                Margin="20"
                                TextColor="White"
-                               Text="{Binding Path=PlatformName, StringFormat='Receive ⭐️ 150 points for connecting your {0} with SSW Rewards'}"/>
+                               Text="{Binding Path=PlatformName, StringFormat='Receive ⭐️ 150 points for connecting your {0} with SSW Rewards'}">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label"
+                                             Binding="{Binding CurrentUrl, Converter={toolkit:IsStringNullOrEmptyConverter}}"
+                                             Value="False">
+                                    <Setter Property="Text" Value="{Binding Path=PlatformName, StringFormat='Update your {0} connection with SSW Rewards'}" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
                         <Border
                             Margin="20,0"
                             StrokeShape="RoundRectangle 10"

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
@@ -10,12 +10,13 @@ public partial class AddSocialMediaPage
 
     public AddSocialMediaPage(IFirebaseAnalyticsService firebaseAnalyticsService, IServiceProvider provider,
         int socialMediaPlatformId,
+        string currentUrl = null,
         Color parentPageStatusBarColor = null)
     {
         _parentPageStatusBarColor = parentPageStatusBarColor ?? Colors.Black;
         _firebaseAnalyticsService = firebaseAnalyticsService;
         InitializeComponent();
-        BindingContext = ActivatorUtilities.CreateInstance<AddSocialMediaViewModel>(provider, socialMediaPlatformId);
+        BindingContext = ActivatorUtilities.CreateInstance<AddSocialMediaViewModel>(provider, socialMediaPlatformId, currentUrl);
     }
 
     protected override void OnAppearing()

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
@@ -10,7 +10,7 @@ public partial class AddSocialMediaPage
 
     public AddSocialMediaPage(IFirebaseAnalyticsService firebaseAnalyticsService, IServiceProvider provider,
         int socialMediaPlatformId,
-        string currentUrl = null,
+        string currentUrl,
         Color parentPageStatusBarColor = null)
     {
         _parentPageStatusBarColor = parentPageStatusBarColor ?? Colors.Black;

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -10,7 +10,7 @@ public partial class AddSocialMediaViewModel : BaseViewModel
 {
     private readonly IUserService _userService;
     private readonly ISnackbarService _snackbarService;
-    private int _platformId;
+    private readonly int _platformId;
 
     [ObservableProperty]
     private string _placeholder;
@@ -35,44 +35,51 @@ public partial class AddSocialMediaViewModel : BaseViewModel
 
     [ObservableProperty]
     private string _errorText;
-
+    
+    [ObservableProperty]
+    private string _currentUrl;
+    
     public AddSocialMediaViewModel(IUserService userService,
         ISnackbarService snackbarService,
-        int socialMediaPlatformId)
+        int socialMediaPlatformId,
+        string currentUrl = null)
     {
         _userService = userService;
         _snackbarService = snackbarService;
         _platformId = socialMediaPlatformId;
+        _currentUrl = currentUrl;
         
         Initialise(socialMediaPlatformId);
     }
 
     private void Initialise(int socialMediaPlatformId)
     {
+        var url = !string.IsNullOrEmpty(CurrentUrl) ? CurrentUrl : null;
+        
         switch (socialMediaPlatformId)
         {
             case Constants.SocialMediaPlatformIds.LinkedIn:
                 PlatformName = "LinkedIn";
-                Url = "https://linkedin.com/in/";
-                Placeholder = "https://linkedin.com/in/[your-name]";
+                Url = url ?? "https://linkedin.com/in/";
+                Placeholder = url ?? "https://linkedin.com/in/[your-name]";
                 ValidationPattern = "^https?://(www.)?linkedin.com/in/([a-zA-Z0-9._-]+)$";
                 break;
             case Constants.SocialMediaPlatformIds.GitHub:
                 PlatformName = "GitHub";
-                Url = "https://github.com/";
-                Placeholder = "https://github.com/[your-username]";
+                Url = url ?? "https://github.com/";
+                Placeholder = url ?? "https://github.com/[your-username]";
                 ValidationPattern = "^https?://(www.)?github.com/([a-zA-Z0-9._-]+)$";
                 break;
             case Constants.SocialMediaPlatformIds.Twitter:
                 PlatformName = "Twitter";
-                Url = "https://x.com/";
-                Placeholder = "https://x.com/[your-username]";
+                Url = url ?? "https://x.com/";
+                Placeholder = url ?? "https://x.com/[your-username]";
                 ValidationPattern = "^https?://(www.)?(twitter|x).com/([a-zA-Z0-9._-]+)$";
                 break;
             case Constants.SocialMediaPlatformIds.Company:
                 PlatformName = "Company";
-                Url = "https://";
-                Placeholder = "https://[your-website]";
+                Url = url ?? "https://";
+                Placeholder = url ?? "https://[your-website]";
                 ValidationPattern = @"^https?://\S+";
                 break;
         }

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -113,7 +113,10 @@ public partial class AddSocialMediaViewModel : BaseViewModel
             InputText = Url;
         }
 
-        CursorPosition = InputText.Length; // For some reason, works only on Android
+        App.Current.Dispatcher.Dispatch(() =>
+        {
+            CursorPosition = InputText.Length;
+        });
     }
 
     private bool IsUrlValid()

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -42,7 +42,7 @@ public partial class AddSocialMediaViewModel : BaseViewModel
     public AddSocialMediaViewModel(IUserService userService,
         ISnackbarService snackbarService,
         int socialMediaPlatformId,
-        string currentUrl = null)
+        string currentUrl)
     {
         _userService = userService;
         _snackbarService = snackbarService;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1087 

> 2. What was changed?

1. Fixes setting the cursor position to the end when tapping the field in the social media popup.
2. Updates the social media popups to load existing data when opened from the Settings page.

<img src="https://github.com/user-attachments/assets/ca99fe9f-58cd-49ec-8073-224ab6feea94" width="400" />

**✅ Figure: Social media popups now show existing data**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->