### PR TITLE
Admin | Changing Azure auth to federated credentials

### DIFF
--- a/.github/workflows/api-main.yml
+++ b/.github/workflows/api-main.yml
@@ -19,7 +19,9 @@ jobs:
       ADMIN_PORTAL_URL: https://staging.rewards.ssw.com.au
       IDS_URL: https://app-ssw-ident-staging-api.azurewebsites.net
     secrets:
-      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
       SQL_ADMIN_GROUP_SID: ${{ secrets.SQL_ADMIN_GROUP_SID }}
 
@@ -35,6 +37,8 @@ jobs:
       ADMIN_PORTAL_URL: https://rewards.ssw.com.au
       IDS_URL: https://identity.ssw.com.au
     secrets:
-      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
       SQL_ADMIN_GROUP_SID: ${{ secrets.SQL_ADMIN_GROUP_SID }}


### PR DESCRIPTION
Fixing GitHub Actions
Replaced
Azure_Credentials secrets with
AZURE_CLIENT_ID
AZURE_TENANT_ID 
AZURE_SUBSCRIPTION_ID

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Zendesk Ticket  https://pdi-ssw.zendesk.com/agent/tickets/15652

> 2. What was changed?
The api-main.yml file
Similar change to https://github.com/SSWConsulting/SSW.Rewards.Mobile/pull/1122/files
https://learn.microsoft.com/en-us/azure/app-service/deploy-github-actions?tabs=openid%2Cpython%2Caspnetcore

> 3. Did you do pair or mob programming?

I worked with @chrisschultzssw @kikibianc @jernejk @vladislav-kir 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->