### PR TITLE
⚡ Only fetch UserId when needed instead of entire row

### DIFF
--- a/src/Application/Achievements/Command/PostAchievement/PostAchievementCommand.cs
+++ b/src/Application/Achievements/Command/PostAchievement/PostAchievementCommand.cs
@@ -42,11 +42,11 @@ public class PostAchievementCommandHandler : IRequestHandler<PostAchievementComm
         
         var achievementModel = _mapper.Map<AchievementDto>(requestedAchievement);
 
-        var user = await _userService.GetCurrentUser(cancellationToken);
+        var userId = await _userService.GetCurrentUserId(cancellationToken);
 
         var userAchievements = await _context
             .UserAchievements
-            .Where(ua => ua.UserId == user.Id)
+            .Where(ua => ua.UserId == userId)
             .ToListAsync(cancellationToken);
         
         // check for milestone achievements
@@ -81,7 +81,7 @@ public class PostAchievementCommandHandler : IRequestHandler<PostAchievementComm
 
                 var userMeetAchievement = new UserAchievement
                 {
-                    UserId = user.Id,
+                    UserId = userId,
                     Achievement = meetAchievement
                 };
 
@@ -100,7 +100,7 @@ public class PostAchievementCommandHandler : IRequestHandler<PostAchievementComm
 
         var userAchievement = new UserAchievement
         {
-            UserId = user.Id,
+            UserId = userId,
             AchievementId = requestedAchievement.Id
         };
 
@@ -108,7 +108,7 @@ public class PostAchievementCommandHandler : IRequestHandler<PostAchievementComm
 
         if (requestedAchievement.Type == AchievementType.Attended)
         {
-            var milestoneAchievement = new UserAchievement { UserId = user.Id };
+            var milestoneAchievement = new UserAchievement { UserId = userId };
 
             // UG = puzzle, Hackday = lightbulb, Superpowers = lightning, Workshop = certificate
             switch (requestedAchievement.Icon)

--- a/src/Application/Common/Interfaces/IUserService.cs
+++ b/src/Application/Common/Interfaces/IUserService.cs
@@ -51,6 +51,8 @@ public interface IUserService
     CurrentUserDto GetCurrentUser();
     Task<CurrentUserDto> GetCurrentUser(CancellationToken cancellationToken);
 
+    Task<int> GetCurrentUserId(CancellationToken cancellationToken);
+
     // Get user's QR code
     string GetStaffQRCode(string emailAddress);
     Task<string> GetStaffQRCode(string emailAddress, CancellationToken cancellationToken);

--- a/src/Application/Notifications/Commands/RequestNotification/RequestNotification.cs
+++ b/src/Application/Notifications/Commands/RequestNotification/RequestNotification.cs
@@ -50,14 +50,14 @@ public class RequestNotificationHandler : IRequestHandler<RequestNotification, U
         await _notificationService
             .RequestNotificationAsync(notification, cancellationToken);
 
-        var user = await _userService.GetCurrentUser(cancellationToken);
+        var userId = await _userService.GetCurrentUserId(cancellationToken);
 
         var notificationEntry = new Notification
         {
             Message             = notification.Text,
             NotificationTag     = string.Join(",", notification.Tags),
             NotificationAction  = notification.Action,
-            SentByStaffMemberId = user.Id
+            SentByStaffMemberId = userId
         };
         await _context.Notifications.AddAsync(notificationEntry, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);

--- a/src/Application/Notifications/Commands/RequestNotification/RequestNotificationCommand.cs
+++ b/src/Application/Notifications/Commands/RequestNotification/RequestNotificationCommand.cs
@@ -39,14 +39,14 @@ public class RequestNotificationCommand : IRequest<Unit>
             await _notificationService
                 .RequestNotificationAsync(notification, cancellationToken);
 
-            var user = await _userService.GetCurrentUser(cancellationToken);
+            var userId = await _userService.GetCurrentUserId(cancellationToken);
 
             var notificationEntry = new Notification
             {
                 Message             = notification.Text,
                 NotificationTag     = string.Join(",", notification.Tags),
                 NotificationAction  = notification.Action,
-                SentByStaffMemberId = user.Id
+                SentByStaffMemberId = userId
             };
             await _context.Notifications.AddAsync(notificationEntry, cancellationToken);
             await _context.SaveChangesAsync(cancellationToken);

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -2,8 +2,8 @@
 using AutoMapper.QueryableExtensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SSW.Rewards.Shared.DTOs.Users;
 using SSW.Rewards.Application.Common.Exceptions;
+using SSW.Rewards.Shared.DTOs.Users;
 
 namespace SSW.Rewards.Application.Services;
 
@@ -156,6 +156,26 @@ public class UserService : IUserService, IRolesService
         }
 
         return _mapper.Map<CurrentUserDto>(user);
+    }
+
+    public async Task<int> GetCurrentUserId(CancellationToken cancellationToken)
+    {
+        string currentUserEmail = _currentUserService.GetUserEmail();
+
+        var user = await _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.Email == currentUserEmail)
+            .Select(x => new { x.Id, x.Activated })
+            .SingleOrDefaultAsync(cancellationToken)
+            ?? throw new NotFoundException(nameof(User), currentUserEmail);
+
+        if (!user.Activated)
+        {
+            // Only update user active state in DB when needed. This should be rare.
+            await ActivateUser(user.Id, cancellationToken);
+        }
+
+        return user.Id;
     }
 
     public IEnumerable<Role> GetCurrentUserRoles()
@@ -365,5 +385,18 @@ public class UserService : IUserService, IRolesService
     public Task UpdateUser(int UserId, User user, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
+    }
+
+    private async Task ActivateUser(int userId, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users
+            .FirstOrDefaultAsync(x => x.Id == userId, cancellationToken)
+            ?? throw new NotFoundException(nameof(User), userId);
+
+        if (!user.Activated)
+        {
+            user.Activated = true;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
     }
 }

--- a/src/Application/Staff/Queries/GetStaffList/GetStaffListQuery.cs
+++ b/src/Application/Staff/Queries/GetStaffList/GetStaffListQuery.cs
@@ -27,9 +27,9 @@ public sealed class Handler : IRequestHandler<GetStaffListQuery, StaffListViewMo
             .ProjectTo<StaffMemberDto>(_mapper.ConfigurationProvider)
             .ToListAsync(cancellationToken);
 
-        var user = await _userService.GetCurrentUser(cancellationToken);
+        var userId = await _userService.GetCurrentUserId(cancellationToken);
 
-        var achievements = await _userService.GetUserAchievements(user.Id, cancellationToken);
+        var achievements = await _userService.GetUserAchievements(userId, cancellationToken);
 
         var completedAchievements = achievements.UserAchievements
             .Where(a => a.Complete)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1119 

> 2. What was changed?

✏️ When code needed just `CurrentUserId` it used the entire user table with achievements and rewards. This will only fetch the bare minimum not only to return the `CurrentUserId` but also activate the user if needed.

Impacts several endpoints like posting achievements, requesting notifications and getting staff list.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->