### PR TITLE
🐛 Mobile | iOS crash fix

### DIFF
--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellHandler.cs
@@ -17,4 +17,9 @@ internal class CustomShellHandler : ShellRenderer
 
         return renderer;
     }
+
+    protected override IShellPageRendererTracker CreatePageRendererTracker()
+    {
+        return new CustomShellPageRendererTracker(this);
+    }
 }

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellPageRendererTracker.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellPageRendererTracker.cs
@@ -14,6 +14,7 @@ public class CustomShellPageRendererTracker : ShellPageRendererTracker
     {
         // Fixes MAUI bug where this can return a NullReferenceException
         // TODO: Remove when (hopefully) fixed in .NET MAUI 9
+        // See: https://github.com/dotnet/maui/pull/26786
         if (ViewController is null || Page is null)
         {
             return;

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellPageRendererTracker.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellPageRendererTracker.cs
@@ -1,0 +1,24 @@
+using Microsoft.Maui.Controls.Platform.Compatibility;
+
+namespace SSW.Rewards.Mobile.Renderers;
+
+public class CustomShellPageRendererTracker : ShellPageRendererTracker
+{
+    public CustomShellPageRendererTracker(IShellContext context)
+        : base(context)
+    {
+
+    }
+
+    protected override void UpdateTabBarVisible()
+    {
+        // Fixes MAUI bug where this can return a NullReferenceException
+        // TODO: Remove when (hopefully) fixed in .NET MAUI 9
+        if (ViewController is null || Page is null)
+        {
+            return;
+        }
+        
+        base.UpdateTabBarVisible();
+    }
+}


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

While testing on very rare occasions the iOS app can crash while navigating. This is a MAUI bug that should hopefully be fixed in .NET 9.

> 2. What was changed?

Overrides a shell page handler to add a null check to fix this issue.

> 3. Did you do pair or mob programming?
No 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->