### PR TITLE
🐛 Fixed a bug that cause /api/achievement/search to crash.

### DIFF
--- a/src/Application/Achievements/Queries/SearchAchievements/SearchAchievementQuery.cs
+++ b/src/Application/Achievements/Queries/SearchAchievements/SearchAchievementQuery.cs
@@ -20,8 +20,14 @@ public class SearchAchievementQueryHandler : IRequestHandler<SearchAchievementQu
 
     public async Task<AchievementListViewModel> Handle(SearchAchievementQuery request, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(request?.SearchTerm))
+        {
+            return new() { Achievements = [] };
+        }
+
+        string searchTerm = request.SearchTerm.ToLower();
         var achievements = await _context.Achievements
-            .Where(a => a.Name.ToLower().Contains(request.SearchTerm.ToLower()))
+            .Where(x => x.Name != null && x.Name.Contains(searchTerm))
             .ToListAsync(cancellationToken);
 
         return new AchievementListViewModel


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1173 

> 2. What was changed?

✏️ When search term is empty, it will no longer crash.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->