### PR TITLE
Bump Xcode version in pipeline

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -42,8 +42,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          sudo xcode-select -s "/Applications/Xcode_16.0.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.0.app" >> $GITHUB_ENV
+          sudo xcode-select -s "/Applications/Xcode_16.2.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.2.app" >> $GITHUB_ENV
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -42,8 +42,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          sudo xcode-select -s "/Applications/Xcode_15.4.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_15.4.app" >> $GITHUB_ENV
+          sudo xcode-select -s "/Applications/Xcode_16.0.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.0.app" >> $GITHUB_ENV
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Failing iOS build in pipeline

> 2. What was changed?

The pipeline is now complaining about the SDK version being too old. This bumps it up to the latest to hopefully resolve this.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->