### PR TITLE
🐛 Mobile | Fix error messages on social media popup

### DIFF
--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -49,6 +49,7 @@
                                 </DataTrigger>
                             </Label.Triggers>
                         </Label>
+                        
                         <Border
                             Margin="20,0"
                             StrokeShape="RoundRectangle 10"
@@ -69,13 +70,40 @@
                                 </controls:BorderlessEntry.Behaviors>
                             </Entry>
                         </Border>
+                        
+                        <VerticalStackLayout HeightRequest="40">
+                            <Label
+                                FontSize="11"
+                                Margin="30,0"
+                                Text="{Binding ErrorText}"
+                                TextColor="{StaticResource SSWRed}"
+                            />
+                            <Label
+                                FontSize="11"
+                                Margin="30,0"
+                                Text="{Binding SuccessText}"
+                                TextColor="White"
+                            />
+                        </VerticalStackLayout>
+                        
                         <Label
-                            FontSize="11"
-                            Margin="30,0"
-                            IsVisible="{Binding IsError}"
-                            Text="{Binding ErrorText}"
-                            TextColor="{StaticResource SSWRed}"
-                        />
+                            HorizontalOptions="Center"
+                            FontFamily="FA6Brands"
+                            Text="{Binding Icon}"
+                            FontAutoScalingEnabled="False"
+                            FontSize="50"
+                            TextColor="DimGrey">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label"
+                                             Binding="{Binding InputText, Converter={toolkit:IsStringNotNullOrEmptyConverter}}"
+                                             Value="True">
+                                    <Setter Property="TextColor" Value="{StaticResource SSWRed}" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding OpenLinkCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
                     </VerticalStackLayout>
                     <Button
                         Text="Connect"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1213

> 2. What was changed?

1. Updates the social media popup to insert existing links as text rather than a placeholder so it doesn't show an error about the field being empty when the Connect button is tapped and nothing was changed.
2. Shows "✅ Done" when Connect is tapped and the field is valid.
3. Adds an icon for the selected social media below the field that can be tapped to open the entered URL.

<img src="https://github.com/user-attachments/assets/c01936ff-8c8d-449f-bcfd-c8e73e79aa03" width="400" />

**FIgure: Updated social media popup with no more placeholder text and new tappable icon**


> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->