### PR TITLE
🐛 Fix Android crash when accepting URL from camera

### DIFF
--- a/src/MobileUI/Features/App.xaml.cs
+++ b/src/MobileUI/Features/App.xaml.cs
@@ -45,13 +45,13 @@ public partial class App : Application
     {
         base.OnAppLinkRequestReceived(uri);
         
-        if (uri.Scheme != "sswrewards")
+        if (uri.Scheme != ApiClientConstants.RewardsQRCodeProtocol)
         {
             return;
         }
 
         var queryDictionary = System.Web.HttpUtility.ParseQueryString(uri.Query);
-        var code = queryDictionary.Get("code");
+        var code = queryDictionary.Get(ApiClientConstants.RewardsQRCodeProtocolQueryName);
         
         if (_authService.IsLoggedIn)
         {

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -132,7 +132,6 @@ public static class MauiProgram
                     return;
                 }
 
-                activity.Finish();
                 Task.Run(() => HandleAppLink(data));
             }));
 #endif

--- a/src/MobileUI/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileUI/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="84" android:versionName="3.0.45">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="85" android:versionName="3.0.46">
 	<application android:allowBackup="false" android:icon="@mipmap/icon_android_dark" android:supportsRtl="true" android:label="SSW Rewards">
 		<meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
 	</application>
@@ -42,8 +42,11 @@
 			<action android:name="android.intent.action.SENDTO" />
 			<data android:scheme="mailto" />
 		</intent>
-		<package android:name="com.linkedin.android" /> <!--it will open the LinkedIn links automatically in app -->
-		<package android:name="com.twitter.android" /> <!--it will open the Twitter (X) links automatically in app -->
-		<package android:name="com.github.android" /> <!--it will open the GitHub links automatically in app -->
+		<package android:name="com.linkedin.android" />
+		<!--it will open the LinkedIn links automatically in app -->
+		<package android:name="com.twitter.android" />
+		<!--it will open the Twitter (X) links automatically in app -->
+		<package android:name="com.github.android" />
+		<!--it will open the GitHub links automatically in app -->
 	</queries>
 </manifest>

--- a/src/MobileUI/Platforms/iOS/Info.plist
+++ b/src/MobileUI/Platforms/iOS/Info.plist
@@ -33,7 +33,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.45</string>
+	<string>3.0.46</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1181 - When testing QR Codes with full URL, it was crashing on Android if the app was closed or suspended.

> 2. What was changed?

✏️ Removed `activity.Finish()`.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->