### PR TITLE
Fix email confirmation autologin on iOS

### DIFF
--- a/src/MobileUI/Constants.cs
+++ b/src/MobileUI/Constants.cs
@@ -3,16 +3,16 @@
 public static class Constants
 {
 #if DEBUG
-    public const string ApiBaseUrl = "https://app-sswrewards-api-staging.azurewebsites.net";
+    // public const string ApiBaseUrl = "https://app-sswrewards-api-staging.azurewebsites.net";
     // public const string ApiBaseUrl = "https://api.rewards.ssw.com.au";
-    // public const string ApiBaseUrl = "https://0a88-180-150-47-47.ngrok-free.app";
+    public const string ApiBaseUrl = "https://0a88-180-150-47-47.ngrok-free.app";
     public const string AppCenterAndroidId = "285df68b-ea1b-4afb-94c3-2581613c6880";
     public const string AppCenterIOSId = "71ea37dd-20c5-40ca-9d68-81b743d81337";
 
 #elif QA
     public string ApiBaseUrl = "https://sswconsulting-dev.azurewebsites.net";
 #else
-    public const string ApiBaseUrl = "https://app-sswrewards-api-staging.azurewebsites.net";
+    public const string ApiBaseUrl = "https://api.rewards.ssw.com.au";
     public const string AppCenterAndroidId = "d6f591ec-8cef-44d7-96c0-08f31f91fb74";
     public const string AppCenterIOSId = "21efe682-dc49-4d39-8af8-ad05911be003";
 #endif
@@ -22,8 +22,8 @@ public static class Constants
     public const string AutologinRedirectUrl = "sswrewards://autologin";
 
 #if DEBUG
-    // public const string AuthorityUri = "https://identity.ssw.com.au";
-    public const string AuthorityUri = "https://app-ssw-ident-staging-api.azurewebsites.net";
+    public const string AuthorityUri = "https://identity.ssw.com.au";
+    // public const string AuthorityUri = "https://app-ssw-ident-staging-api.azurewebsites.net";
 #else
     public const string AuthorityUri = "https://identity.ssw.com.au";
 #endif
@@ -43,13 +43,13 @@ public static class Constants
         public const int Twitter = 3;
         public const int Company = 4;
     }
-
+    
     public static class AnalyticsEvents
     {
         public const string QuizStart = "quiz_start";
         public const string QuizPass = "quiz_pass";
         public const string QuizFail = "quiz_fail";
-
+        
         public const string RewardView = "reward_view";
         public const string RewardRedemptionPending = "reward_redemption_pending";
         public const string RewardRedemptionCancelled = "reward_redemption_cancelled";

--- a/src/MobileUI/Constants.cs
+++ b/src/MobileUI/Constants.cs
@@ -3,26 +3,27 @@
 public static class Constants
 {
 #if DEBUG
-    // public const string ApiBaseUrl = "https://app-sswrewards-api-staging.azurewebsites.net";
+    public const string ApiBaseUrl = "https://app-sswrewards-api-staging.azurewebsites.net";
     // public const string ApiBaseUrl = "https://api.rewards.ssw.com.au";
-    public const string ApiBaseUrl = "https://0a88-180-150-47-47.ngrok-free.app";
+    // public const string ApiBaseUrl = "https://0a88-180-150-47-47.ngrok-free.app";
     public const string AppCenterAndroidId = "285df68b-ea1b-4afb-94c3-2581613c6880";
     public const string AppCenterIOSId = "71ea37dd-20c5-40ca-9d68-81b743d81337";
 
 #elif QA
     public string ApiBaseUrl = "https://sswconsulting-dev.azurewebsites.net";
 #else
-    public const string ApiBaseUrl = "https://api.rewards.ssw.com.au";
+    public const string ApiBaseUrl = "https://app-sswrewards-api-staging.azurewebsites.net";
     public const string AppCenterAndroidId = "d6f591ec-8cef-44d7-96c0-08f31f91fb74";
     public const string AppCenterIOSId = "21efe682-dc49-4d39-8af8-ad05911be003";
 #endif
     public const string MaxApiSupportedVersion = "1.0";
 
     public const string AuthRedirectUrl = "msauth.com.ssw.consulting://auth";
+    public const string AutologinRedirectUrl = "sswrewards://autologin";
 
 #if DEBUG
-    public const string AuthorityUri = "https://identity.ssw.com.au";
-    // public const string AuthorityUri = "https://app-ssw-ident-staging-api.azurewebsites.net";
+    // public const string AuthorityUri = "https://identity.ssw.com.au";
+    public const string AuthorityUri = "https://app-ssw-ident-staging-api.azurewebsites.net";
 #else
     public const string AuthorityUri = "https://identity.ssw.com.au";
 #endif
@@ -42,13 +43,13 @@ public static class Constants
         public const int Twitter = 3;
         public const int Company = 4;
     }
-    
+
     public static class AnalyticsEvents
     {
         public const string QuizStart = "quiz_start";
         public const string QuizPass = "quiz_pass";
         public const string QuizFail = "quiz_fail";
-        
+
         public const string RewardView = "reward_view";
         public const string RewardRedemptionPending = "reward_redemption_pending";
         public const string RewardRedemptionCancelled = "reward_redemption_cancelled";

--- a/src/MobileUI/Features/App.xaml.cs
+++ b/src/MobileUI/Features/App.xaml.cs
@@ -44,8 +44,18 @@ public partial class App : Application
     protected override async void OnAppLinkRequestReceived(Uri uri)
     {
         base.OnAppLinkRequestReceived(uri);
-        
-        if (uri.Scheme == ApiClientConstants.RewardsQRCodeProtocol)
+
+        if ($"{uri.Scheme}://{uri.Host}" == Constants.AutologinRedirectUrl)
+        {
+            var queryDictionary = System.Web.HttpUtility.ParseQueryString(uri.Query);
+            var token = queryDictionary.Get("token");
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                await _authService.AutologinAsync(token);
+            }
+        }
+        else if (uri.Scheme == ApiClientConstants.RewardsQRCodeProtocol)
         {
             var queryDictionary = System.Web.HttpUtility.ParseQueryString(uri.Query);
             var code = queryDictionary.Get(ApiClientConstants.RewardsQRCodeProtocolQueryName);
@@ -61,16 +71,6 @@ public partial class App : Application
                 ((LoginPage)MainPage)?.QueueCodeScan(code);
             }
         }
-        else if ($"{uri.Scheme}://{uri.Host}" == Constants.AuthRedirectUrl)
-        {
-            var queryDictionary = System.Web.HttpUtility.ParseQueryString(uri.Query);
-            var token = queryDictionary.Get("token");
-
-            if (!string.IsNullOrEmpty(token))
-            {
-                await _authService.AutologinAsync(token);
-            }
-        }        
     }
 
     private async Task CheckApiCompatibilityAsync()

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -123,17 +123,37 @@ public static class MauiProgram
                 ios.OpenUrl((app, url, options) => HandleAppLink(url.AbsoluteString));
             });
 #elif ANDROID
-            events.AddAndroid(android => android.OnCreate((activity, bundle) => {
-                var action = activity.Intent?.Action;
-                var data = activity.Intent?.Data?.ToString();
-
-                if (action != Android.Content.Intent.ActionView || data is null)
+            events.AddAndroid(android => 
+            {
+                android.OnCreate((activity, bundle) =>
                 {
-                    return;
-                }
+                    var action = activity.Intent?.Action;
+                    var data = activity.Intent?.Data?.ToString();
 
-                Task.Run(() => HandleAppLink(data));
-            }));
+                    if (action != Android.Content.Intent.ActionView || data is null)
+                    {
+                        return;
+                    }
+
+                    Task.Run(() => HandleAppLink(data));
+                });
+
+                android.OnNewIntent((activity, intent) =>
+                {
+                    if (intent != null)
+                    {
+                        var action = intent.Action;
+                        var data = intent.Data?.ToString();
+                        
+                        if (action != Android.Content.Intent.ActionView || data is null)
+                        {
+                            return;
+                        }
+
+                        Task.Run(() => HandleAppLink(data));
+                    }
+                });
+            });
 #endif
         });
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Issue with Autologin not working on iOS - https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/1008

> 2. What was changed?

- Changed deep link used for autologin to "sswrewards://autologin"
- Android - Added deep link processing with OnNewIntent, so they are processed correctly when App is already running on the phone

> 3. Did you do pair or mob programming?

No

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->