### PR TITLE
🐛 Mobile | Top Bar fixes

### DIFF
--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -2,6 +2,10 @@
 using CommunityToolkit.Mvvm.Messaging;
 using SSW.Rewards.Mobile.Messages;
 
+#if IOS
+using UIKit;
+#endif
+
 namespace SSW.Rewards.Mobile;
 
 public partial class AppShell
@@ -23,6 +27,38 @@ public partial class AppShell
 
         Process.GetCurrentProcess().CloseMainWindow();
         return true;
+    }
+    
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+		
+#if IOS
+        // Workaround for filling the gap above our custom top bar on iOS
+        // See: https://github.com/drasticactions/MauiRepros/blob/main/StatusBarHack/MainPage.xaml.cs#L30-L52
+        if (this.GetParentWindow()?.Handler?.PlatformView is not UIWindow window)
+        {
+            return;
+        }
+
+        var topPadding = window?.SafeAreaInsets.Top ?? 0;
+        Application.Current.Resources.TryGetValue("Background", out var background);
+        
+        if (background is not Color backgroundColor)
+        {
+            return;
+        }
+
+        var statusBar = new UIView(new CoreGraphics.CGRect(0, 0, UIKit.UIScreen.MainScreen.Bounds.Size.Width, topPadding))
+        {
+            BackgroundColor = UIColor.FromRGB(backgroundColor.Red, backgroundColor.Green, backgroundColor.Blue)
+        };
+
+        if (this.Handler?.PlatformView is UIView view)
+        {
+            view?.AddSubview(statusBar);
+        }
+#endif
     }
 
     private void OnNavigating(object sender, ShellNavigatingEventArgs e)

--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -5,16 +5,15 @@
                     xmlns:resolver="clr-namespace:Maui.Plugins.PageResolver;assembly=Maui.Plugins.PageResolver"
                     xmlns:vm="clr-namespace:SSW.Rewards.Mobile.ViewModels">
     <ControlTemplate x:Key="PageTemplate">
-        <Grid RowDefinitions="60,*"
+        <Grid RowDefinitions="50,*"
               Margin="0"
-              Padding="0"
-              TranslationY="{OnPlatform iOS=-10, Default=0}">
+              Padding="0">
             <Grid.BindingContext>
                 <resolver:ResolveViewModel x:TypeArguments="vm:TopBarViewModel" />
             </Grid.BindingContext>
             <Grid Grid.Row="0"
-                  ColumnDefinitions="60,*,60"
-                  HeightRequest="60"
+                  ColumnDefinitions="50,*,50"
+                  HeightRequest="50"
                   Padding="10,5"
                   BackgroundColor="{StaticResource Background}"
                   VerticalOptions="Start"
@@ -26,7 +25,7 @@
                       IsVisible="{Binding ShowAvatar}"
                       HeightRequest="40"
                       WidthRequest="40"
-                      VerticalOptions="End">
+                      VerticalOptions="Center">
                     <mct:AvatarView ImageSource="{Binding ProfilePic}"
                                     HeightRequest="40"
                                     WidthRequest="40"
@@ -38,7 +37,6 @@
                         </mct:AvatarView.GestureRecognizers>
                     </mct:AvatarView>
                 </Grid>
-
 
                 <Button
                     Grid.Column="0"
@@ -53,7 +51,7 @@
                     Padding="0"
                     IsVisible="{Binding ShowBack}"
                     Command="{Binding GoBackCommand}"
-                    VerticalOptions="End">
+                    VerticalOptions="Center">
                     <Button.ImageSource>
                         <FontImageSource FontFamily="FluentIcons"
                                          Glyph="&#xf189;"
@@ -62,18 +60,21 @@
                     </Button.ImageSource>
                 </Button>
                 
-                <Label Grid.Column="1"
-                       Text="{Binding Title}"
-                       Style="{StaticResource LabelBold}"
-                       FontSize="18"
-                       VerticalOptions="Center"
-                       VerticalTextAlignment="Center"
-                       HorizontalOptions="Center" />
+                <Grid Grid.Column="1"
+                      VerticalOptions="Center"
+                      HeightRequest="50">
+                    <Label Text="{Binding Title}"
+                           Style="{StaticResource LabelBold}"
+                           FontSize="18"
+                           VerticalOptions="Center"
+                           VerticalTextAlignment="Center"
+                           HorizontalOptions="Center" />
+                </Grid>
 
                 <ImageButton Grid.Column="2"
                              Command="{Binding OpenScannerCommand}"
                              IsVisible="{Binding ShowScanner}"
-                             VerticalOptions="End">
+                             VerticalOptions="Center">
                     <ImageButton.Source>
                         <FontImageSource FontFamily="FluentIcons"
                                          Glyph="&#xf636;"/>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

1. Implements a proper workaround on iOS for the gap that appears above our custom top bar. We previously worked around this by setting a negative Y translation on the top bar on iOS but this gap can change between devices (such as the latest iPhone 16 models which have an increased gap). This change fills the gap with our Background colour for all gap sizes so our top bar template can work generically.
2. Fixes an issue where title text in the top bar can be off-centre.

<img src="https://github.com/user-attachments/assets/2471d729-c852-49bb-8a3d-d76cf4fa9ab2" width="400" />

**✅ Figure: There are no gaps above the top bar when the Y translation is removed**

<img src="https://github.com/user-attachments/assets/a66f20d5-f892-4b13-920d-3c3c21491eb6" width="400" />

**✅ Figure: Title text is now correctly vertically centred**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
