### PR TITLE
Set ApplicationVersion on the publish command in pipeline

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,14 +24,6 @@ jobs:
           $buildNumber=${{ inputs.build_number }}
           echo "Build Number: $buildNumber"
 
-      - name: Update Build Number
-        run: |
-          $content = Get-Content src/MobileUI/MobileUI.csproj -Raw
-
-          $newContent = $content -replace '<ApplicationVersion>.*</ApplicationVersion>', "<ApplicationVersion>$buildNumber</ApplicationVersion>"
-
-          Set-Content src/MobileUI/MobileUI.csproj -Value $newContent
-
       - name: Update google-services.json
         shell: bash
         run: |
@@ -61,7 +53,9 @@ jobs:
 
       - name: Build and sign
         run: dotnet publish src/MobileUI/MobileUI.csproj `
-          -f:net8.0-android -c:Release /p:AndroidKeyStore=True `
+          -f:net8.0-android -c:Release `
+          /p:ApplicationVersion=${{ inputs.build_number }} `
+          /p:AndroidKeyStore=True `
           /p:AndroidSigningKeyStore="${{ github.workspace }}/sswrewards.keystore" `
           /p:AndroidSigningKeyPass=${{ secrets.ANDROID_KEYPASSWORD }} `
           /p:AndroidSigningKeyAlias=${{ secrets.ANDROID_KEYSTOREALIAS }} `


### PR DESCRIPTION
One more go at trying to resolve this before I give up 😅

Sets the ApplicationVersion on the publish command to hopefully fix it being set to 1 in the pipeline. I can confirm that this command works locally to set it on the resulting APK/AAB.