### PR TITLE
🐛 Mobile | Add try...catch when launching external browser

### DIFF
--- a/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml.cs
+++ b/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml.cs
@@ -36,7 +36,7 @@ public partial class AboutSswPage
         }
         catch (Exception)
         {
-            await Application.Current.MainPage.DisplayAlert("Error", "An unexpected error occurred. No browser may be installed on the device.", "OK");
+            await Application.Current.MainPage.DisplayAlert("Error", "There was an error trying to launch the default browser.", "OK");
         }
     }
 

--- a/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml.cs
+++ b/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml.cs
@@ -30,7 +30,14 @@ public partial class AboutSswPage
 
     private async void FindoutMore_Tapped(object sender, EventArgs e)
     {
-        await Browser.OpenAsync("https://www.ssw.com.au/ssw/Company/AboutUs.aspx", BrowserLaunchMode.External);
+        try
+        {
+            await Browser.OpenAsync("https://www.ssw.com.au/ssw/Company/AboutUs.aspx", BrowserLaunchMode.External);
+        }
+        catch (Exception)
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", "An unexpected error occurred. No browser may be installed on the device.", "OK");
+        }
     }
 
     protected override void OnDisappearing()

--- a/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
+++ b/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
@@ -204,7 +204,14 @@ public partial class ProfileViewModelBase : BaseViewModel
 
         if (Uri.TryCreate(userProfile, UriKind.Absolute, out Uri uri))
         {
-            await Browser.Default.OpenAsync(uri, BrowserLaunchMode.External);
+            try
+            {
+                await Browser.Default.OpenAsync(uri, BrowserLaunchMode.External);
+            }
+            catch (Exception)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "An unexpected error occurred. No browser may be installed on the device.", "OK");
+            }
         }
     }
 

--- a/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
+++ b/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
@@ -210,7 +210,7 @@ public partial class ProfileViewModelBase : BaseViewModel
             }
             catch (Exception)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", "An unexpected error occurred. No browser may be installed on the device.", "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "There was an error trying to launch the default browser.", "OK");
             }
         }
     }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1062

> 2. What was changed?

There's currently an issue with MAUI on Android 14 when using BrowserLaunchMode.External where a FeatureNotSupportedException can be thrown. This change wraps these in a try...catch to handle this a bit more gracefully for the time being.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->