### PR TITLE
Set build version from count of commits

### DIFF
--- a/.github/workflows/mobile-main.yml
+++ b/.github/workflows/mobile-main.yml
@@ -20,15 +20,9 @@ jobs:
       - name: Generate build number
         id: set_build_number
         run: |
-          commitHash=$(git rev-parse HEAD)
-          hexBuildNumber=${commitHash: -8}
-
-          # Convert hexadecimal to uppercase
-          hexBuildNumber=$(echo "$hexBuildNumber" | tr '[:lower:]' '[:upper:]')
-
-          # Convert from hexadecimal to decimal
-          buildNumber=$(echo "ibase=16; $hexBuildNumber" | bc)
-          echo "Decimal Build Number based on Commit ID: $buildNumber"
+          # Get count of commits on branch
+          buildNumber=$(git rev-list --count HEAD)
+          echo "Build number based on commit count: $buildNumber"
 
           echo "buildNumber=$buildNumber" >> $GITHUB_ENV
           echo "buildNumber=$buildNumber" >> $GITHUB_OUTPUT


### PR DESCRIPTION
We're getting this error on the Android deploy:

"Error: Version code 1 has already been used."

This is being set by the "Generate build number" step in the workflow. This seems to be working correctly, but the output seems to generate an integer greater than the 32-bit max, which is what the Android build expects. This might be why it's being recorded as "1" here.

This updates the build number to instead be generated by the count of commits on the branch, which provides a more sane number that auto-increments with every push to main.