### PR TITLE
1150 - Fix crash when clicking on Staff without User record

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Import Provisioning Profile
         run: |
-            printf "%s" ${{ secrets.APPLE_PROFILE }} | base64 --decode > SSW_Rewards_iOS_Distribution.mobileprovision
+            echo ${{ secrets.APPLE_PROFILE }} | base64 --decode > SSW_Rewards_iOS_Distribution.mobileprovision
             mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
             cp SSW_Rewards_iOS_Distribution.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
 

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Import Provisioning Profile
         run: |
-            echo ${{ secrets.APPLE_PROFILE }} | base64 --decode > SSW_Rewards_iOS_Distribution.mobileprovision
+            printf "%s" ${{ secrets.APPLE_PROFILE }} | base64 --decode > SSW_Rewards_iOS_Distribution.mobileprovision
             mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
             cp SSW_Rewards_iOS_Distribution.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
 

--- a/src/Application/Achievements/Command/CreateAchievement/CreateAchievementCommand.cs
+++ b/src/Application/Achievements/Command/CreateAchievement/CreateAchievementCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+﻿using SSW.Rewards.Application.Common.Helpers;
 using SSW.Rewards.Shared.DTOs.Achievements;
 
 namespace SSW.Rewards.Application.Achievements.Command.PostAchievement;
@@ -25,16 +25,13 @@ public class CreateAchievementCommandHandler : IRequestHandler<CreateAchievement
 
     public async Task<AchievementAdminDto> Handle(CreateAchievementCommand request, CancellationToken cancellationToken)
     {
-        var codeData = Encoding.ASCII.GetBytes($"ach:{Guid.NewGuid().ToString()}");
-        var code = Convert.ToBase64String(codeData);
-        
         var achievement = new Achievement
         {
             Name = request.Name,
             Value = request.Value,
             Type = request.Type,
             IsMultiscanEnabled = request.IsMultiscanEnabled,
-            Code = code
+            Code = AchievementHelper.GenerateCode(Guid.NewGuid().ToString()),
         };
 
         _context.Achievements.Add(achievement);

--- a/src/Application/Common/Extensions/UserExtensions.cs
+++ b/src/Application/Common/Extensions/UserExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Mail;
-using System.Text;
+using SSW.Rewards.Application.Common.Helpers;
 using SSW.Rewards.Shared.DTOs.Users;
 
 namespace SSW.Rewards.Application.Common.Extensions;
@@ -20,16 +20,13 @@ public static class UserExtensions
 
     public static void GenerateAchievement(this User user)
     {
-        var codeData = Encoding.ASCII.GetBytes($"ach:{Guid.NewGuid().ToString()}");
-        var code = Convert.ToBase64String(codeData);
-
         var achievement = new Achievement
         {
             Name = user.FullName,
             Value = 100,
             Type = AchievementType.Scanned,
             IsMultiscanEnabled = false,
-            Code = code
+            Code = AchievementHelper.GenerateCode(Guid.NewGuid().ToString()),
         };
 
         user.Achievement = achievement;

--- a/src/Application/Common/Helpers/AchievementHelper.cs
+++ b/src/Application/Common/Helpers/AchievementHelper.cs
@@ -1,0 +1,11 @@
+﻿using System.Text;
+
+namespace SSW.Rewards.Application.Common.Helpers;
+public static class AchievementHelper
+{
+    public static string GenerateCode(string inputValue)
+    {
+        var codeData = Encoding.ASCII.GetBytes($"ach:{inputValue}");
+        return Convert.ToBase64String(codeData);
+    }
+}

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -97,7 +97,7 @@ public class UserService : IUserService, IRolesService
 
             newUser.Roles.Add(new UserRole { Role = staffRole });
 
-            var existingStaff = _dbContext.StaffMembers
+            var existingStaff = await _dbContext.StaffMembers
                 .TagWithContext("GetExistingStaff")
                 .FirstOrDefaultAsync(r => r.Email == newUser.Email);
 

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -106,7 +106,7 @@ public class UserService : IUserService, IRolesService
                 var staffMemberEntity = new StaffMember();
 
                 staffMemberEntity.Email = newUser.Email;
-                staffMemberEntity.Name = newUser.FullName ??= string.Empty;
+                staffMemberEntity.Name = newUser.FullName ?? string.Empty;
 
                 await _dbContext.StaffMembers.AddAsync(staffMemberEntity, cancellationToken);
 

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -3,6 +3,7 @@ using AutoMapper.QueryableExtensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SSW.Rewards.Application.Common.Exceptions;
+using SSW.Rewards.Application.Common.Helpers;
 using SSW.Rewards.Shared.DTOs.Users;
 
 namespace SSW.Rewards.Application.Services;
@@ -95,6 +96,28 @@ public class UserService : IUserService, IRolesService
                 .FirstOrDefaultAsync(r => r.Name == "Staff");
 
             newUser.Roles.Add(new UserRole { Role = staffRole });
+
+            var existingStaff = _dbContext.StaffMembers
+                .TagWithContext("GetExistingStaff")
+                .FirstOrDefaultAsync(r => r.Email == newUser.Email);
+
+            if (existingStaff == null)
+            {
+                var staffMemberEntity = new StaffMember();
+
+                staffMemberEntity.Email = newUser.Email;
+                staffMemberEntity.Name = newUser.FullName ??= string.Empty;
+
+                await _dbContext.StaffMembers.AddAsync(staffMemberEntity, cancellationToken);
+
+                staffMemberEntity.StaffAchievement ??= new Achievement
+                {
+                    Name = staffMemberEntity.Name,
+                    Code = AchievementHelper.GenerateCode(staffMemberEntity.Name),
+                    Type = AchievementType.Scanned,
+                    Value = 0
+                };
+            }
         }
 
         var unclaimedAchievements = await _dbContext.UnclaimedAchievements

--- a/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
+++ b/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
@@ -107,7 +107,7 @@ public class UpsertStaffMemberProfileCommandHandler : IRequestHandler<UpsertStaf
                 newUser.Roles.Add(new UserRole { Role = role });
             }
 
-            _context.Users.Add(newUser);
+            await _context.Users.AddAsync(newUser);
 
             _cacheService.Remove(CacheTags.NewlyUserCreated);
         }

--- a/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
+++ b/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
@@ -1,4 +1,7 @@
-﻿using SSW.Rewards.Application.Common.Helpers;
+﻿using Microsoft.EntityFrameworkCore;
+using SSW.Rewards.Application.Common.Helpers;
+using SSW.Rewards.Application.Common.Interfaces;
+using SSW.Rewards.Domain.Entities;
 using SSW.Rewards.Shared.DTOs.Staff;
 
 namespace SSW.Rewards.Application.Staff.Commands.UpsertStaffMemberProfile;
@@ -29,13 +32,16 @@ public class UpsertStaffMemberProfileCommandHandler : IRequestHandler<UpsertStaf
 {
     private readonly IMapper _mapper;
     private readonly IApplicationDbContext _context;
+    private readonly ICacheService _cacheService;
 
     public UpsertStaffMemberProfileCommandHandler(
         IMapper mapper,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ICacheService cacheService)
     {
         _mapper = mapper;
         _context = context;
+        _cacheService = cacheService;
     }
 
     public async Task<StaffMemberDto> Handle(UpsertStaffMemberProfileCommand request, CancellationToken cancellationToken)
@@ -71,6 +77,40 @@ public class UpsertStaffMemberProfileCommandHandler : IRequestHandler<UpsertStaf
             Type = AchievementType.Scanned
         };
         staffMemberEntity.StaffAchievement.Value = request.Points;
+
+        var existingUser = await _context.Users
+            .TagWithContext("GetUserByEmail")
+            .Where(u => u.Email == request.Email)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existingUser == null)
+        {
+            var newUser = new Domain.Entities.User
+            {
+                Email = request.Email,
+                FullName = request.Name,
+                CreatedUtc = DateTime.UtcNow
+            };
+
+            if (!newUser.Email.ToLower().Contains("ssw.com.au"))
+            {
+                newUser.GenerateAchievement();
+            }
+
+            var roles = await _context.Roles
+                .TagWithContext("GetUserAndStaffRoles")
+                .Where(r => r.Name == "User" || r.Name == "Staff")
+                .ToArrayAsync();
+
+            foreach (var role in roles)
+            {
+                newUser.Roles.Add(new UserRole { Role = role });
+            }
+
+            _context.Users.Add(newUser);
+
+            _cacheService.Remove(CacheTags.NewlyUserCreated);
+        }
 
         await _context.SaveChangesAsync(cancellationToken);
         return _mapper.Map<StaffMemberDto>(staffMemberEntity);

--- a/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
+++ b/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+﻿using SSW.Rewards.Application.Common.Helpers;
 using SSW.Rewards.Shared.DTOs.Staff;
 
 namespace SSW.Rewards.Application.Staff.Commands.UpsertStaffMemberProfile;
@@ -67,7 +67,7 @@ public class UpsertStaffMemberProfileCommandHandler : IRequestHandler<UpsertStaf
         staffMemberEntity.StaffAchievement ??= new Achievement
         {
             Name = staffMemberEntity.Name,
-            Code = GenerateCode(staffMemberEntity.Name),
+            Code = AchievementHelper.GenerateCode(staffMemberEntity.Name),
             Type = AchievementType.Scanned
         };
         staffMemberEntity.StaffAchievement.Value = request.Points;
@@ -139,11 +139,5 @@ public class UpsertStaffMemberProfileCommandHandler : IRequestHandler<UpsertStaf
         }
 
         return skill;
-    }
-
-    private static string GenerateCode(string inputValue)
-    {
-        var codeData = Encoding.ASCII.GetBytes($"ach:{inputValue}");
-        return Convert.ToBase64String(codeData);
     }
 }

--- a/src/Application/System/Commands/Common/SampleDataSeeder.cs
+++ b/src/Application/System/Commands/Common/SampleDataSeeder.cs
@@ -2,6 +2,7 @@
 using ExcelDataReader;
 using MoreLinq;
 using SSW.Rewards.Application.Achievements.Common;
+using SSW.Rewards.Application.Common.Helpers;
 
 namespace SSW.Rewards.Application.System.Commands.Common;
 
@@ -83,8 +84,7 @@ public class SampleDataSeeder
 
         foreach (var achievement in achievements)
         {
-            var codeData = Encoding.ASCII.GetBytes($"ach:{achievement.Name}");
-            achievement.Code = Convert.ToBase64String(codeData);
+            achievement.Code = AchievementHelper.GenerateCode(achievement.Name);
 
             sb.AppendLine(achievement.Code);
         }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/1150

> 2. What was changed?

- UserService | CreateUser - Automatically create a Staff record for new Staff users

- UpsertStaffMemberProfileCommandHandler - Automatically create a User record for new Staff records

- Added AchievementHelper | GenerateCode - refactored repeated code for generating Achievement QR Code

> 3. Did you do pair or mob programming?

No

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->