### PR TITLE
⚡ Improvement performance for getting user by ID and list of staff members

### DIFF
--- a/src/Application/Common/Interfaces/ICurrentUserService.cs
+++ b/src/Application/Common/Interfaces/ICurrentUserService.cs
@@ -5,5 +5,5 @@ public interface ICurrentUserService
     string GetUserId();
     string GetUserEmail();
     string GetUserFullName();
-    string GetUserProfilePic();
+    string? GetUserProfilePic();
 }

--- a/src/Application/Common/Interfaces/IUserService.cs
+++ b/src/Application/Common/Interfaces/IUserService.cs
@@ -31,7 +31,6 @@ public interface IUserService
 
 
     // Get user
-    UserProfileDto GetUser(int userId);
     Task<UserProfileDto> GetUser(int userId, CancellationToken cancellationToken);
     Task<int> GetUserId(string email, CancellationToken cancellationToken);
     

--- a/src/Application/Users/Queries/GetCurrentUserRoles/GetCurrentUserRolesQuery.cs
+++ b/src/Application/Users/Queries/GetCurrentUserRoles/GetCurrentUserRolesQuery.cs
@@ -5,11 +5,11 @@ public class GetCurrentUserRolesQuery : IRequest<string[]>
 
 }
 
-public class GetCurrentUserRolesQuerHandler : IRequestHandler<GetCurrentUserRolesQuery, string[]>
+public class GetCurrentUserRolesQueryHandler : IRequestHandler<GetCurrentUserRolesQuery, string[]>
 {
     private readonly IUserService _userService;
 
-    public GetCurrentUserRolesQuerHandler(IUserService userService, ICurrentUserService currentUserService)
+    public GetCurrentUserRolesQueryHandler(IUserService userService)
     {
         _userService = userService;
     }

--- a/src/Common/DTOs/Users/UserProfileDto.cs
+++ b/src/Common/DTOs/Users/UserProfileDto.cs
@@ -9,6 +9,6 @@ public class UserProfileDto
     public int Points { get; set; }
     public int Balance { get; set; }
     public int Rank { get; set; }
-    public IEnumerable<UserRewardDto> Rewards { get; set; } = Enumerable.Empty<UserRewardDto>();
-    public IEnumerable<UserAchievementDto> Achievements { get; set; } = Enumerable.Empty<UserAchievementDto>();
+    public IEnumerable<UserRewardDto> Rewards { get; set; } = [];
+    public IEnumerable<UserAchievementDto> Achievements { get; set; } = [];
 }

--- a/src/WebAPI/Services/CurrentUserService.cs
+++ b/src/WebAPI/Services/CurrentUserService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Claims;
-
 using SSW.Rewards.Application.Common.Interfaces;
 
 namespace SSW.Rewards.WebAPI.Services;
@@ -13,19 +12,21 @@ public class CurrentUserService : ICurrentUserService
         _httpContextAccessor = httpContextAccessor;
     }
 
-    public string GetUserId() => _httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+    public string GetUserId() => GetUser()?.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
 
-    public string GetUserEmail() => _httpContextAccessor.HttpContext?.User?.Claims?.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value ?? string.Empty;
+    public string GetUserEmail() => GetUser()?.Claims?.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value?.ToLowerInvariant()?.Trim() ?? string.Empty;
 
     public string GetUserFullName()
     {
-        ClaimsPrincipal user = _httpContextAccessor.HttpContext?.User;
+        ClaimsPrincipal? user = GetUser();
         return $"{user?.FindFirstValue(ClaimTypes.GivenName)} {user?.FindFirstValue(ClaimTypes.Surname)}";
     }
 
-    public string GetUserProfilePic()
+    public string? GetUserProfilePic()
     {
         // TODO: Get the user profile pic from claims
         return null;
     }
+
+    private ClaimsPrincipal? GetUser() => _httpContextAccessor.HttpContext?.User;
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1119
Get /api/user/GetUser/{id}, /api/staff/get and /api/network/GetList were one of most expensive endpoint relative to usage at NDC Porto.

> 2. What was changed?

✏️ Optimised queries and minor refactors.

On my desktop when testing 10 concurrent connection for 1 minute, I've seen about double the performance from ~10 to ~20 req/s.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->