### PR TITLE
⚡ Improved performance for logging when any request takes 500ms+

### DIFF
--- a/src/Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/src/Application/Common/Behaviours/LoggingBehaviour.cs
@@ -19,7 +19,6 @@ public class LoggingBehaviour<TRequest> : IRequestPreProcessor<TRequest> where T
     public async Task Process(TRequest request, CancellationToken cancellationToken)
     {
         var requestName = typeof(TRequest).Name;
-        string userName = string.Empty;
         int userId = 0;
 
         var userEmail = _currentUserService.GetUserEmail() ?? string.Empty;
@@ -34,16 +33,9 @@ public class LoggingBehaviour<TRequest> : IRequestPreProcessor<TRequest> where T
             {
                 userId = 0;
             }
-
-            if (userId > 0)
-            {
-                var user = await _userService.GetUser(userId, cancellationToken);
-
-                userName = user.FullName;
-            }
         }
 
         _logger.LogInformation("SSW.Rewards Request: {Name} {@UserId} {@UserName} {@Request}",
-            requestName, userId, userName, request);
+            requestName, userId, userEmail, request);
     }
 }

--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -35,7 +35,6 @@ public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequ
         if (elapsedMilliseconds > 500)
         {
             var requestName = typeof(TRequest).Name;
-            string userName = string.Empty;
             int userId = 0;
 
             var userEmail = _currentUserService.GetUserEmail() ?? string.Empty;
@@ -50,17 +49,10 @@ public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequ
                 {
                     userId = 0;
                 }
-
-                if (userId > 0)
-                {
-                    var user = await _userService.GetUser(userId, cancellationToken);
-
-                    userName = user.FullName;
-                }
             }
 
             _logger.LogWarning("SSW.Rewards Long Running Request: {Name} ({ElapsedMilliseconds} milliseconds) {@UserId} {@UserName} {@Request}",
-                requestName, elapsedMilliseconds, userId, userName, request);
+                requestName, elapsedMilliseconds, userId, userEmail, request);
         }
 
         return response;

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -117,13 +117,22 @@ public class UserService : IUserService, IRolesService
 
     public async Task<int> GetUserId(string email, CancellationToken cancellationToken)
     {
-        if (String.IsNullOrWhiteSpace(email))
-            throw new ArgumentNullException("no email provided");
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new ArgumentNullException(nameof(email), "no email provided");
+        }
+
         email = email.Trim().ToLower();
-        var user = await _dbContext.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Email.ToLower() == email, cancellationToken);
-        if (user == null)
-            throw new NotFoundException("No user found");
-        return user.Id;
+
+        var user = await _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.Email.ToLower() == email)
+            .Select(x => new { x.Id })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return user != null
+            ? user.Id
+            : throw new NotFoundException("No user found");
     }
 
     public CurrentUserDto GetCurrentUser()


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1119 

> 2. What was changed?

✏️ PerformanceBehaviour no longer uses a super heavy method on requests that takes 500+ ms.  that even on powerful machine takes ~350 ms.

Also, `GetUserId` was optimised to only return id instead of entire row which should further improve performance for many endpoints.

![image](https://github.com/user-attachments/assets/cbe82319-f44b-468d-9b90-90f398767388)

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->