### PR TITLE
Fix build number setting in workflow

### DIFF
--- a/.github/workflows/mobile-main.yml
+++ b/.github/workflows/mobile-main.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Generate build number
         id: set_build_number
         run: |


### PR DESCRIPTION
My last PR wasn't working as expected as it seems by default the repo doesn't return the full history (so it only shows 1). This should hopefully set the build correctly as it should see the full history.