### PR TITLE
✨ Reacts only to QR codes that contains "sswrewards://"

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanViewModel.cs
+++ b/src/MobileUI/Features/Scanner/ScanViewModel.cs
@@ -144,10 +144,15 @@ public partial class ScanViewModel : BaseViewModel, IRecipient<EnableScannerMess
                 return;
             }
 
+            var rawValue = result.FirstOrDefault()?.RawValue;
+            if (string.IsNullOrWhiteSpace(rawValue) || !rawValue.StartsWith("sswrewards://", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // SSW Rewards code not found, keep looking.
+                return;
+            }
+
             IsCameraEnabled = false;
             
-            var rawValue = result.FirstOrDefault()?.RawValue;
-
             var popup = new PopupPages.ScanResult(_resultViewModel, rawValue);
             MopupService.Instance.PushAsync(popup);
         });


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1176 

> 2. What was changed?

✏️ When scanning for QR code, it only reacts to QR codes that starts with "sswrewards://". Other QR codes are ignored.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->