### PR TITLE
♻️ API | Update weekly leaderboard to use past 7 days

### DIFF
--- a/src/Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardList.cs
+++ b/src/Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardList.cs
@@ -55,7 +55,7 @@ public class GetFilteredLeaderboardListHandler : IRequestHandler<GetFilteredLead
             .Include(u => u.UserAchievements)
             .ThenInclude(ua => ua.Achievement)
             .Where(u => !string.IsNullOrWhiteSpace(u.FullName))
-            .Select(u => new LeaderboardUserDto(u, DateTime.Now.FirstDayOfWeek()))
+            .Select(u => new LeaderboardUserDto(u))
             .ToListAsync(cancellationToken);
         
         users

--- a/src/Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardListQuery.cs
@@ -51,7 +51,7 @@ public class GetFilteredLeaderboardListQueryHandler : IRequestHandler<GetFiltere
             .Include(u => u.UserAchievements)
             .ThenInclude(ua => ua.Achievement)
             .Where(u => !string.IsNullOrWhiteSpace(u.FullName))
-            .Select(u => new LeaderboardUserDto(u, DateTime.Now.FirstDayOfWeek()))
+            .Select(u => new LeaderboardUserDto(u))
             .ToListAsync(cancellationToken);
         
         users

--- a/src/Application/Leaderboard/Queries/GetLeaderboardList/GetLeaderboardListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetLeaderboardList/GetLeaderboardListQuery.cs
@@ -27,7 +27,7 @@ public class Handler : IRequestHandler<GetLeaderboardListQuery, LeaderboardViewM
             .Include(u => u.SocialMediaIds)
                 .ThenInclude(s => s.SocialMediaPlatform)
             .Where(u => !string.IsNullOrWhiteSpace(u.FullName))
-            .Select(u => new LeaderboardUserDto(u, DateTime.Now.FirstDayOfWeek()))
+            .Select(u => new LeaderboardUserDto(u))
             .ToListAsync(cancellationToken);
 
         users

--- a/src/Application/PrizeDraw/Queries/GetEligibleUsers.cs
+++ b/src/Application/PrizeDraw/Queries/GetEligibleUsers.cs
@@ -55,8 +55,8 @@ public class GetEligibleUsersHandler : IRequestHandler<GetEligibleUsers, Eligibl
         }
         else if (request.Filter == LeaderboardFilter.ThisWeek)
         {
-            var start = _dateTime.Now.FirstDayOfWeek();
-            var end = start.AddDays(7);
+            var start = _dateTime.Now.AddDays(-7);
+            var end = _dateTime.Now;
             // TODO: Find a better way - EF Can't translate our extension method -- so writing the date range comparison directly in linq for now
             eligibleUsers = eligibleUsers
                 .TagWith("PointsThisWeek")

--- a/src/Application/PrizeDraw/Queries/Mapping.cs
+++ b/src/Application/PrizeDraw/Queries/Mapping.cs
@@ -6,9 +6,6 @@ public class Mapping : Profile
 {
     public Mapping()
     {
-        var start = DateTime.Now.FirstDayOfWeek();
-        var end = start.AddDays(7);
-
         CreateMap<User, EligibleUserDto>()
                 .ForMember(dst => dst.Balance, opt => opt.Ignore())
                 .ForMember(dst => dst.UserId, opt => opt.MapFrom(src => src.Id))
@@ -31,7 +28,7 @@ public class Mapping : Profile
                     .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year && ua.AwardedAt.Month == DateTime.Now.Month && ua.AwardedAt.Day == DateTime.Now.Day)
                     .Sum(ua => ua.Achievement.Value)))
                 .ForMember(dst => dst.PointsThisWeek, opt => opt.MapFrom(src => src.UserAchievements
-                    .Where(ua => start <= ua.AwardedAt && ua.AwardedAt <= end)
+                    .Where(ua => DateTime.Now.AddDays(-7) <= ua.AwardedAt && ua.AwardedAt <= DateTime.Now)
                     .Sum(ua => ua.Achievement.Value)));
     }
 }

--- a/src/Common/DTOs/Leaderboard/LeaderboardUserDto.cs
+++ b/src/Common/DTOs/Leaderboard/LeaderboardUserDto.cs
@@ -21,10 +21,8 @@ public class LeaderboardUserDto
 
     public LeaderboardUserDto() {}
 
-    public LeaderboardUserDto(User user, DateTime firstDayOfWeek)
+    public LeaderboardUserDto(User user)
     {
-        var start = firstDayOfWeek;
-        var end = start.AddDays(7);
         Rank = 0; // Ignored
         UserId = user.Id;
         Name = user.FullName;
@@ -34,18 +32,18 @@ public class LeaderboardUserDto
         PointsClaimed = user.UserRewards.Sum(ur => ur.Reward.Cost);
         PointsToday = user.UserAchievements
             .Where(ua => 
-                ua.AwardedAt.Year == DateTime.Now.Year && 
+                ua.AwardedAt.Year == DateTime.UtcNow.Year && 
                 ua.AwardedAt.Month == DateTime.UtcNow.Month && 
                 ua.AwardedAt.Day == DateTime.UtcNow.Day)
             .Sum(ua => ua.Achievement.Value);
         PointsThisWeek = user.UserAchievements
-            .Where(ua => start <= ua.AwardedAt && ua.AwardedAt <= end)
+            .Where(ua => DateTime.UtcNow.AddDays(-7) <= ua.AwardedAt && ua.AwardedAt <= DateTime.UtcNow)
             .Sum(ua => ua.Achievement.Value);
         PointsThisMonth = user.UserAchievements
-            .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year && ua.AwardedAt.Month == DateTime.UtcNow.Month)
+            .Where(ua => ua.AwardedAt.Year == DateTime.UtcNow.Year && ua.AwardedAt.Month == DateTime.UtcNow.Month)
             .Sum(ua => ua.Achievement.Value);
         PointsThisYear = user.UserAchievements
-            .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year)
+            .Where(ua => ua.AwardedAt.Year == DateTime.UtcNow.Year)
             .Sum(ua => ua.Achievement.Value);
 
         var company = user.SocialMediaIds.FirstOrDefault(s => s.SocialMediaPlatform.Name == "Company")


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1108 

> 2. What was changed?

Updates the weekly leaderboard to use the last 7 days rather than the current week.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->