### PR TITLE
♻️ Mobile | Update tab bar design

### DIFF
--- a/src/MobileUI/Controls/CustomTabBar.cs
+++ b/src/MobileUI/Controls/CustomTabBar.cs
@@ -1,0 +1,22 @@
+using System.Windows.Input;
+using Maui.BindableProperty.Generator.Core;
+
+namespace SSW.Rewards.Mobile.Controls;
+
+public partial class CustomTabBar : TabBar
+{
+    public event EventHandler CenterViewTapped;
+    [AutoBindable]
+    private ImageSource? centerViewImageSource;
+    [AutoBindable]
+    private string? centerViewText;
+    [AutoBindable]
+    private bool centerViewVisible;
+    [AutoBindable]
+    public Color? centerViewBackgroundColor;
+    
+    public void CenterView_Tapped()
+    {
+        CenterViewTapped?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/MobileUI/Controls/ProfileStats.xaml
+++ b/src/MobileUI/Controls/ProfileStats.xaml
@@ -16,38 +16,61 @@
         <converters:LevelToStarsConverter x:Key="LevelToStars" />
     </Border.Resources>
     <VerticalStackLayout
-        Spacing="15"
-        Padding="0,15">
+        Spacing="15">
         <Grid>
-            <Grid.GestureRecognizers>
-                <TapGestureRecognizer Command="{Binding ChangeProfilePictureCommand}" />
-            </Grid.GestureRecognizers>
+            <Grid>
+                <Button WidthRequest="50"
+                    HeightRequest="50"
+                    MinimumHeightRequest="50"
+                    MinimumWidthRequest="50"
+                    CornerRadius="25"
+                    BackgroundColor="Transparent"
+                    Padding="0"
+                    Command="{Binding ClosePageCommand}"
+                    HorizontalOptions="End"
+                    VerticalOptions="Start" >
+                    <Button.ImageSource>
+                        <FontImageSource FontFamily="FA6Regular"
+                                         Glyph="&#xf057;"
+                                         Size="30"
+                                         Color="White"
+                                         FontAutoScalingEnabled="False" />
+                    </Button.ImageSource>
+                </Button>
+            </Grid>
+            <Grid WidthRequest="120"
+                  HeightRequest="120"
+                  Margin="0,10,0,0">
+                <Grid.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding ChangeProfilePictureCommand}" />
+                </Grid.GestureRecognizers>
             
-            <!-- Setting Text="" here to prevent "?" from being displayed before image load -->
-            <toolkit:AvatarView ImageSource="{Binding ProfilePic}"
-                                Text=""
-                                WidthRequest="120"
-                                HeightRequest="120"
-                                CornerRadius="60"
-                                BorderWidth="2" />
+                <!-- Setting Text="" here to prevent "?" from being displayed before image load -->
+                <toolkit:AvatarView ImageSource="{Binding ProfilePic}"
+                                    Text=""
+                                    WidthRequest="120"
+                                    HeightRequest="120"
+                                    CornerRadius="60"
+                                    BorderWidth="2" />
 
-            <Border
-                BackgroundColor="{StaticResource primary}"
-                HorizontalOptions="Center"
-                VerticalOptions="Center"
-                TranslationX="40"
-                TranslationY="35"
-                StrokeShape="Ellipse"
-                StrokeThickness="0"
-                IsVisible="{Binding IsMe}">
-                <Label
-                    FontFamily="FluentIcons"
-                    FontAutoScalingEnabled="False"
-                    FontSize="25"
-                    Text="&#xe299;"
-                    Margin="3"
-                    TextColor="White" />
-            </Border>
+                <Border
+                    BackgroundColor="{StaticResource primary}"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    TranslationX="40"
+                    TranslationY="35"
+                    StrokeShape="Ellipse"
+                    StrokeThickness="0"
+                    IsVisible="{Binding IsMe}">
+                    <Label
+                        FontFamily="FluentIcons"
+                        FontAutoScalingEnabled="False"
+                        FontSize="25"
+                        Text="&#xe299;"
+                        Margin="3"
+                        TextColor="White" />
+                </Border>
+            </Grid>
         </Grid>
 
         <VerticalStackLayout VerticalOptions="Center">

--- a/src/MobileUI/Features/Activity/ActivityPage.xaml
+++ b/src/MobileUI/Features/Activity/ActivityPage.xaml
@@ -7,11 +7,45 @@
              xmlns:activityFeed="clr-namespace:SSW.Rewards.Shared.DTOs.ActivityFeed;assembly=Shared"
              xmlns:enums="clr-namespace:SSW.Rewards.Enums;assembly=SSW.Rewards.Enums"
              x:DataType="viewModels:ActivityPageViewModel"
-             ControlTemplate="{DynamicResource PageTemplate}"
              x:Class="SSW.Rewards.Mobile.Pages.ActivityPage"
              x:Name="Activity">
-    <Grid RowDefinitions="45, *" Padding="15,10, 15, 0" RowSpacing="15">
-        <Grid RowDefinitions="45" Grid.Row="0">
+    <Grid RowDefinitions="Auto, 45, *" Padding="15, 0" RowSpacing="15">
+        <Grid Grid.Row="0"
+              ColumnDefinitions="100, *, 100">
+            <Grid Grid.Column="1"
+                  VerticalOptions="Center">
+                <Label Text="Activity"
+                       Style="{StaticResource LabelBold}"
+                       FontSize="18"
+                       VerticalOptions="Center"
+                       VerticalTextAlignment="Center"
+                       HorizontalOptions="Center" />
+            </Grid>
+
+            <Border
+                Grid.Column="2"
+                HorizontalOptions="End"
+                VerticalOptions="Center"
+                HeightRequest="30" 
+                WidthRequest="30"
+                StrokeShape="RoundRectangle 15"
+                StrokeThickness="2"
+                Stroke="White">
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
+                </Border.GestureRecognizers>
+                <Label
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    FontFamily="FA6Solid"
+                    Text="&#xf00d;"
+                    FontSize="18"
+                    FontAutoScalingEnabled="False"
+                    TextColor="White" />
+            </Border>
+        </Grid>
+        <Grid RowDefinitions="45" Grid.Row="1">
             <controls:SegmentedControl
                 Grid.Row="0"
                 Segments="{Binding Segments}"
@@ -26,7 +60,7 @@
         <RefreshView
             Command="{Binding RefreshCommand}"
             IsRefreshing="{Binding IsRefreshing}"
-            Grid.Row="1">
+            Grid.Row="2">
             <CollectionView
                 ItemsSource="{Binding Feed}"
                 ItemsUpdatingScrollMode="KeepItemsInView"
@@ -120,7 +154,7 @@
             </CollectionView>
         </RefreshView>
         <ActivityIndicator
-            Grid.Row="1"
+            Grid.Row="2"
             HorizontalOptions="Center"
             VerticalOptions="Center"
             Color="{StaticResource SSWRed}"

--- a/src/MobileUI/Features/Activity/ActivityPage.xaml
+++ b/src/MobileUI/Features/Activity/ActivityPage.xaml
@@ -9,7 +9,7 @@
              x:DataType="viewModels:ActivityPageViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.ActivityPage"
              x:Name="Activity">
-    <Grid RowDefinitions="Auto, 45, *" Padding="15, 0" RowSpacing="15">
+    <Grid RowDefinitions="Auto, 45, *" Padding="15,10,15,0" RowSpacing="10">
         <Grid Grid.Row="0"
               ColumnDefinitions="100, *, 100">
             <Grid Grid.Column="1"
@@ -21,29 +21,27 @@
                        VerticalTextAlignment="Center"
                        HorizontalOptions="Center" />
             </Grid>
-
-            <Border
+            
+            <Button
                 Grid.Column="2"
+                WidthRequest="40"
+                HeightRequest="40"
+                MinimumHeightRequest="40"
+                MinimumWidthRequest="40"
+                CornerRadius="20"
+                BackgroundColor="Transparent"
+                Padding="0"
+                Command="{Binding ClosePageCommand}"
                 HorizontalOptions="End"
-                VerticalOptions="Center"
-                HeightRequest="30" 
-                WidthRequest="30"
-                StrokeShape="RoundRectangle 15"
-                StrokeThickness="2"
-                Stroke="White">
-                <Border.GestureRecognizers>
-                    <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
-                </Border.GestureRecognizers>
-                <Label
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    HorizontalTextAlignment="Center"
-                    FontFamily="FA6Solid"
-                    Text="&#xf00d;"
-                    FontSize="18"
-                    FontAutoScalingEnabled="False"
-                    TextColor="White" />
-            </Border>
+                VerticalOptions="Center" >
+                <Button.ImageSource>
+                    <FontImageSource FontFamily="FA6Regular"
+                                     Glyph="&#xf057;"
+                                     Size="30"
+                                     Color="White"
+                                     FontAutoScalingEnabled="False" />
+                </Button.ImageSource>
+            </Button>
         </Grid>
         <Grid RowDefinitions="45" Grid.Row="1">
             <controls:SegmentedControl

--- a/src/MobileUI/Features/Activity/ActivityPageViewModel.cs
+++ b/src/MobileUI/Features/Activity/ActivityPageViewModel.cs
@@ -187,4 +187,10 @@ public partial class ActivityPageViewModel(IActivityFeedService activityService,
         else
             await Shell.Current.Navigation.PushModalAsync<OthersProfilePage>(item.UserId);
     }
+    
+    [RelayCommand]
+    private async Task ClosePage()
+    {
+        await App.Current.MainPage.Navigation.PopModalAsync();
+    }
 }

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -24,7 +24,7 @@
                 <Setter Property="Shell.UnselectedColor" Value="#95FFFFFF" />
                 <Setter Property="Shell.TabBarBackgroundColor" Value="{StaticResource TabBarBackground}" />
                 <Setter Property="Shell.TabBarForegroundColor" Value="White"/>
-                <Setter Property="Shell.TabBarUnselectedColor" Value="#95FFFFFF"/>
+                <Setter Property="Shell.TabBarUnselectedColor" Value="{StaticResource Gray300}"/>
                 <Setter Property="Shell.TabBarTitleColor" Value="#BE4b47"/>
             </Style>
             <Style TargetType="ShellItem" BasedOn="{StaticResource BaseStyle}" />
@@ -65,37 +65,67 @@
     </Shell.FlyoutHeader>
 
 
-    <FlyoutItem Style="{StaticResource BaseStyle}" x:Name="MyTabbar">
-        <Shell.ItemTemplate>
-            <DataTemplate>
-                <VerticalStackLayout HeightRequest="1"
-                                     BackgroundColor="{StaticResource FlyoutBackgroundColour}"/>
-            </DataTemplate>
-        </Shell.ItemTemplate>
-        <!-- HACK: The following workaround is for a bug with Shell tab icons on iOS.
-                    It will need to be updated before we deploy to Android.
-                    See: https://github.com/dotnet/maui/issues/8244 -->
-
-        <Tab Route="main" Icon="icon_star" Title="Leaderboard">
-            <ShellContent ContentTemplate="{DataTemplate pages:LeaderboardPage}" />
+    <controls:CustomTabBar CenterViewText="Scan"
+                        CenterViewVisible="True"
+                        CenterViewBackgroundColor="{StaticResource SSWRed}"
+                        CenterViewTapped="Button_Clicked">
+        <controls:CustomTabBar.CenterViewImageSource>
+            
+            <FontImageSource FontFamily="FluentIcons"
+                             Glyph="&#xf636;"></FontImageSource>
+        </controls:CustomTabBar.CenterViewImageSource>
+        <Tab Title="Leaderboard" Icon="icon_star">
+            <ShellContent
+                Title="Leaderboard"
+                ContentTemplate="{DataTemplate pages:LeaderboardPage}"
+                Route="main" />
         </Tab>
-
-        <Tab Route="earn" Icon="icon_gamepad" Title="Earn">
-            <ShellContent ContentTemplate="{DataTemplate pages:QuizPage}" />
+        <Tab Title="Earn" Icon="icon_gamepad">
+            <ShellContent
+                Title="Earn"
+                ContentTemplate="{DataTemplate pages:QuizPage}"
+                Route="earn" />
         </Tab>
-
-        <Tab Route="redeem" Icon="icon_store" Title="Redeem">
-            <ShellContent ContentTemplate="{DataTemplate pages:RedeemPage}" />
+        <Tab Title="Network" Icon="icon_people">
+            <ShellContent
+                Title="Network"
+                ContentTemplate="{DataTemplate pages:NetworkPage}"
+                Route="people" />
         </Tab>
-
-        <Tab Route="people" Icon="icon_people" Title="Network">
-            <ShellContent ContentTemplate="{DataTemplate pages:NetworkPage}" />
+        <Tab Title="Activity" Icon="icon_gamepad">
+            <ShellContent
+                Title="Activity"
+                ContentTemplate="{DataTemplate pages:ActivityPage}"
+                Route="activity" />
         </Tab>
-
-        <Tab Route="activity" Icon="icon_bell" Title="Activity">
-            <ShellContent ContentTemplate="{DataTemplate pages:ActivityPage}" />
-        </Tab>
-    </FlyoutItem>
+    </controls:CustomTabBar>
+    <!-- <FlyoutItem Style="{StaticResource BaseStyle}" x:Name="MyTabbar"> -->
+    <!--     <Shell.ItemTemplate> -->
+    <!--         <DataTemplate> -->
+    <!--             <VerticalStackLayout HeightRequest="1" -->
+    <!--                                  BackgroundColor="{StaticResource FlyoutBackgroundColour}"/> -->
+    <!--         </DataTemplate> -->
+    <!--     </Shell.ItemTemplate> -->
+    <!--     <Tab Route="main" Icon="icon_star" Title="Leaderboard"> -->
+    <!--         <ShellContent ContentTemplate="{DataTemplate pages:LeaderboardPage}" /> -->
+    <!--     </Tab> -->
+    <!-- -->
+    <!--     <Tab Route="earn" Icon="icon_gamepad" Title="Earn"> -->
+    <!--         <ShellContent ContentTemplate="{DataTemplate pages:QuizPage}" /> -->
+    <!--     </Tab> -->
+    <!-- -->
+    <!--     <Tab Route="scan" Icon="icon_qrcode" Title="Scan"> -->
+    <!--         <ShellContent ContentTemplate="{DataTemplate pages:ScanPage}" /> -->
+    <!--     </Tab> -->
+    <!-- -->
+    <!--     <Tab Route="people" Icon="icon_people" Title="Network"> -->
+    <!--         <ShellContent ContentTemplate="{DataTemplate pages:NetworkPage}" /> -->
+    <!--     </Tab> -->
+    <!-- -->
+    <!--     <Tab Route="activity" Icon="icon_bell" Title="Activity"> -->
+    <!--         <ShellContent ContentTemplate="{DataTemplate pages:ActivityPage}" /> -->
+    <!--     </Tab> -->
+    <!-- </FlyoutItem> -->
 
     <Shell.FlyoutFooter>
         <controls:FlyoutFooter />

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -73,7 +73,7 @@
             <FontImageSource FontFamily="FluentIcons"
                              Glyph="&#xf636;"
                              FontAutoScalingEnabled="False"
-                             Size="40"></FontImageSource>
+                             Size="55" />
         </controls:CustomTabBar.CenterViewImageSource>
         <Tab Title="Leaderboard" Icon="icon_star">
             <ShellContent
@@ -87,9 +87,9 @@
                 ContentTemplate="{DataTemplate pages:QuizPage}"
                 Route="earn" />
         </Tab>
-        <Tab Title="Scan">
+        <Tab Title="">
             <ShellContent
-                Title="Scan"
+                Title=""
                 ContentTemplate="{DataTemplate pages:ScanPage}"
                 Route="scan" />
         </Tab>

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -99,11 +99,11 @@
                 ContentTemplate="{DataTemplate pages:NetworkPage}"
                 Route="people" />
         </Tab>
-        <Tab Title="Activity" Icon="icon_gamepad">
+        <Tab Title="Redeem" Icon="icon_store">
             <ShellContent
-                Title="Activity"
-                ContentTemplate="{DataTemplate pages:ActivityPage}"
-                Route="activity" />
+                Title="Redeem"
+                ContentTemplate="{DataTemplate pages:RedeemPage}"
+                Route="redeem" />
         </Tab>
     </controls:CustomTabBar>
 

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -5,7 +5,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:SSW.Rewards.Mobile.Pages"
     xmlns:controls="clr-namespace:SSW.Rewards.Mobile.Controls"
-    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     Title="SSW.Rewards"
     FlyoutBackgroundColor="{StaticResource FlyoutBackgroundColour}"
     Shell.NavBarIsVisible="False"

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -11,6 +11,7 @@
     Shell.NavBarIsVisible="False"
     Navigating="OnNavigating"
     MenuItemTemplate="{StaticResource SSWMenuTemplate}"
+    FlyoutBehavior="Flyout"
     x:Name="RewardsShell">
 
     <Shell.Resources>

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -63,14 +63,12 @@
     <Shell.FlyoutHeader>
         <controls:FlyoutHeader />
     </Shell.FlyoutHeader>
-
-
+    
     <controls:CustomTabBar CenterViewText="Scan"
                         CenterViewVisible="True"
                         CenterViewBackgroundColor="{StaticResource SSWRed}"
                         CenterViewTapped="Button_Clicked">
         <controls:CustomTabBar.CenterViewImageSource>
-            
             <FontImageSource FontFamily="FluentIcons"
                              Glyph="&#xf636;"></FontImageSource>
         </controls:CustomTabBar.CenterViewImageSource>
@@ -86,6 +84,12 @@
                 ContentTemplate="{DataTemplate pages:QuizPage}"
                 Route="earn" />
         </Tab>
+        <Tab Title="Scan">
+            <ShellContent
+                Title="Scan"
+                ContentTemplate="{DataTemplate pages:ScanPage}"
+                Route="scan" />
+        </Tab>
         <Tab Title="Network" Icon="icon_people">
             <ShellContent
                 Title="Network"
@@ -99,33 +103,6 @@
                 Route="activity" />
         </Tab>
     </controls:CustomTabBar>
-    <!-- <FlyoutItem Style="{StaticResource BaseStyle}" x:Name="MyTabbar"> -->
-    <!--     <Shell.ItemTemplate> -->
-    <!--         <DataTemplate> -->
-    <!--             <VerticalStackLayout HeightRequest="1" -->
-    <!--                                  BackgroundColor="{StaticResource FlyoutBackgroundColour}"/> -->
-    <!--         </DataTemplate> -->
-    <!--     </Shell.ItemTemplate> -->
-    <!--     <Tab Route="main" Icon="icon_star" Title="Leaderboard"> -->
-    <!--         <ShellContent ContentTemplate="{DataTemplate pages:LeaderboardPage}" /> -->
-    <!--     </Tab> -->
-    <!-- -->
-    <!--     <Tab Route="earn" Icon="icon_gamepad" Title="Earn"> -->
-    <!--         <ShellContent ContentTemplate="{DataTemplate pages:QuizPage}" /> -->
-    <!--     </Tab> -->
-    <!-- -->
-    <!--     <Tab Route="scan" Icon="icon_qrcode" Title="Scan"> -->
-    <!--         <ShellContent ContentTemplate="{DataTemplate pages:ScanPage}" /> -->
-    <!--     </Tab> -->
-    <!-- -->
-    <!--     <Tab Route="people" Icon="icon_people" Title="Network"> -->
-    <!--         <ShellContent ContentTemplate="{DataTemplate pages:NetworkPage}" /> -->
-    <!--     </Tab> -->
-    <!-- -->
-    <!--     <Tab Route="activity" Icon="icon_bell" Title="Activity"> -->
-    <!--         <ShellContent ContentTemplate="{DataTemplate pages:ActivityPage}" /> -->
-    <!--     </Tab> -->
-    <!-- </FlyoutItem> -->
 
     <Shell.FlyoutFooter>
         <controls:FlyoutFooter />

--- a/src/MobileUI/Features/AppShell.xaml
+++ b/src/MobileUI/Features/AppShell.xaml
@@ -71,7 +71,9 @@
                         CenterViewTapped="Button_Clicked">
         <controls:CustomTabBar.CenterViewImageSource>
             <FontImageSource FontFamily="FluentIcons"
-                             Glyph="&#xf636;"></FontImageSource>
+                             Glyph="&#xf636;"
+                             FontAutoScalingEnabled="False"
+                             Size="40"></FontImageSource>
         </controls:CustomTabBar.CenterViewImageSource>
         <Tab Title="Leaderboard" Icon="icon_star">
             <ShellContent

--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -69,6 +69,7 @@ public partial class AppShell
 
     private void OnNavigating(object sender, ShellNavigatingEventArgs e)
     {
+        // Prevent Scan page from being navigated to outside a modal
         if (e.Target.Location.OriginalString.Contains("scan"))
         {
             e.Cancel();

--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -16,7 +16,7 @@ public partial class AppShell
         InitializeComponent();
         Routing.RegisterRoute("earn/details", typeof(QuizDetailsPage));
         Routing.RegisterRoute("scan", typeof(ScanPage));
-        Routing.RegisterRoute("redeem", typeof(RedeemPage));
+        Routing.RegisterRoute("activity", typeof(ActivityPage));
     }
     
     protected override bool OnBackButtonPressed()

--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -16,6 +16,7 @@ public partial class AppShell
         InitializeComponent();
         Routing.RegisterRoute("earn/details", typeof(QuizDetailsPage));
         Routing.RegisterRoute("scan", typeof(ScanPage));
+        Routing.RegisterRoute("redeem", typeof(RedeemPage));
     }
     
     protected override bool OnBackButtonPressed()

--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -68,6 +68,12 @@ public partial class AppShell
 
     private void OnNavigating(object sender, ShellNavigatingEventArgs e)
     {
+        if (e.Target.Location.OriginalString.Contains("scan"))
+        {
+            e.Cancel();
+            App.Current.MainPage.Navigation.PushModalAsync<ScanPage>();
+        }
+        
         WeakReferenceMessenger.Default.Send(new TopBarAvatarMessage(AvatarOptions.Original));
         WeakReferenceMessenger.Default.Send(new TopBarTitleMessage(string.Empty));
     }

--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -29,6 +29,11 @@ public partial class AppShell
         return true;
     }
     
+    private void Button_Clicked(object sender, EventArgs e)
+    {
+        App.Current.MainPage.Navigation.PushModalAsync<ScanPage>();
+    }
+    
     protected override void OnAppearing()
     {
         base.OnAppearing();

--- a/src/MobileUI/Features/Profile/MyProfilePage.xaml
+++ b/src/MobileUI/Features/Profile/MyProfilePage.xaml
@@ -13,32 +13,8 @@
     </ContentPage.Behaviors>
 
     <ScrollView>
-        <Grid RowDefinitions="Auto, *"
-              Margin="15,0">
-            
-            <!-- Close button -->
-            <Grid Grid.Row="0"
-                  Margin="0,10">
-                <Border
-                    HorizontalOptions="End"
-                    BackgroundColor="{StaticResource Background}"
-                    StrokeShape="Ellipse"
-                    StrokeThickness="0"
-                    IsVisible="{Binding ShowCloseButton}">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
-                    </Border.GestureRecognizers>
-                    <Label
-                        FontFamily="FluentIcons"
-                        Text="&#xe4c3;"
-                        FontSize="35"
-                        FontAutoScalingEnabled="False"
-                        TextColor="{StaticResource primary}" />
-                </Border>
-            </Grid>
-
-            <VerticalStackLayout Grid.Row="1"
-                                 Spacing="15"
+        <Grid Margin="15,15,15,0">
+            <VerticalStackLayout Spacing="15"
                                  IsVisible="{Binding Path=IsLoading, Converter={mct:InvertedBoolConverter}}">
                 <controls:ProfileStats />
 
@@ -46,7 +22,6 @@
             </VerticalStackLayout>
 
             <ActivityIndicator
-                Grid.Row="1"
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
                 Color="{StaticResource SSWRed}"

--- a/src/MobileUI/Features/Profile/OthersProfilePage.xaml
+++ b/src/MobileUI/Features/Profile/OthersProfilePage.xaml
@@ -13,32 +13,8 @@
     </ContentPage.Behaviors>
 
     <ScrollView>
-        <Grid RowDefinitions="Auto, *"
-              Margin="15,0">
-            
-            <!-- Close button -->
-            <Grid Grid.Row="0"
-                  Margin="0,10">
-                <Border
-                    HorizontalOptions="End"
-                    BackgroundColor="{StaticResource Background}"
-                    StrokeShape="Ellipse"
-                    StrokeThickness="0"
-                    IsVisible="{Binding ShowCloseButton}">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
-                    </Border.GestureRecognizers>
-                    <Label
-                        FontFamily="FluentIcons"
-                        Text="&#xe4c3;"
-                        FontSize="35"
-                        FontAutoScalingEnabled="False"
-                        TextColor="{StaticResource primary}" />
-                </Border>
-            </Grid>
-
-            <VerticalStackLayout Grid.Row="1"
-                                 Spacing="15"
+        <Grid Margin="15,15,15,0">
+            <VerticalStackLayout Spacing="15"
                                  IsVisible="{Binding Path=IsLoading, Converter={mct:InvertedBoolConverter}}">
                 <controls:ProfileStats />
 
@@ -62,7 +38,6 @@
             </VerticalStackLayout>
 
             <ActivityIndicator
-                Grid.Row="1"
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
                 Color="{StaticResource SSWRed}"

--- a/src/MobileUI/Features/Quiz/QuizViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizViewModel.cs
@@ -12,8 +12,8 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
     private bool _isLoaded;
     private readonly IQuizService _quizService;
 
-    private string quizDetailsPageUrl = "///earn/details";
-    
+    private const string QuizDetailsPageUrl = "///earn/details";
+
     private IDispatcherTimer _timer;
     
     private const int AutoScrollInterval = 6;
@@ -118,7 +118,7 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
     [RelayCommand]
     private async Task OpenQuiz(int quizId)
     {
-        await AppShell.Current.GoToAsync($"{quizDetailsPageUrl}?QuizId={quizId}");
+        await AppShell.Current.GoToAsync($"{QuizDetailsPageUrl}?QuizId={quizId}");
     }
 
     private bool CanOpenQuiz(int quizId)

--- a/src/MobileUI/Features/Quiz/QuizViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizViewModel.cs
@@ -12,7 +12,7 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
     private bool _isLoaded;
     private readonly IQuizService _quizService;
 
-    private string quizDetailsPageUrl = "earn/details";
+    private string quizDetailsPageUrl = "///earn/details";
     
     private IDispatcherTimer _timer;
     

--- a/src/MobileUI/Features/Redeem/RedeemPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemPage.xaml
@@ -17,8 +17,7 @@
                   RowSpacing="10">
                 <Border Grid.Row="0"
                         StrokeThickness="0"
-                        StrokeShape="RoundRectangle 8"
-                        Padding="3">
+                        StrokeShape="RoundRectangle 8">
                     <Grid ColumnDefinitions="100, *, 100">
                         <Border Grid.Column="0"
                                 StrokeThickness="1"
@@ -34,7 +33,7 @@
                                     FontFamily="FA6Solid"
                                     HorizontalOptions="Center"
                                     VerticalOptions="Center"
-                                    FontSize="11"
+                                    FontSize="14"
                                     Style="{StaticResource LabelBold}"
                                     InputTransparent="True" />
                                 <Label

--- a/src/MobileUI/Features/Redeem/RedeemPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemPage.xaml
@@ -15,79 +15,76 @@
             <Grid RowDefinitions="Auto, *"
                   Margin="15,5,15,0"
                   RowSpacing="10">
-                <Border Grid.Row="0"
-                        StrokeThickness="0"
-                        StrokeShape="RoundRectangle 8">
-                    <Grid ColumnDefinitions="100, *, 100">
-                        <Border Grid.Column="0"
-                                StrokeThickness="1"
-                                StrokeShape="RoundRectangle 6"
+                <Grid Grid.Row="0"
+                      ColumnDefinitions="100, *, 100">
+                    <Border Grid.Column="0"
+                            StrokeThickness="1"
+                            StrokeShape="RoundRectangle 6"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Fill">
+                        <HorizontalStackLayout Spacing="5"
+                                               Padding="8"
+                                               Background="{StaticResource ButtonBrush}">
+                            <Label
+                                TextColor="{StaticResource Coin}"
+                                Text="&#xf51e;"
+                                FontFamily="FA6Solid"
+                                HorizontalOptions="Center"
+                                VerticalOptions="Center"
+                                FontSize="14"
+                                Style="{StaticResource LabelBold}"
+                                InputTransparent="True" />
+                            <Label
+                                Text="{Binding Credits, StringFormat='{0:n0}'}"
                                 HorizontalOptions="Start"
-                                VerticalOptions="Fill">
-                            <HorizontalStackLayout Spacing="5"
-                                                   Padding="8"
-                                                   Background="{StaticResource ButtonBrush}">
-                                <Label
-                                    TextColor="{StaticResource Coin}"
-                                    Text="&#xf51e;"
-                                    FontFamily="FA6Solid"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center"
-                                    FontSize="14"
-                                    Style="{StaticResource LabelBold}"
-                                    InputTransparent="True" />
-                                <Label
-                                    Text="{Binding Credits, StringFormat='{0:n0}'}"
-                                    HorizontalOptions="Start"
-                                    VerticalOptions="Center"
-                                    FontSize="14"
-                                    Style="{StaticResource LabelBold}"
-                                    InputTransparent="True" />
-                            </HorizontalStackLayout>
-                        </Border>
-                        
-                        <Grid Grid.Column="1"
-                              VerticalOptions="Center">
-                            <Label Text="Redeem"
-                                   Style="{StaticResource LabelBold}"
-                                   FontSize="18"
-                                   VerticalOptions="Center"
-                                   VerticalTextAlignment="Center"
-                                   HorizontalOptions="Center" />
-                        </Grid>
-                        
-                        <Border Grid.Column="2"
-                                StrokeThickness="0"
-                                StrokeShape="RoundRectangle 6"
-                                HorizontalOptions="End"
-                                VerticalOptions="Fill">
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
-                            </Border.GestureRecognizers>
-                            <HorizontalStackLayout Spacing="5"
-                                                   Padding="8"
-                                                   Background="{StaticResource BrandBrush}">
-                                <Label
-                                    TextColor="White"
-                                    Text="&#xf057;"
-                                    FontFamily="FA6Regular"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center"
-                                    FontSize="14"
-                                    Style="{StaticResource LabelBold}"
-                                    InputTransparent="True" />
-                                <Label
-                                    Text="Close"
-                                    Style="{StaticResource LabelBold}"
-                                    HorizontalOptions="Start"
-                                    VerticalOptions="Center"
-                                    FontSize="14"
-                                    InputTransparent="True" />
-                            </HorizontalStackLayout>
-                        </Border>
-                    </Grid>
-                </Border>
+                                VerticalOptions="Center"
+                                FontSize="14"
+                                Style="{StaticResource LabelBold}"
+                                InputTransparent="True" />
+                        </HorizontalStackLayout>
+                    </Border>
 
+                    <Grid Grid.Column="1"
+                          VerticalOptions="Center">
+                        <Label Text="Redeem"
+                               Style="{StaticResource LabelBold}"
+                               FontSize="18"
+                               VerticalOptions="Center"
+                               VerticalTextAlignment="Center"
+                               HorizontalOptions="Center" />
+                    </Grid>
+
+                    <Border Grid.Column="2"
+                            StrokeThickness="0"
+                            StrokeShape="RoundRectangle 6"
+                            HorizontalOptions="End"
+                            VerticalOptions="Fill">
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
+                        </Border.GestureRecognizers>
+                        <HorizontalStackLayout Spacing="5"
+                                               Padding="8"
+                                               Background="{StaticResource BrandBrush}">
+                            <Label
+                                TextColor="White"
+                                Text="&#xf057;"
+                                FontFamily="FA6Regular"
+                                HorizontalOptions="Center"
+                                VerticalOptions="Center"
+                                FontSize="14"
+                                Style="{StaticResource LabelBold}"
+                                InputTransparent="True" />
+                            <Label
+                                Text="Close"
+                                Style="{StaticResource LabelBold}"
+                                HorizontalOptions="Start"
+                                VerticalOptions="Center"
+                                FontSize="14"
+                                InputTransparent="True" />
+                        </HorizontalStackLayout>
+                    </Border>
+                </Grid>
+                
                 <RefreshView Grid.Row="1"
                              Command="{Binding RefreshRewardsCommand}"
                              IsRefreshing="{Binding IsRefreshing}">
@@ -127,7 +124,7 @@
                                                 ButtonText="GET"
                                                 ItemId="{Binding Id}"
                                                 IsButtonDisabled="{Binding CanAfford, Converter={mct:InvertedBoolConverter}}"
-                                                ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}"/>
+                                                ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}" />
                                         </DataTemplate>
                                     </CarouselView.ItemTemplate>
                                 </CarouselView>
@@ -141,7 +138,7 @@
                                                Margin="0,0,0,15"
                                                x:Name="QuizIndicator" />
                             </Grid>
-                            
+
                             <CollectionView
                                 ItemsSource="{Binding Rewards}"
                                 ItemsUpdatingScrollMode="KeepItemsInView"

--- a/src/MobileUI/Features/Redeem/RedeemPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemPage.xaml
@@ -8,83 +8,65 @@
              xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              BackgroundColor="{StaticResource FlyoutBackgroundColour}"
              x:Name="RewardList"
+             ControlTemplate="{DynamicResource PageTemplate}"
              x:DataType="viewModels:RedeemViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.RedeemPage">
     <ContentPage.Content>
         <Grid>
             <Grid RowDefinitions="Auto, *"
-                  Margin="15,5,15,0"
+                  Margin="15"
                   RowSpacing="10">
-                <Grid Grid.Row="0"
-                      ColumnDefinitions="100, *, 100">
-                    <Border Grid.Column="0"
-                            StrokeThickness="1"
-                            StrokeShape="RoundRectangle 6"
-                            HorizontalOptions="Start"
-                            VerticalOptions="Fill">
-                        <HorizontalStackLayout Spacing="5"
-                                               Padding="8"
-                                               Background="{StaticResource ButtonBrush}">
-                            <Label
-                                TextColor="{StaticResource Coin}"
-                                Text="&#xf51e;"
-                                FontFamily="FA6Solid"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                FontSize="14"
-                                Style="{StaticResource LabelBold}"
-                                InputTransparent="True" />
-                            <Label
-                                Text="{Binding Credits, StringFormat='{0:n0}'}"
-                                HorizontalOptions="Start"
-                                VerticalOptions="Center"
-                                FontSize="14"
-                                Style="{StaticResource LabelBold}"
-                                InputTransparent="True" />
-                        </HorizontalStackLayout>
-                    </Border>
-
-                    <Grid Grid.Column="1"
-                          VerticalOptions="Center">
-                        <Label Text="Redeem"
-                               Style="{StaticResource LabelBold}"
-                               FontSize="18"
-                               VerticalOptions="Center"
-                               VerticalTextAlignment="Center"
-                               HorizontalOptions="Center" />
+                <Border Grid.Row="0"
+                        BackgroundColor="{StaticResource Background}"
+                        StrokeThickness="0"
+                        StrokeShape="RoundRectangle 8"
+                        Padding="3">
+                    <Grid ColumnDefinitions="Auto, *, Auto">
+                        <Border Grid.Column="0"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 6"
+                                HorizontalOptions="End"
+                                VerticalOptions="Fill">
+                            <Grid Padding="10" Background="{StaticResource ButtonBrush}">
+                                <Label
+                                    Text="&#xf290;"
+                                    FontFamily="FA6Solid"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    FontSize="14"
+                                    Style="{StaticResource LabelBold}"
+                                    InputTransparent="True" />
+                            </Grid>
+                        </Border>
+                        <Border Grid.Column="2"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 6"
+                                HorizontalOptions="End"
+                                VerticalOptions="Fill">
+                            <HorizontalStackLayout Spacing="5"
+                                                   Padding="8"
+                                                   Background="{StaticResource ButtonBrush}">
+                                <Label
+                                    TextColor="{StaticResource Coin}"
+                                    Text="&#xf51e;"
+                                    FontFamily="FA6Solid"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    FontSize="11"
+                                    Style="{StaticResource LabelBold}"
+                                    InputTransparent="True" />
+                                <Label
+                                    Text="{Binding Credits, StringFormat='{0:n0}'}"
+                                    Style="{StaticResource LabelBold}"
+                                    HorizontalOptions="Start"
+                                    VerticalOptions="Center"
+                                    FontSize="14"
+                                    InputTransparent="True" />
+                            </HorizontalStackLayout>
+                        </Border>
                     </Grid>
+                </Border>
 
-                    <Border Grid.Column="2"
-                            StrokeThickness="0"
-                            StrokeShape="RoundRectangle 6"
-                            HorizontalOptions="End"
-                            VerticalOptions="Fill">
-                        <Border.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
-                        </Border.GestureRecognizers>
-                        <HorizontalStackLayout Spacing="5"
-                                               Padding="8"
-                                               Background="{StaticResource BrandBrush}">
-                            <Label
-                                TextColor="White"
-                                Text="&#xf057;"
-                                FontFamily="FA6Regular"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                FontSize="14"
-                                Style="{StaticResource LabelBold}"
-                                InputTransparent="True" />
-                            <Label
-                                Text="Close"
-                                Style="{StaticResource LabelBold}"
-                                HorizontalOptions="Start"
-                                VerticalOptions="Center"
-                                FontSize="14"
-                                InputTransparent="True" />
-                        </HorizontalStackLayout>
-                    </Border>
-                </Grid>
-                
                 <RefreshView Grid.Row="1"
                              Command="{Binding RefreshRewardsCommand}"
                              IsRefreshing="{Binding IsRefreshing}">
@@ -124,7 +106,7 @@
                                                 ButtonText="GET"
                                                 ItemId="{Binding Id}"
                                                 IsButtonDisabled="{Binding CanAfford, Converter={mct:InvertedBoolConverter}}"
-                                                ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}" />
+                                                ButtonCommand="{Binding Source={x:Reference RewardList}, Path=BindingContext.RedeemRewardCommand}"/>
                                         </DataTemplate>
                                     </CarouselView.ItemTemplate>
                                 </CarouselView>
@@ -138,7 +120,7 @@
                                                Margin="0,0,0,15"
                                                x:Name="QuizIndicator" />
                             </Grid>
-
+                            
                             <CollectionView
                                 ItemsSource="{Binding Rewards}"
                                 ItemsUpdatingScrollMode="KeepItemsInView"

--- a/src/MobileUI/Features/Redeem/RedeemPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemPage.xaml
@@ -8,12 +8,30 @@
              xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              BackgroundColor="{StaticResource FlyoutBackgroundColour}"
              x:Name="RewardList"
-             ControlTemplate="{DynamicResource PageTemplate}"
              x:DataType="viewModels:RedeemViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.RedeemPage">
     <ContentPage.Content>
-        <Grid>
-            <Grid RowDefinitions="Auto, *"
+        <Grid RowDefinitions="Auto, *">
+            <Grid Grid.Row="0"
+                  Margin="15,0">
+                <Border
+                    HorizontalOptions="End"
+                    BackgroundColor="{StaticResource Background}"
+                    StrokeShape="Ellipse"
+                    StrokeThickness="0">
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
+                    </Border.GestureRecognizers>
+                    <Label
+                        FontFamily="FluentIcons"
+                        Text="&#xe4c3;"
+                        FontSize="35"
+                        FontAutoScalingEnabled="False"
+                        TextColor="{StaticResource primary}" />
+                </Border>
+            </Grid>
+            <Grid Grid.Row="1"
+                  RowDefinitions="Auto, *"
                   Margin="15"
                   RowSpacing="10">
                 <Border Grid.Row="0"

--- a/src/MobileUI/Features/Redeem/RedeemPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemPage.xaml
@@ -11,55 +11,19 @@
              x:DataType="viewModels:RedeemViewModel"
              x:Class="SSW.Rewards.Mobile.Pages.RedeemPage">
     <ContentPage.Content>
-        <Grid RowDefinitions="Auto, *">
-            <Grid Grid.Row="0"
-                  Margin="15,0">
-                <Border
-                    HorizontalOptions="End"
-                    BackgroundColor="{StaticResource Background}"
-                    StrokeShape="Ellipse"
-                    StrokeThickness="0">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
-                    </Border.GestureRecognizers>
-                    <Label
-                        FontFamily="FluentIcons"
-                        Text="&#xe4c3;"
-                        FontSize="35"
-                        FontAutoScalingEnabled="False"
-                        TextColor="{StaticResource primary}" />
-                </Border>
-            </Grid>
-            <Grid Grid.Row="1"
-                  RowDefinitions="Auto, *"
-                  Margin="15"
+        <Grid>
+            <Grid RowDefinitions="Auto, *"
+                  Margin="15,5,15,0"
                   RowSpacing="10">
                 <Border Grid.Row="0"
-                        BackgroundColor="{StaticResource Background}"
                         StrokeThickness="0"
                         StrokeShape="RoundRectangle 8"
                         Padding="3">
-                    <Grid ColumnDefinitions="Auto, *, Auto">
+                    <Grid ColumnDefinitions="100, *, 100">
                         <Border Grid.Column="0"
-                                StrokeThickness="0"
+                                StrokeThickness="1"
                                 StrokeShape="RoundRectangle 6"
-                                HorizontalOptions="End"
-                                VerticalOptions="Fill">
-                            <Grid Padding="10" Background="{StaticResource ButtonBrush}">
-                                <Label
-                                    Text="&#xf290;"
-                                    FontFamily="FA6Solid"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center"
-                                    FontSize="14"
-                                    Style="{StaticResource LabelBold}"
-                                    InputTransparent="True" />
-                            </Grid>
-                        </Border>
-                        <Border Grid.Column="2"
-                                StrokeThickness="0"
-                                StrokeShape="RoundRectangle 6"
-                                HorizontalOptions="End"
+                                HorizontalOptions="Start"
                                 VerticalOptions="Fill">
                             <HorizontalStackLayout Spacing="5"
                                                    Padding="8"
@@ -75,6 +39,46 @@
                                     InputTransparent="True" />
                                 <Label
                                     Text="{Binding Credits, StringFormat='{0:n0}'}"
+                                    HorizontalOptions="Start"
+                                    VerticalOptions="Center"
+                                    FontSize="14"
+                                    Style="{StaticResource LabelBold}"
+                                    InputTransparent="True" />
+                            </HorizontalStackLayout>
+                        </Border>
+                        
+                        <Grid Grid.Column="1"
+                              VerticalOptions="Center">
+                            <Label Text="Redeem"
+                                   Style="{StaticResource LabelBold}"
+                                   FontSize="18"
+                                   VerticalOptions="Center"
+                                   VerticalTextAlignment="Center"
+                                   HorizontalOptions="Center" />
+                        </Grid>
+                        
+                        <Border Grid.Column="2"
+                                StrokeThickness="0"
+                                StrokeShape="RoundRectangle 6"
+                                HorizontalOptions="End"
+                                VerticalOptions="Fill">
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
+                            </Border.GestureRecognizers>
+                            <HorizontalStackLayout Spacing="5"
+                                                   Padding="8"
+                                                   Background="{StaticResource BrandBrush}">
+                                <Label
+                                    TextColor="White"
+                                    Text="&#xf057;"
+                                    FontFamily="FA6Regular"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    FontSize="14"
+                                    Style="{StaticResource LabelBold}"
+                                    InputTransparent="True" />
+                                <Label
+                                    Text="Close"
                                     Style="{StaticResource LabelBold}"
                                     HorizontalOptions="Start"
                                     VerticalOptions="Center"

--- a/src/MobileUI/Features/Redeem/RedeemViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemViewModel.cs
@@ -167,10 +167,4 @@ public partial class RedeemViewModel : BaseViewModel
             await MopupService.Instance.PushAsync(popup);
         }
     }
-    
-    [RelayCommand]
-    private async Task ClosePage()
-    {
-        await App.Current.MainPage.Navigation.PopModalAsync();
-    }
 }

--- a/src/MobileUI/Features/Redeem/RedeemViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemViewModel.cs
@@ -62,12 +62,11 @@ public partial class RedeemViewModel : BaseViewModel
 
     public async Task Initialise()
     {
-        if (_isLoaded)
+        if (!_isLoaded)
         {
-            return;
+            await LoadData();
         }
 
-        await LoadData();
         BeginAutoScroll();
     }
 
@@ -167,5 +166,11 @@ public partial class RedeemViewModel : BaseViewModel
             };
             await MopupService.Instance.PushAsync(popup);
         }
+    }
+    
+    [RelayCommand]
+    private async Task ClosePage()
+    {
+        await App.Current.MainPage.Navigation.PopModalAsync();
     }
 }

--- a/src/MobileUI/Features/Scanner/ScanViewModel.cs
+++ b/src/MobileUI/Features/Scanner/ScanViewModel.cs
@@ -89,11 +89,13 @@ public partial class ScanViewModel : BaseViewModel, IRecipient<EnableScannerMess
         });
     }
 
-    public void OnAppearing()
+    public async Task OnAppearing()
     {
         WeakReferenceMessenger.Default.Register(this);
+        
+        var hasPermissions = await Methods.AskForRequiredPermissionAsync();
 
-        if (IsScanVisible)
+        if (hasPermissions && IsScanVisible)
         {
             IsCameraEnabled = true;
         }

--- a/src/MobileUI/Features/TopBar/TopBarViewModel.cs
+++ b/src/MobileUI/Features/TopBar/TopBarViewModel.cs
@@ -23,7 +23,7 @@ public partial class TopBarViewModel : ObservableObject
     private bool _showBack;
 
     [ObservableProperty]
-    private bool _showScanner = true;
+    private bool _showRedeem = true;
     
     [ObservableProperty]
     private string _title = string.Empty;
@@ -63,13 +63,9 @@ public partial class TopBarViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task OpenScanner()
+    private async Task OpenRedeemPage()
     {
-        var granted = await _permissionsService.CheckAndRequestPermission<Permissions.Camera>();
-        if (granted)
-        {
-            await App.Current.MainPage.Navigation.PushModalAsync<ScanPage>();
-        }
+        await App.Current.MainPage.Navigation.PushModalAsync<RedeemPage>();
     }
 
     [RelayCommand]
@@ -83,13 +79,13 @@ public partial class TopBarViewModel : ObservableObject
     {
         ShowBack = false;
         ShowAvatar = true;
-        ShowScanner = true;
+        ShowRedeem = true;
     }
 
     private void SetBackButton()
     {
         ShowBack = true;
         ShowAvatar = false;
-        ShowScanner = false;
+        ShowRedeem = false;
     }
 }

--- a/src/MobileUI/Features/TopBar/TopBarViewModel.cs
+++ b/src/MobileUI/Features/TopBar/TopBarViewModel.cs
@@ -23,7 +23,7 @@ public partial class TopBarViewModel : ObservableObject
     private bool _showBack;
 
     [ObservableProperty]
-    private bool _showRedeem = true;
+    private bool _showActivity = true;
     
     [ObservableProperty]
     private string _title = string.Empty;
@@ -63,9 +63,9 @@ public partial class TopBarViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task OpenRedeemPage()
+    private async Task OpenActivityPage()
     {
-        await App.Current.MainPage.Navigation.PushModalAsync<RedeemPage>();
+        await App.Current.MainPage.Navigation.PushModalAsync<ActivityPage>();
     }
 
     [RelayCommand]
@@ -79,13 +79,13 @@ public partial class TopBarViewModel : ObservableObject
     {
         ShowBack = false;
         ShowAvatar = true;
-        ShowRedeem = true;
+        ShowActivity = true;
     }
 
     private void SetBackButton()
     {
         ShowBack = true;
         ShowAvatar = false;
-        ShowRedeem = false;
+        ShowActivity = false;
     }
 }

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -52,6 +52,10 @@ public static class MauiProgram
         {
             handlers.AddHandler(typeof(TableView), typeof(CustomTableViewRenderer));
             handlers.AddHandler<Border, NotAnimatedBorderHandler>();
+            
+#if ANDROID
+            handlers.AddHandler<Shell, CustomShellHandler>();
+#endif
         });
 
         builder.Services.AddDependencies();

--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -52,10 +52,7 @@ public static class MauiProgram
         {
             handlers.AddHandler(typeof(TableView), typeof(CustomTableViewRenderer));
             handlers.AddHandler<Border, NotAnimatedBorderHandler>();
-            
-#if ANDROID
-            handlers.AddHandler<Shell, CustomShellHandler>();
-#endif
+            handlers.AddHandler(typeof(Shell), typeof(CustomShellHandler));
         });
 
         builder.Services.AddDependencies();

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellHandler.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellHandler.cs
@@ -1,0 +1,17 @@
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+
+namespace SSW.Rewards.Mobile.Renderers;
+
+internal class CustomShellHandler : ShellRenderer
+{
+    protected override IShellItemRenderer CreateShellItemRenderer(ShellItem shellItem)
+    {
+        return new CustomShellItemRenderer(this);
+    }
+
+    protected override IShellSectionRenderer CreateShellSectionRenderer(ShellSection shellSection)
+    {
+        return new CustomShellSectionRenderer(this);
+    }
+}

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
@@ -1,4 +1,5 @@
 using SSW.Rewards.Mobile.Controls;
+using Color = Android.Graphics.Color;
 
 namespace SSW.Rewards.Mobile.Renderers;
 
@@ -24,13 +25,13 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
 			};
 
 			rootLayout.AddView(view);
-			const int middleViewSize = 200;
+			const int middleViewSize = 280;
 			var middleViewLayoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent,
 																	  ViewGroup.LayoutParams.WrapContent,
 																	  GravityFlags.CenterHorizontal |
 																	  GravityFlags.Bottom)
 			{
-				BottomMargin = 80,
+				BottomMargin = 30,
 				Width = middleViewSize,
 				Height = middleViewSize
 			};
@@ -51,6 +52,7 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
 				};
 				var backgroundDrawable = new GradientDrawable();
 				backgroundDrawable.SetShape(ShapeType.Rectangle);
+                backgroundDrawable.SetStroke(14, Color.White);
 				backgroundDrawable.SetCornerRadius(middleViewSize / 2f);
 				backgroundDrawable.SetColor(tabBar.CenterViewBackgroundColor.ToPlatform(Colors.Transparent));
 				backgroundView.SetBackground(backgroundDrawable);
@@ -64,13 +66,12 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
 				{
 					return;
 				}
-
-				const int padding = 20;
+                
 				middleView.LayoutParameters = new FrameLayout.LayoutParams(
-					150, 150,
+					180, 180,
 					GravityFlags.CenterHorizontal | GravityFlags.Bottom)
 				{
-					BottomMargin = middleViewLayoutParams.BottomMargin + 25
+					BottomMargin = middleViewLayoutParams.BottomMargin + 50
 				};
 				middleView.SetBackground(drawable);
 				middleView.SetMinimumHeight(0);

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
@@ -24,13 +24,13 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
 			};
 
 			rootLayout.AddView(view);
-			const int middleViewSize = 150;
+			const int middleViewSize = 200;
 			var middleViewLayoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent,
 																	  ViewGroup.LayoutParams.WrapContent,
 																	  GravityFlags.CenterHorizontal |
 																	  GravityFlags.Bottom)
 			{
-				BottomMargin = 100,
+				BottomMargin = 80,
 				Width = middleViewSize,
 				Height = middleViewSize
 			};
@@ -67,10 +67,10 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
 
 				const int padding = 20;
 				middleView.LayoutParameters = new FrameLayout.LayoutParams(
-					drawable.Bitmap.Width - padding, drawable.Bitmap.Height - padding,
+					150, 150,
 					GravityFlags.CenterHorizontal | GravityFlags.Bottom)
 				{
-					BottomMargin = middleViewLayoutParams.BottomMargin + (int)(1.5 * padding)
+					BottomMargin = middleViewLayoutParams.BottomMargin + 25
 				};
 				middleView.SetBackground(drawable);
 				middleView.SetMinimumHeight(0);

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
@@ -1,0 +1,86 @@
+using SSW.Rewards.Mobile.Controls;
+
+namespace SSW.Rewards.Mobile.Renderers;
+
+using Android.Graphics.Drawables;
+using Android.OS;
+using Android.Views;
+using Android.Widget;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Platform;
+
+internal class CustomShellItemRenderer(IShellContext context) : ShellItemRenderer(context)
+{
+	public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
+	{
+		var view = base.OnCreateView(inflater, container, savedInstanceState);
+		if (Context is not null && ShellItem is CustomTabBar { CenterViewVisible: true } tabBar)
+		{
+			var rootLayout = new FrameLayout(Context)
+			{
+				LayoutParameters =
+					new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent)
+			};
+
+			rootLayout.AddView(view);
+			const int middleViewSize = 150;
+			var middleViewLayoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent,
+																	  ViewGroup.LayoutParams.WrapContent,
+																	  GravityFlags.CenterHorizontal |
+																	  GravityFlags.Bottom)
+			{
+				BottomMargin = 100,
+				Width = middleViewSize,
+				Height = middleViewSize
+			};
+			var middleView = new Button(Context)
+			{
+				LayoutParameters = middleViewLayoutParams
+			};
+			middleView.Click += delegate
+            {
+                tabBar.CenterView_Tapped();
+            };
+			middleView.SetPadding(0, 0, 0, 0);
+			if (tabBar.CenterViewBackgroundColor is not null)
+			{
+				var backgroundView = new View(Context)
+				{
+					LayoutParameters = middleViewLayoutParams
+				};
+				var backgroundDrawable = new GradientDrawable();
+				backgroundDrawable.SetShape(ShapeType.Rectangle);
+				backgroundDrawable.SetCornerRadius(middleViewSize / 2f);
+				backgroundDrawable.SetColor(tabBar.CenterViewBackgroundColor.ToPlatform(Colors.Transparent));
+				backgroundView.SetBackground(backgroundDrawable);
+				rootLayout.AddView(backgroundView);
+			}
+
+			var context = tabBar.Window?.Page?.Handler?.MauiContext ?? Application.Current?.Windows.LastOrDefault()?.Page?.Handler?.MauiContext;
+			tabBar.CenterViewImageSource?.LoadImage(context!, result =>
+			{
+				if (result?.Value is not BitmapDrawable drawable || drawable.Bitmap is null)
+				{
+					return;
+				}
+
+				const int padding = 20;
+				middleView.LayoutParameters = new FrameLayout.LayoutParams(
+					drawable.Bitmap.Width - padding, drawable.Bitmap.Height - padding,
+					GravityFlags.CenterHorizontal | GravityFlags.Bottom)
+				{
+					BottomMargin = middleViewLayoutParams.BottomMargin + (int)(1.5 * padding)
+				};
+				middleView.SetBackground(drawable);
+				middleView.SetMinimumHeight(0);
+				middleView.SetMinimumWidth(0);
+			});
+
+			rootLayout.AddView(middleView);
+			return rootLayout;
+		}
+
+		return view;
+	}
+}

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellSectionRenderer.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellSectionRenderer.cs
@@ -1,0 +1,33 @@
+namespace SSW.Rewards.Mobile.Renderers;
+
+using Android.OS;
+using Android.Views;
+using Android.Widget;
+using AndroidX.CoordinatorLayout.Widget;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+
+internal class CustomShellSectionRenderer(IShellContext shellContext) : ShellSectionRenderer(shellContext)
+{
+    public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
+    {
+        var relativeLayout = new RelativeLayout(Context);
+        relativeLayout.LayoutParameters = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent,
+            ViewGroup.LayoutParams.MatchParent);
+
+        var view = base.OnCreateView(inflater, container, savedInstanceState);
+        if (view is not CoordinatorLayout coordinatorLayout)
+        {
+            return view;
+        }
+
+        for (var i = 0; i < coordinatorLayout.ChildCount; i++)
+        {
+            var child = coordinatorLayout.GetChildAt(i);
+            coordinatorLayout.RemoveView(child);
+            relativeLayout.AddView(child);
+        }
+
+        coordinatorLayout.AddView(relativeLayout);
+        return coordinatorLayout;
+    }
+}

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform.Compatibility;
+using UIKit;
 
 namespace SSW.Rewards.Mobile.Renderers;
 
@@ -12,4 +13,18 @@ internal class CustomShellHandler : ShellRenderer
             ShellItem = item
         };
     }
+    
+    private sealed class MyShellTabBarAppearanceTracker : ShellTabBarAppearanceTracker
+    {
+        public override void SetAppearance(UITabBarController controller, ShellAppearance appearance)
+        {
+            base.SetAppearance(controller, appearance);
+            if (UIDevice.CurrentDevice.CheckSystemVersion(17, 0))
+            {
+                controller.TraitOverrides.HorizontalSizeClass = UIUserInterfaceSizeClass.Compact;
+
+            }
+        }
+    }
+    protected override IShellTabBarAppearanceTracker CreateTabBarAppearanceTracker() => new MyShellTabBarAppearanceTracker();
 }

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
@@ -1,0 +1,15 @@
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+
+namespace SSW.Rewards.Mobile.Renderers;
+
+internal class CustomShellHandler : ShellRenderer
+{
+    protected override IShellItemRenderer CreateShellItemRenderer(ShellItem item)
+    {
+        return new CustomShellItemRenderer(this)
+        {
+            ShellItem = item
+        };
+    }
+}

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
@@ -8,23 +8,13 @@ internal class CustomShellHandler : ShellRenderer
 {
     protected override IShellItemRenderer CreateShellItemRenderer(ShellItem item)
     {
-        return new CustomShellItemRenderer(this)
-        {
-            ShellItem = item
-        };
-    }
-    
-    private sealed class MyShellTabBarAppearanceTracker : ShellTabBarAppearanceTracker
-    {
-        public override void SetAppearance(UITabBarController controller, ShellAppearance appearance)
-        {
-            base.SetAppearance(controller, appearance);
-            if (UIDevice.CurrentDevice.CheckSystemVersion(17, 0))
-            {
-                controller.TraitOverrides.HorizontalSizeClass = UIUserInterfaceSizeClass.Compact;
+        var renderer = new CustomShellItemRenderer(this) { ShellItem = item };
 
-            }
-        }
+        // Override to not use new tab bar in iPadOS 18
+        if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad &&
+            UIDevice.CurrentDevice.CheckSystemVersion(18, 0) && renderer is ShellItemRenderer shellItemRenderer)
+            shellItemRenderer.TraitOverrides.HorizontalSizeClass = UIUserInterfaceSizeClass.Compact;
+
+        return renderer;
     }
-    protected override IShellTabBarAppearanceTracker CreateTabBarAppearanceTracker() => new MyShellTabBarAppearanceTracker();
 }

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
@@ -1,0 +1,56 @@
+using CoreGraphics;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using SSW.Rewards.Mobile.Controls;
+using UIKit;
+
+namespace SSW.Rewards.Mobile.Renderers;
+
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Platform;
+
+internal class CustomShellItemRenderer(IShellContext context) : ShellItemRenderer(context)
+{
+    private UIButton? middleView;
+
+    public override async void ViewWillLayoutSubviews()
+    {
+        base.ViewWillLayoutSubviews();
+        if (View is not null && ShellItem is CustomTabBar { CenterViewVisible: true } tabbar)
+        {
+            if (middleView is not null)
+            {
+                middleView.RemoveFromSuperview();
+            }
+
+            if (middleView is null)
+            {
+                var context = tabbar.Window?.Page?.Handler?.MauiContext ?? Application.Current?.Windows.LastOrDefault()?.Page?.Handler?.MauiContext;
+                var image = await tabbar.CenterViewImageSource.GetPlatformImageAsync(context!);
+
+                middleView = new UIButton(UIButtonType.Custom);
+                middleView.BackgroundColor = tabbar.CenterViewBackgroundColor?.ToPlatform();
+                middleView.Frame = new CGRect(CGPoint.Empty, new CGSize(70, 70));
+                if (image is not null)
+                {
+                    middleView.SetImage(image.Value, UIControlState.Normal);
+                    middleView.Frame = new CGRect(CGPoint.Empty, image.Value.Size + new CGSize(20, 20));
+                }
+
+                middleView.AutoresizingMask = UIViewAutoresizing.FlexibleRightMargin |
+                                              UIViewAutoresizing.FlexibleLeftMargin |
+                                              UIViewAutoresizing.FlexibleBottomMargin;
+                middleView.Layer.CornerRadius = middleView.Frame.Width / 2;
+                middleView.Layer.MasksToBounds = false;
+
+                middleView.TouchUpInside += delegate
+                {
+                    tabbar.CenterView_Tapped();
+                };;
+            }
+
+            middleView.Center = new CGPoint(View.Bounds.GetMidX(), TabBar.Frame.Top);
+
+            View.AddSubview(middleView);
+        }
+    }
+}

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
@@ -33,14 +33,14 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
                 if (image is not null)
                 {
                     middleView.SetImage(image.Value, UIControlState.Normal);
-                    middleView.Frame = new CGRect(CGPoint.Empty, image.Value.Size + new CGSize(20, 20));
+                    middleView.Frame = new CGRect(CGPoint.Empty, image.Value.Size + new CGSize(30, 30));
                 }
 
                 middleView.AutoresizingMask = UIViewAutoresizing.FlexibleRightMargin |
                                               UIViewAutoresizing.FlexibleLeftMargin |
                                               UIViewAutoresizing.FlexibleBottomMargin;
                 middleView.Layer.CornerRadius = middleView.Frame.Width / 2;
-                middleView.Layer.BorderWidth = 2;
+                middleView.Layer.BorderWidth = 4;
                 middleView.Layer.BorderColor = UIColor.White.CGColor;
                 middleView.Layer.MasksToBounds = false;
 
@@ -50,7 +50,7 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
                 };;
             }
 
-            middleView.Center = new CGPoint(View.Bounds.GetMidX(), TabBar.Frame.Top);
+            middleView.Center = new CGPoint(View.Bounds.GetMidX(), TabBar.Frame.Top + 4);
 
             View.AddSubview(middleView);
         }

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
@@ -40,6 +40,8 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
                                               UIViewAutoresizing.FlexibleLeftMargin |
                                               UIViewAutoresizing.FlexibleBottomMargin;
                 middleView.Layer.CornerRadius = middleView.Frame.Width / 2;
+                middleView.Layer.BorderWidth = 2;
+                middleView.Layer.BorderColor = UIColor.White.CGColor;
                 middleView.Layer.MasksToBounds = false;
 
                 middleView.TouchUpInside += delegate

--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -70,16 +70,28 @@
                            VerticalTextAlignment="Center"
                            HorizontalOptions="Center" />
                 </Grid>
-
-                <ImageButton Grid.Column="2"
-                             Command="{Binding OpenScannerCommand}"
-                             IsVisible="{Binding ShowScanner}"
-                             VerticalOptions="Center">
-                    <ImageButton.Source>
-                        <FontImageSource FontFamily="FluentIcons"
-                                         Glyph="&#xf636;"/>
-                    </ImageButton.Source>
-                </ImageButton>
+                
+                <Button
+                    Grid.Column="2"
+                    HeightRequest="40"
+                    WidthRequest="40"
+                    MinimumHeightRequest="40"
+                    MinimumWidthRequest="40"
+                    CornerRadius="20"
+                    BorderWidth="2"
+                    BorderColor="White"
+                    BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                    Padding="0"
+                    Command="{Binding OpenRedeemPageCommand}"
+                    IsVisible="{Binding ShowRedeem}"
+                    VerticalOptions="Center">
+                    <ImageButton.Behaviors>
+                        <mct:IconTintColorBehavior TintColor="White" />
+                    </ImageButton.Behaviors>
+                    <Button.ImageSource>
+                        <FileImageSource File="icon_store" />
+                    </Button.ImageSource>
+                </Button>
             </Grid>
             <ContentPresenter Grid.Row="1" />
         </Grid>

--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -89,14 +89,14 @@
                     BorderColor="White"
                     BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                     Padding="0"
-                    Command="{Binding OpenRedeemPageCommand}"
-                    IsVisible="{Binding ShowRedeem}"
+                    Command="{Binding OpenActivityPageCommand}"
+                    IsVisible="{Binding ShowActivity}"
                     VerticalOptions="Center">
                     <ImageButton.Behaviors>
                         <mct:IconTintColorBehavior TintColor="White" />
                     </ImageButton.Behaviors>
                     <Button.ImageSource>
-                        <FileImageSource File="icon_store" />
+                        <FileImageSource File="icon_bell" />
                     </Button.ImageSource>
                 </Button>
             </Grid>

--- a/src/MobileUI/Resources/Styles/Templates.xaml
+++ b/src/MobileUI/Resources/Styles/Templates.xaml
@@ -60,6 +60,13 @@
                     </Button.ImageSource>
                 </Button>
                 
+                <Image Grid.Column="1"
+                       VerticalOptions="Center"
+                       HorizontalOptions="Center"
+                       HeightRequest="40"
+                       Source="ssw_logo_darkmode"
+                       IsVisible="{Binding Title, Converter={mct:IsStringNullOrEmptyConverter}}"/>
+                
                 <Grid Grid.Column="1"
                       VerticalOptions="Center"
                       HeightRequest="50">


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1214 

> 2. What was changed?

1. Rearranges the tab bar and uses custom platform code to allow a big centre button for scanning.
2. Adds the SSW logo at the top.
3. Moves activity to the top right and makes it a pop up as it's no longer a shell page.
4. Tweaks the close button on other popups for consistency with the new activity popup.
5. Adds an override so iPads on iPadOS 18 use our custom tab bar and not the new default one at the top of the screen.

<img src="https://github.com/user-attachments/assets/d7d8b19e-192c-4470-b2a6-10dc05d2163f" width="400" />

**Figure: Icons now rearranged with a big scan button in the center**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->