### PR TITLE
Leaderboard & Network pages - fix incorrect user profile pictures

### DIFF
--- a/src/Application/Network/Queries/GetNetworkProfileList/GetNetworkProfileListQuery.cs
+++ b/src/Application/Network/Queries/GetNetworkProfileList/GetNetworkProfileListQuery.cs
@@ -22,16 +22,20 @@ public class GetNetworkProfileListHandler : IRequestHandler<GetNetworkProfileLis
 {
     private readonly IApplicationDbContext _dbContext;
     private readonly ICurrentUserService _currentUserService;
+    private readonly IProfilePicStorageProvider _profilePicStorageProvider;
 
-    public GetNetworkProfileListHandler(IApplicationDbContext dbContext, ICurrentUserService currentUserService)
+    public GetNetworkProfileListHandler(IApplicationDbContext dbContext, ICurrentUserService currentUserService, IProfilePicStorageProvider profilePicStorageProvider)
     {
         _dbContext = dbContext;
         _currentUserService = currentUserService;
+        _profilePicStorageProvider = profilePicStorageProvider;
     }
 
     public async Task<NetworkProfileListViewModel> Handle(GetNetworkProfileListQuery request, CancellationToken cancellationToken)
     {
         var userEmail = _currentUserService.GetUserEmail();
+
+        var defaultProfilePictureUrl = await _profilePicStorageProvider.GetProfilePicUri("v2sophie.png");
 
         // Get user ID, user achievement ID and staff achievement ID.
         // Usually it only has one of the achievement IDs.
@@ -136,7 +140,7 @@ public class GetNetworkProfileListHandler : IRequestHandler<GetNetworkProfileLis
                 UserId = g.Key.UserId,
                 Email = g.Key.Email ?? string.Empty,
                 Name = g.Key.Name ?? string.Empty,
-                ProfilePicture = g.Key.ProfilePicture ?? string.Empty,
+                ProfilePicture = g.Key.ProfilePicture ?? defaultProfilePictureUrl.ToString(),
                 AchievementId = g.Max(x => x.AchievementId),
                 Scanned = g.Any(x => x.Scanned || scannedAchievements.Contains(x.AchievementId)),
                 ScannedMe = g.Any(x => x.ScannedMe),


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Users that don't have a Profile Picture in blob storage sometimes get incorrect picture, instead of the local v2sophie.png

closes #1154 

> 2. What was changed?

Leaderboard & Network Queries - if User has no Profile Picture - use v2sophie.png from blob storage 

> 3. Did you do pair or mob programming?

No

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->