### PR TITLE
🐛 Fix crashing and not returning results for achievements and rewards search

### DIFF
--- a/src/Application/Common/Extensions/EfCoreLinqExtensions.cs
+++ b/src/Application/Common/Extensions/EfCoreLinqExtensions.cs
@@ -1,7 +1,11 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 namespace SSW.Rewards.Application.Common.Extensions;
 
+/// <summary>
+/// JK's extension methods for EF Core LINQ queries.
+/// </summary>
 public static class EfCoreLinqExtensions
 {
     /// <summary>
@@ -26,4 +30,49 @@ public static class EfCoreLinqExtensions
         string className = Path.GetFileNameWithoutExtension(callerFileName);
         return className + "-" + callerName + message;
     }
+
+    /// <summary>
+    /// Applies the specified predicate as a filter to the source query only if the given condition is true.
+    /// </summary>
+    /// <typeparam name="TSource">The type of entity being queried.</typeparam>
+    /// <param name="source">The source query.</param>
+    /// <param name="condition">The boolean condition to be checked.</param>
+    /// <param name="predicate">The predicate to be applied as a filter when the condition is true.</param>
+    /// <returns>A new query with the predicate applied as a filter if the condition is true, or the original query otherwise.</returns>
+    public static IQueryable<TSource> WhenTrue<TSource>(this IQueryable<TSource> source, bool condition, Expression<Func<TSource, bool>> predicate)
+        => condition
+        ? source.Where(predicate)
+        : source;
+
+    /// <summary>
+    /// Applies the specified predicate as a filter to the source query only if the provided string value is not empty.
+    /// </summary>
+    /// <typeparam name="TSource">The type of entity being queried.</typeparam>
+    /// <param name="source">The source query.</param>
+    /// <param name="value">The string value to be checked for emptiness.</param>
+    /// <param name="predicate">The predicate to be applied as a filter when the string value is not empty.</param>
+    /// <returns>A new query with the predicate applied as a filter if the string value is not empty, or the original query otherwise.</returns>
+    public static IQueryable<TSource> WhenStringNotEmpty<TSource>(this IQueryable<TSource> source, string? value, Expression<Func<TSource, bool>> predicate)
+        => !string.IsNullOrEmpty(value)
+        ? source.Where(predicate)
+        : source;
+
+    /// <summary>
+    /// Applies the specified predicate as a filter to the source query only if the provided list is not empty.
+    /// </summary>
+    /// <typeparam name="TSource">The type of entity being queried.</typeparam>
+    /// <param name="source">The source query.</param>
+    /// <param name="value">The List to be checked for emptiness.</param>
+    /// <param name="predicate">The predicate to be applied as a filter when the List is not empty.</param>
+    /// <returns>A new query with the predicate applied as a filter if the list is not empty, or the original query otherwise.</returns>
+    public static IQueryable<TSource> WhenNotEmpty<TSource, TList>(this IQueryable<TSource> source, IEnumerable<TList> list, Expression<Func<TSource, bool>> predicate)
+        => list != null && list.Any()
+        ? source.Where(predicate)
+        : source;
+
+    public static IQueryable<TSource> ApplyPagination<TSource>(this IQueryable<TSource> source, IPagedRequest pagedRequest)
+        => ApplyPagination(source, pagedRequest.Page, pagedRequest.PageSize);
+
+    public static IQueryable<TSource> ApplyPagination<TSource>(this IQueryable<TSource> source, int page, int pageSize)
+        => source.Skip(page * pageSize).Take(pageSize);
 }

--- a/src/Application/Common/Interfaces/IPagedRequest.cs
+++ b/src/Application/Common/Interfaces/IPagedRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace SSW.Rewards.Application.Common.Interfaces;
+
+public interface IPagedRequest
+{
+    public int Page { get; }
+    public int PageSize { get; }
+}

--- a/src/Application/Rewards/Queries/SearchRewards/SearchRewardsQuery.cs
+++ b/src/Application/Rewards/Queries/SearchRewards/SearchRewardsQuery.cs
@@ -1,10 +1,15 @@
-﻿using SSW.Rewards.Shared.DTOs.Rewards;
+﻿using AutoMapper.QueryableExtensions;
+using SSW.Rewards.Shared.DTOs.Rewards;
 
 namespace SSW.Rewards.Application.Rewards.Queries.SearchRewards;
 
-public class SearchRewardsQuery : IRequest<RewardListViewModel>
+public class SearchRewardsQuery : IRequest<RewardListViewModel>, IPagedRequest
 {
     public string SearchTerm { get; set; } = string.Empty;
+
+    public int Page { get; set; }
+
+    public int PageSize { get; set; }
 }
 
 public class SearchRewardsQueryHandler : IRequestHandler<SearchRewardsQuery, RewardListViewModel>
@@ -20,13 +25,15 @@ public class SearchRewardsQueryHandler : IRequestHandler<SearchRewardsQuery, Rew
 
     public async Task<RewardListViewModel> Handle(SearchRewardsQuery request, CancellationToken cancellationToken)
     {
+        string searchTerm = request.SearchTerm?.ToLower() ?? string.Empty;
         var rewards = await _context.Rewards
-            .Where(a => a.Name.ToLower().Contains(request.SearchTerm.ToLower()))
+            .AsNoTracking()
+            .TagWithContext()
+            .WhenStringNotEmpty(searchTerm, x => x.Name != null && x.Name.Contains(searchTerm))
+            .ProjectTo<RewardDto>(_mapper.ConfigurationProvider)
+            .ApplyPagination(request)
             .ToListAsync(cancellationToken);
 
-        return new RewardListViewModel
-        {
-            Rewards = _mapper.Map<IEnumerable<RewardDto>>(rewards)
-        };
+        return new RewardListViewModel { Rewards = rewards };
     }
 }

--- a/src/WebAPI/Controllers/AchievementController.cs
+++ b/src/WebAPI/Controllers/AchievementController.cs
@@ -24,9 +24,9 @@ public class AchievementController : ApiControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<AchievementListViewModel>> Search([FromQuery] string searchTerm)
+    public async Task<ActionResult<AchievementListViewModel>> Search([FromQuery] string searchTerm, [FromQuery] int page = 0, [FromQuery] int pageSize = 50)
     {
-        return Ok(await Mediator.Send(new SearchAchievementQuery { SearchTerm = searchTerm }));
+        return Ok(await Mediator.Send(new SearchAchievementQuery { SearchTerm = searchTerm, Page = page, PageSize = pageSize }));
     }
 
     [HttpGet]

--- a/src/WebAPI/Controllers/RewardController.cs
+++ b/src/WebAPI/Controllers/RewardController.cs
@@ -38,9 +38,9 @@ public class RewardController : ApiControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<RewardListViewModel>> Search([FromQuery] string searchTerm)
+    public async Task<ActionResult<RewardListViewModel>> Search([FromQuery] string searchTerm, [FromQuery] int page = 0, [FromQuery] int pageSize = 50)
     {
-        return Ok(await Mediator.Send(new SearchRewardsQuery { SearchTerm = searchTerm }));
+        return Ok(await Mediator.Send(new SearchRewardsQuery { SearchTerm = searchTerm, Page = page, PageSize = pageSize }));
     }
 
     [HttpGet]


### PR DESCRIPTION
…lts when query is empty

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1173 

> 2. What was changed?

✏️ Fixed crash for rewards and rewards/achievements search now return results when query string is null/empty.
It also now does pagination by default (default 50 items)

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->

![image](https://github.com/user-attachments/assets/fefdb1b9-9c0a-4fcf-bb9e-11947d51a159)
