### PR TITLE
Speed up iOS publish build in pipeline

### DIFF
--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -37,6 +37,8 @@
 		<CreatePackage>false</CreatePackage>
 		<CodesignProvision>Automatic</CodesignProvision>
 		<CodesignKey>iPhone Developer</CodesignKey>
+        <MtouchUseLlvm>False</MtouchUseLlvm>
+        <AotAssemblies>True</AotAssemblies>
 	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->


### PR DESCRIPTION
The publish build for iOS in the pipeline is currently taking forever (50-60 minutes) compared to the Android build (10 or so minutes).

This tweak should speed up the iOS build.