### PR TITLE
♻️ Mobile | Set up Firebase exception handling

### DIFF
--- a/src/MobileUI/Features/Login/LoginPageViewModel.cs
+++ b/src/MobileUI/Features/Login/LoginPageViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.AppCenter.Crashes;
 using Mopups.Services;
+using Plugin.Firebase.Crashlytics;
 using SSW.Rewards.Mobile.Common;
 
 namespace SSW.Rewards.Mobile.ViewModels;
@@ -121,7 +121,7 @@ public partial class LoginPageViewModel : BaseViewModel
         catch (Exception e)
         {
             // Everything else is fatal
-            Crashes.TrackError(e);
+            CrossFirebaseCrashlytics.Current.RecordException(e);
             Console.WriteLine(e);
             await WaitForWindowClose();
             await Application.Current.MainPage.DisplayAlert("Login Failure",

--- a/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsViewModel.cs
@@ -124,7 +124,7 @@ namespace SSW.Rewards.Mobile.ViewModels
         private void LogEvent(string eventName)
         {
             _firebaseAnalyticsService.Log(eventName,
-                new Dictionary<string, string> { { "quiz_id", _quizId.ToString() }, { "quiz_title", QuizTitle } });
+                new Dictionary<string, object> { { "quiz_id", _quizId.ToString() }, { "quiz_title", QuizTitle } });
         }
 
         private async Task SubmitAnswer()

--- a/src/MobileUI/Features/Redeem/RedeemRewardViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemRewardViewModel.cs
@@ -115,7 +115,7 @@ public partial class RedeemRewardViewModel(
 
     private void LogEvent(string eventName)
     {
-        firebaseAnalyticsService.Log(eventName, new Dictionary<string, string>
+        firebaseAnalyticsService.Log(eventName, new Dictionary<string, object>
         {
             { "reward_id", _reward.Id.ToString() },
             { "reward_name", _reward.Name },

--- a/src/MobileUI/MauiExceptions.cs
+++ b/src/MobileUI/MauiExceptions.cs
@@ -1,0 +1,67 @@
+/* MIT License
+
+   Copyright (c) 2022 Matt Johnson-Pint
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+   
+   From https://gist.github.com/mattjohnsonpint/7b385b7a2da7059c4a16562bc5ddb3b7
+*/
+
+public static class MauiExceptions
+{
+    // We'll route all unhandled exceptions through this one event.
+    public static event UnhandledExceptionEventHandler UnhandledException;
+
+    static MauiExceptions()
+    {
+        // This is the normal event expected, and should still be used.
+        // It will fire for exceptions from iOS and Mac Catalyst,
+        // and for exceptions on background threads from WinUI 3.
+        
+        AppDomain.CurrentDomain.UnhandledException += (sender, args) => 
+        {
+            UnhandledException?.Invoke(sender, args);
+        };
+
+#if IOS || MACCATALYST
+
+        // For iOS and Mac Catalyst
+        // Exceptions will flow through AppDomain.CurrentDomain.UnhandledException,
+        // but we need to set UnwindNativeCode to get it to work correctly. 
+        // 
+        // See: https://github.com/xamarin/xamarin-macios/issues/15252
+        
+        ObjCRuntime.Runtime.MarshalManagedException += (_, args) =>
+        {
+            args.ExceptionMode = ObjCRuntime.MarshalManagedExceptionMode.UnwindNativeCode;
+        };
+
+#elif ANDROID
+
+        // For Android:
+        // All exceptions will flow through Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser,
+        // and NOT through AppDomain.CurrentDomain.UnhandledException
+
+        Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) =>
+        {
+            UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, true));
+        };
+#endif
+    }
+}

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -32,7 +32,6 @@
 		<CodesignProvision>Automatic</CodesignProvision>
 		<CodesignKey>iPhone Developer</CodesignKey>
 		<MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
 		<CreatePackage>false</CreatePackage>
@@ -77,9 +76,6 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
 		<PackageReference Include="M.BindableProperty.Generator" Version="0.11.1" />
-		<PackageReference Include="Microsoft.AppCenter" Version="5.0.3" />
-		<PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.3" />
-		<PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.3" />
 		<PackageReference Include="Mopups" Version="1.3.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="QRCoder-ImageSharp" Version="0.10.0" />
@@ -93,16 +89,18 @@
 	<ItemGroup Condition="$(TargetFramework.Contains('android'))">
         <GoogleServicesJson Include="Platforms/Android/google-services.json" />
 		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.7.1" />
-		<PackageReference Include="Xamarin.Firebase.Messaging" Version="123.3.1.2" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.3.0.2" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.4.0" />
         <PackageReference Include="Xamarin.Google.Dagger" Version="2.48.1.2" />
-        <PackageReference Include="Xamarin.Firebase.Core" Version="121.1.1.8" />
-        <PackageReference Include="Xamarin.Firebase.Analytics" Version="121.3.0.6" />
 	</ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
         <BundleResource Include="Platforms/iOS/GoogleService-Info.plist" Link="GoogleService-Info.plist" />
-        <PackageReference Include="Xamarin.Firebase.iOS.Analytics" Version="8.10.0.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios' OR '$(TargetFramework)' == 'net8.0-android'">
+        <PackageReference Include="Plugin.Firebase.Analytics" Version="3.1.1" />
+        <PackageReference Include="Plugin.Firebase.CloudMessaging" Version="3.1.2" />
+        <PackageReference Include="Plugin.Firebase.Crashlytics" Version="3.1.1" />
     </ItemGroup>
     
     <!--https://github.com/dotnet/maui/issues/16514-->
@@ -121,4 +119,20 @@
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
         <BundleResource Include="Platforms\iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
     </ItemGroup>
+
+    <!-- Target needed until LinkWithSwiftSystemLibraries makes it into the SDK: https://github.com/xamarin/xamarin-macios/pull/20463 -->
+    <Target Name="LinkWithSwift" DependsOnTargets="_ParseBundlerArguments;_DetectSdkLocations" BeforeTargets="_LinkNativeExecutable">
+        <PropertyGroup>
+            <_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('iossimulator-'))">iphonesimulator</_SwiftPlatform>
+            <_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('ios-'))">iphoneos</_SwiftPlatform>
+        </PropertyGroup>
+        <ItemGroup>
+            <_CustomLinkFlags Include="-L" />
+            <_CustomLinkFlags Include="/usr/lib/swift" />
+            <_CustomLinkFlags Include="-L" />
+            <_CustomLinkFlags Include="$(_SdkDevPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(_SwiftPlatform)" />
+            <_CustomLinkFlags Include="-Wl,-rpath" />
+            <_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
+        </ItemGroup>
+    </Target>
 </Project>

--- a/src/MobileUI/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileUI/Platforms/Android/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ssw.consulting" android:versionCode="86" android:versionName="3.0.47">
 	<application android:allowBackup="false" android:icon="@mipmap/icon_android_dark" android:supportsRtl="true" android:label="SSW Rewards">
 		<meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
+    <meta-data android:name="firebase_analytics_collection_enabled" android:value="true" />
 	</application>
 	<!-- Setting Targeted sdk version to 32 instead of the latest 33 due to Android Permissions not correctly implemented yet
 		 See Issue: https://github.com/dotnet/maui/issues/11275 -->

--- a/src/MobileUI/Platforms/Android/MainActivity.cs
+++ b/src/MobileUI/Platforms/Android/MainActivity.cs
@@ -2,6 +2,7 @@
 using Android.Content.PM;
 using Android.OS;
 using Microsoft.Maui.Controls.Compatibility.Platform.Android;
+using Plugin.Firebase.CloudMessaging;
 using Color = Microsoft.Maui.Graphics.Color;
 
 namespace SSW.Rewards.Mobile;
@@ -39,6 +40,7 @@ public class MainActivity : MauiAppCompatActivity
 
             var notificationManager = (NotificationManager)GetSystemService(Android.Content.Context.NotificationService);
             notificationManager.CreateNotificationChannel(channel);
+            FirebaseCloudMessagingImplementation.ChannelId = Channel_ID;
         }
     }
 }

--- a/src/MobileUI/Platforms/Android/Resources/values/strings.xml
+++ b/src/MobileUI/Platforms/Android/Resources/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="com.google.firebase.crashlytics.mapping_file_id">none</string>
+</resources>

--- a/src/MobileUI/Platforms/iOS/AppDelegate.cs
+++ b/src/MobileUI/Platforms/iOS/AppDelegate.cs
@@ -1,9 +1,41 @@
-﻿using Foundation;
+﻿using Firebase.CloudMessaging;
+using Foundation;
+using UIKit;
+using UserNotifications;
 
 namespace SSW.Rewards.Mobile;
 
 [Register("AppDelegate")]
-public class AppDelegate : MauiUIApplicationDelegate
+public class AppDelegate : MauiUIApplicationDelegate, IUNUserNotificationCenterDelegate, IMessagingDelegate
 {
 	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+    {
+        Messaging.SharedInstance.Delegate = this;
+        Messaging.SharedInstance.AutoInitEnabled = true;
+
+        var authOptions = UNAuthorizationOptions.Alert | UNAuthorizationOptions.Badge | UNAuthorizationOptions.Sound;
+        UNUserNotificationCenter.Current.RequestAuthorization(authOptions, (granted, error) =>
+        {
+            if (error is not null)
+            {
+                Console.WriteLine("Received Remote Notification");
+            }
+        });
+
+        UNUserNotificationCenter.Current.Delegate = this;
+        
+        UIApplication.SharedApplication.RegisterForRemoteNotifications();
+        
+        return base.FinishedLaunching(app, options);
+    }
+    
+    [Export("messaging:didReceiveRegistrationToken:")]
+    public void DidReceiveRegistrationToken(Messaging message, string token)
+    {
+        SecureStorage.SetAsync("DeviceToken", token);
+        Preferences.Set("DeviceTokenLastTimeUpdated", DateTime.MinValue);
+        Console.WriteLine ($"Firebase registration token: {token}");
+    }
 }

--- a/src/MobileUI/Platforms/iOS/Entitlements.plist
+++ b/src/MobileUI/Platforms/iOS/Entitlements.plist
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>B5652JTA7Q.com.companyname.SSW.Consulting</string>
-	</array>
-</dict>
+    <dict>
+        <key>keychain-access-groups</key>
+        <array>
+            <string>B5652JTA7Q.com.companyname.SSW.Consulting</string>
+        </array>
+        <key>aps-environment</key>
+        <string>development</string>
+    </dict>
 </plist>

--- a/src/MobileUI/Platforms/iOS/Info.plist
+++ b/src/MobileUI/Platforms/iOS/Info.plist
@@ -57,5 +57,9 @@
 			</array>
 		</dict>
 	</array>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>remote-notification</string>
+    </array>
 </dict>
 </plist>

--- a/src/MobileUI/Services/AuthenticationService.cs
+++ b/src/MobileUI/Services/AuthenticationService.cs
@@ -2,7 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using IdentityModel.Client;
 using IdentityModel.OidcClient;
 using IdentityModel.OidcClient.Results;
-using Microsoft.AppCenter.Crashes;
+using Plugin.Firebase.Crashlytics;
 using SSW.Rewards.Mobile.Common;
 using IBrowser = IdentityModel.OidcClient.Browser.IBrowser;
 
@@ -64,7 +64,7 @@ public class AuthenticationService : IAuthenticationService
             }
             catch (Exception ex)
             {
-                Crashes.TrackError(new Exception("Failed to set a logged-in state"));
+                CrossFirebaseCrashlytics.Current.RecordException(new Exception("Failed to set a logged-in state"));
 
                 // TECH DEBT: Workaround for iOS since calling DisplayAlert while a Safari web view is in
                 // the process of closing causes the alert to never appear and the await call never returns.
@@ -78,7 +78,7 @@ public class AuthenticationService : IAuthenticationService
         }
         catch (Exception ex)
         {
-            Crashes.TrackError(new Exception($"AuthDebug: unknown exception was thrown during SignIn ${ex.Message}; ${ex.StackTrace}"));
+            CrossFirebaseCrashlytics.Current.RecordException(new Exception($"AuthDebug: unknown exception was thrown during SignIn ${ex.Message}; ${ex.StackTrace}"));
             await SignOut();
         }
     }
@@ -99,7 +99,7 @@ public class AuthenticationService : IAuthenticationService
 
             if (result.IsError)
             {
-                Crashes.TrackError(new Exception($"AuthDebug: LoginAsync returned error {result.ErrorDescription}"));
+                CrossFirebaseCrashlytics.Current.RecordException(new Exception($"AuthDebug: LoginAsync returned error {result.ErrorDescription}"));
                 await SignOut();
                 return ApiStatus.Error;
             }
@@ -114,7 +114,7 @@ public class AuthenticationService : IAuthenticationService
         }
         catch (Exception ex)
         {
-            Crashes.TrackError(new Exception($"AuthDebug: unknown exception was thrown during SignIn ${ex.Message}; ${ex.StackTrace}"));
+            CrossFirebaseCrashlytics.Current.RecordException(new Exception($"AuthDebug: unknown exception was thrown during SignIn ${ex.Message}; ${ex.StackTrace}"));
             await SignOut();
             return ApiStatus.Error;
         }
@@ -179,7 +179,7 @@ public class AuthenticationService : IAuthenticationService
             }
             catch (Exception ex)
             {
-                Crashes.TrackError(new Exception("Failed to set a logged-in state"));
+                CrossFirebaseCrashlytics.Current.RecordException(new Exception("Failed to set a logged-in state"));
                 return ApiStatus.Unavailable;
             }
 
@@ -187,8 +187,8 @@ public class AuthenticationService : IAuthenticationService
         }
         else
         {
-            Crashes.TrackError(new Exception(
-                $"AuthDebug: loginResult is missing tokens. Missing IdentityToken = {string.IsNullOrWhiteSpace(loginResult.IdentityToken)}, missing AccessToken = {string.IsNullOrWhiteSpace(loginResult.AccessToken)}"));
+            CrossFirebaseCrashlytics.Current.RecordException(new Exception(
+                 $"AuthDebug: loginResult is missing tokens. Missing IdentityToken = {string.IsNullOrWhiteSpace(loginResult.IdentityToken)}, missing AccessToken = {string.IsNullOrWhiteSpace(loginResult.AccessToken)}"));
             return ApiStatus.LoginFailure;
         }
     }
@@ -221,13 +221,13 @@ public class AuthenticationService : IAuthenticationService
             }
             else
             {
-                Crashes.TrackError(new Exception($"{result.Error}, {result.ErrorDescription}"));
+                CrossFirebaseCrashlytics.Current.RecordException(new Exception($"{result.Error}, {result.ErrorDescription}"));
 
                 var signInResult = await SignInAsync();
                 if (signInResult != ApiStatus.Success && signInResult != ApiStatus.CancelledByUser)
                 {
-                    Crashes.TrackError(new Exception(
-                        $"AuthDebug: Unsuccessful attempt to sign in after unsuccessful token refresh, ApiStatus={signInResult}"));
+                    CrossFirebaseCrashlytics.Current.RecordException(new Exception(
+                         $"AuthDebug: Unsuccessful attempt to sign in after unsuccessful token refresh, ApiStatus={signInResult}"));
                 }
 
                 return signInResult == ApiStatus.Success;

--- a/src/MobileUI/Services/FirebaseAnalyticsService.cs
+++ b/src/MobileUI/Services/FirebaseAnalyticsService.cs
@@ -1,11 +1,4 @@
-using Firebase.Analytics;
-
-#if IOS
-using Foundation;
-#else
-    using Android.Content;
-    using Android.OS;
-#endif
+using Plugin.Firebase.Analytics;
 
 namespace SSW.Rewards.Mobile.Services;
 
@@ -14,55 +7,21 @@ namespace SSW.Rewards.Mobile.Services;
 public interface IFirebaseAnalyticsService
 {
     void Log(string value, string eventName = "screen_view", string paramName = "screen_name");
-    void Log(string eventName, IDictionary<string, string> parameters);
+    void Log(string eventName, IDictionary<string, object> parameters);
 }
 
 public class FirebaseAnalyticsService : IFirebaseAnalyticsService
 {
     public void Log(string value, string eventName = "screen_view", string paramName = "screen_name")
     {
-        Log(eventName, new Dictionary<string, string>
+        Log(eventName, new Dictionary<string, object>
         {
             { paramName, value }
         });
     }
 
-    public void Log(string eventName, IDictionary<string, string> parameters)
+    public void Log(string eventName, IDictionary<string, object> parameters)
     {
-#if IOS
-        if (parameters == null)
-        {
-            Analytics.LogEvent(eventName, (Dictionary<object, object>)null);
-            return;
-        }
-
-        var keys = new List<NSString>();
-        var values = new List<NSString>();
-        foreach (var item in parameters)
-        {
-            keys.Add(new NSString(item.Key));
-            values.Add(new NSString(item.Value));
-        }
-
-        var parametersDictionary =
-            NSDictionary<NSString, NSObject>.FromObjectsAndKeys(values.ToArray(), keys.ToArray(), keys.Count);
-        Analytics.LogEvent(eventName, parametersDictionary);
-#else
-        var firebaseAnalytics = FirebaseAnalytics.GetInstance(Platform.CurrentActivity);
-
-        if (parameters == null)
-        {
-            firebaseAnalytics.LogEvent(eventName, null);
-            return;
-        }
-
-        var bundle = new Bundle();
-        foreach (var param in parameters)
-        {
-            bundle.PutString(param.Key, param.Value);
-        }
-
-        firebaseAnalytics.LogEvent(eventName, bundle);
-#endif
+        CrossFirebaseAnalytics.Current.LogEvent(eventName, parameters);
     }
 }

--- a/src/MobileUI/Services/PushNotificationsService.cs
+++ b/src/MobileUI/Services/PushNotificationsService.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AppCenter.Crashes;
-using Microsoft.Extensions.DependencyInjection.Notifications.Commands.UploadDeviceToken;
+﻿using Microsoft.Extensions.DependencyInjection.Notifications.Commands.UploadDeviceToken;
+using Plugin.Firebase.Crashlytics;
 using SSW.Rewards.ApiClient.Services;
 
 namespace SSW.Rewards.Mobile.Services;
@@ -28,7 +28,7 @@ public class PushNotificationsService : IPushNotificationsService
         }
         catch (Exception e)
         {
-            Crashes.TrackError(new Exception($"Couldn't upload device token at {lastTimeUpdated}. Error: {e}"));
+            CrossFirebaseCrashlytics.Current.RecordException(new Exception($"Couldn't upload device token at {lastTimeUpdated}. Error: {e}"));
             return false;
         }
     }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

AppCenter is retiring and needs to be replaced.

Closes #868 

> 2. What was changed?

- Replaces the deprecated Xamarin.Firebase.* packages with the newer and maintained Plugin.Firebase.* packages.
- Sets up Crashlytics from the Plugin.Firebase library and updates the global exception handling to report to Firebase.
- Updates the existing CloudMessaging integration for Android with the new Plugin.Firebase and sets up preliminary support for iOS notifications.

> 3. Did you do pair or mob programming?

No 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->