### PR TITLE
🐛 Mobile | Fix popups changing status bar colour on iOS

### DIFF
--- a/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml
+++ b/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml
@@ -8,7 +8,8 @@
                  CloseWhenBackgroundIsClicked="False"
                  x:Class="SSW.Rewards.PopupPages.AboutSswPage">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
+                                   StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml
+++ b/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml
@@ -9,7 +9,7 @@
                  x:Class="SSW.Rewards.PopupPages.AboutSswPage">
     <pages:PopupPage.Behaviors>
         <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
-                                   StatusBarStyle="DarkContent" />
+                                   StatusBarStyle="LightContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml
+++ b/src/MobileUI/Features/AboutSSW/AboutSswPage.xaml
@@ -8,7 +8,7 @@
                  CloseWhenBackgroundIsClicked="False"
                  x:Class="SSW.Rewards.PopupPages.AboutSswPage">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="{StaticResource Black}" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml
+++ b/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml
@@ -11,7 +11,7 @@
              x:DataType="viewModels:OnBoardingViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.OnBoardingPage">
     <pages:PopupPage.Behaviors>
-        <mct:StatusBarBehavior StatusBarColor="{StaticResource Black}" StatusBarStyle="DarkContent" />
+        <mct:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml
+++ b/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml
@@ -12,7 +12,7 @@
              x:Class="SSW.Rewards.Mobile.Pages.OnBoardingPage">
     <pages:PopupPage.Behaviors>
         <mct:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
-                               StatusBarStyle="DarkContent" />
+                               StatusBarStyle="LightContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml
+++ b/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml
@@ -11,7 +11,8 @@
              x:DataType="viewModels:OnBoardingViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.OnBoardingPage">
     <pages:PopupPage.Behaviors>
-        <mct:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
+        <mct:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
+                               StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/Profile/ProfilePicturePage.xaml
+++ b/src/MobileUI/Features/Profile/ProfilePicturePage.xaml
@@ -11,7 +11,7 @@
                  x:DataType="viewModels:ProfilePictureViewModel"
                  x:Class="SSW.Rewards.PopupPages.ProfilePicturePage">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="{StaticResource Black}" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/Profile/ProfilePicturePage.xaml
+++ b/src/MobileUI/Features/Profile/ProfilePicturePage.xaml
@@ -11,7 +11,8 @@
                  x:DataType="viewModels:ProfilePictureViewModel"
                  x:Class="SSW.Rewards.PopupPages.ProfilePicturePage">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
+                                   StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/Profile/ProfilePicturePage.xaml
+++ b/src/MobileUI/Features/Profile/ProfilePicturePage.xaml
@@ -12,7 +12,7 @@
                  x:Class="SSW.Rewards.PopupPages.ProfilePicturePage">
     <pages:PopupPage.Behaviors>
         <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
-                                   StatusBarStyle="DarkContent" />
+                                   StatusBarStyle="LightContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -15,7 +15,8 @@
                  BackgroundColor="#b3000000"
                  CloseWhenBackgroundIsClicked="False">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
+                                   StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation PositionIn="Bottom"

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -15,7 +15,7 @@
                  BackgroundColor="#b3000000"
                  CloseWhenBackgroundIsClicked="False">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="{StaticResource Black}" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation PositionIn="Bottom"

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -16,7 +16,7 @@
                  CloseWhenBackgroundIsClicked="False">
     <pages:PopupPage.Behaviors>
         <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
-                                   StatusBarStyle="DarkContent" />
+                                   StatusBarStyle="LightContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation PositionIn="Bottom"

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -12,7 +12,8 @@
              x:DataType="viewModels:AddSocialMediaViewModel"
              x:Class="SSW.Rewards.Mobile.PopupPages.AddSocialMediaPage">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
+                                   StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -13,7 +13,7 @@
              x:Class="SSW.Rewards.Mobile.PopupPages.AddSocialMediaPage">
     <pages:PopupPage.Behaviors>
         <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
-                                   StatusBarStyle="DarkContent" />
+                                   StatusBarStyle="LightContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -12,7 +12,7 @@
              x:DataType="viewModels:AddSocialMediaViewModel"
              x:Class="SSW.Rewards.Mobile.PopupPages.AddSocialMediaPage">
     <pages:PopupPage.Behaviors>
-        <toolkit:StatusBarBehavior StatusBarColor="{StaticResource Black}" StatusBarStyle="DarkContent" />
+        <toolkit:StatusBarBehavior StatusBarColor="Transparent" StatusBarStyle="DarkContent" />
     </pages:PopupPage.Behaviors>
     <pages:PopupPage.Animation>
         <animations:MoveAnimation


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1113

> 2. What was changed?

Fixes status bar colour mismatch when opening popups on iOS by setting it to transparent.

https://github.com/user-attachments/assets/3821d4b6-aba1-4cc1-9b3c-ee6a0b762f1a

**✅ Figure: Popups on iOS now longer show a mismatched status bar colour**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->