### PR TITLE
🐛 Bug | Temporarily disable returning UserId with achievements

### DIFF
--- a/src/Application/Achievements/Command/PostAchievement/PostAchievementCommand.cs
+++ b/src/Application/Achievements/Command/PostAchievement/PostAchievementCommand.cs
@@ -52,22 +52,23 @@ public class PostAchievementCommandHandler : IRequestHandler<PostAchievementComm
         // check for milestone achievements
         if (requestedAchievement.Type == AchievementType.Scanned)
         {
-            var scannedUser = await _context.Users
-                .FirstOrDefaultAsync(u => u.AchievementId == requestedAchievement.Id, cancellationToken);
-
-            if (scannedUser == null)
-            {
-                var staffMember = await _context.StaffMembers
-                    .Include(s => s.StaffAchievement)
-                    .Where(s => s.StaffAchievement != null)
-                    .FirstOrDefaultAsync(s => s.StaffAchievement!.Id == requestedAchievement.Id, cancellationToken);
-
-                achievementModel.UserId = staffMember?.Id;
-            }
-            else
-            {
-                achievementModel.UserId = scannedUser.Id;
-            }
+            // TODO: Re-enable when fixed
+            // var scannedUser = await _context.Users
+            //     .FirstOrDefaultAsync(u => u.AchievementId == requestedAchievement.Id, cancellationToken);
+            //
+            // if (scannedUser == null)
+            // {
+            //     var staffMember = await _context.StaffMembers
+            //         .Include(s => s.StaffAchievement)
+            //         .Where(s => s.StaffAchievement != null)
+            //         .FirstOrDefaultAsync(s => s.StaffAchievement!.Id == requestedAchievement.Id, cancellationToken);
+            //
+            //     achievementModel.UserId = staffMember?.Id;
+            // }
+            // else
+            // {
+            //     achievementModel.UserId = scannedUser.Id;
+            // }
             
             if (!userAchievements.Any(ua => ua.Achievement.Name == MilestoneAchievements.MeetSSW))
             {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Crashes

> 2. What was changed?

Crashes might be related to achievements returning an incorrect UserID. Disabling for the time being which should hopefully prevent the app from trying to fetch the user.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->