### PR TITLE
🐛 Mobile | Fix rare navigation crash

### DIFF
--- a/src/MobileUI/DependencyInjection.cs
+++ b/src/MobileUI/DependencyInjection.cs
@@ -28,11 +28,15 @@ public static class DependencyInjection
         {
             typeof(OthersProfilePage),
             typeof(OthersProfileViewModel),
+            typeof(MyProfilePage),
+            typeof(MyProfileViewModel),
             typeof(ProfileViewModelBase),
             typeof(QuizDetailsPage),
             typeof(QuizDetailsViewModel),
-            typeof(ScanPage),
-            typeof(ScanViewModel)
+            typeof(ActivityPage),
+            typeof(ActivityPageViewModel),
+            typeof(SettingsPage),
+            typeof(SettingsViewModel)
         };
 
         var definedTypes = Assembly.GetExecutingAssembly().DefinedTypes
@@ -45,10 +49,15 @@ public static class DependencyInjection
 
         services.AddTransient<OthersProfilePage>();
         services.AddTransient<OthersProfileViewModel>();
+        services.AddTransient<MyProfilePage>();
+        services.AddTransient<MyProfileViewModel>();
+        services.AddTransient<ProfileViewModelBase>();
         services.AddTransient<QuizDetailsPage>();
         services.AddTransient<QuizDetailsViewModel>();
-        services.AddTransient<ScanPage>();
-        services.AddTransient<ScanViewModel>();
+        services.AddTransient<ActivityPage>();
+        services.AddTransient<ActivityPageViewModel>();
+        services.AddTransient<SettingsPage>();
+        services.AddTransient<SettingsViewModel>();
 
         services.AddSingleton<ILeaderService, LeaderService>();
         services.AddSingleton<IUserService, UserService>();

--- a/src/MobileUI/Features/Activity/ActivityPageViewModel.cs
+++ b/src/MobileUI/Features/Activity/ActivityPageViewModel.cs
@@ -16,7 +16,7 @@ public enum ActivityPageSegments
     Friends
 }
 
-public partial class ActivityPageViewModel(IActivityFeedService activityService, IUserService userService) : BaseViewModel
+public partial class ActivityPageViewModel(IActivityFeedService activityService, IUserService userService, IServiceProvider provider) : BaseViewModel
 {
     public ActivityPageSegments CurrentSegment { get; set; }
     
@@ -182,10 +182,16 @@ public partial class ActivityPageViewModel(IActivityFeedService activityService,
     [RelayCommand]
     private async Task ActivityTapped(ActivityFeedItemDto item)
     {
-        if (_myUserId == item.UserId) 
-            await AppShell.Current.GoToAsync($"myprofile");
-        else 
-            await AppShell.Current.GoToAsync($"othersprofile?UserId={item.UserId}");
+        if (_myUserId == item.UserId)
+        {
+            var page = ActivatorUtilities.CreateInstance<MyProfilePage>(provider);
+            await Shell.Current.Navigation.PushAsync(page);
+        }
+        else
+        {
+            var page = ActivatorUtilities.CreateInstance<OthersProfilePage>(provider, item.UserId);
+            await Shell.Current.Navigation.PushAsync(page);
+        }
     }
     
     [RelayCommand]

--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -12,11 +12,6 @@ public partial class AppShell
     {
         BindingContext = this;
         InitializeComponent();
-        Routing.RegisterRoute("earn/details", typeof(QuizDetailsPage));
-        Routing.RegisterRoute("activity", typeof(ActivityPage));
-        Routing.RegisterRoute("settings", typeof(SettingsPage));
-        Routing.RegisterRoute("myprofile", typeof(MyProfilePage));
-        Routing.RegisterRoute("othersprofile", typeof(OthersProfilePage));
     }
     
     protected override bool OnBackButtonPressed()

--- a/src/MobileUI/Features/Flyout/FlyoutFooterViewModel.cs
+++ b/src/MobileUI/Features/Flyout/FlyoutFooterViewModel.cs
@@ -1,16 +1,12 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Mopups.Services;
-using SSW.Rewards.Mobile.PopupPages;
 
 namespace SSW.Rewards.Mobile.ViewModels;
 
 public partial class FlyoutFooterViewModel : ObservableObject
 {
-    private readonly IUserService _userService;
     private readonly IAuthenticationService _authService;
-    private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
-    private readonly IPermissionsService _permissionsService;
+    private readonly IServiceProvider _provider;
 
     [ObservableProperty]
     private bool _isStaff;
@@ -18,12 +14,10 @@ public partial class FlyoutFooterViewModel : ObservableObject
     [ObservableProperty]
     private string _versionNumber;
 
-    public FlyoutFooterViewModel(IUserService userService, IAuthenticationService authService, IFirebaseAnalyticsService firebaseAnalyticsService, IPermissionsService permissionsService)
+    public FlyoutFooterViewModel(IUserService userService, IAuthenticationService authService, IServiceProvider provider)
     {
-        _userService = userService;
         _authService = authService;
-        _firebaseAnalyticsService = firebaseAnalyticsService;
-        _permissionsService = permissionsService;
+        _provider = provider;
         
         VersionNumber = $"Version {AppInfo.VersionString}";
         
@@ -34,14 +28,16 @@ public partial class FlyoutFooterViewModel : ObservableObject
     private async Task MyProfileTapped()
     {
         Shell.Current.FlyoutIsPresented = false;
-        await AppShell.Current.GoToAsync($"myprofile");
+        var page = ActivatorUtilities.CreateInstance<MyProfilePage>(_provider);
+        await Shell.Current.Navigation.PushAsync(page);
     }
     
     [RelayCommand]
     private async Task MySettingsTapped()
     {
         Shell.Current.FlyoutIsPresented = false;
-        await AppShell.Current.GoToAsync($"settings");
+        var page = ActivatorUtilities.CreateInstance<SettingsPage>(_provider);
+        await Shell.Current.Navigation.PushAsync(page);
     }
     
     [RelayCommand]

--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -12,15 +12,17 @@ public partial class LeaderboardViewModel : BaseViewModel
 
     private readonly ILeaderService _leaderService;
     private readonly IUserService _userService;
+    private readonly IServiceProvider _provider;
     private bool _loaded;
     
     public ObservableRangeCollection<LeaderViewModel> SearchResults { get; set; } = [];
 
-    public LeaderboardViewModel(ILeaderService leaderService, IUserService userService)
+    public LeaderboardViewModel(ILeaderService leaderService, IUserService userService, IServiceProvider provider)
     {
         Title = "Leaderboard";
         _leaderService = leaderService;
         _userService = userService;
+        _provider = provider;
         _userService.MyUserIdObservable().Subscribe(myUserId => _myUserId = myUserId);
         _userService.MyPointsObservable().Subscribe(myPoints => MyPoints = myPoints);
         _userService.MyBalanceObservable().Subscribe(HandleMyBalanceChange);
@@ -108,9 +110,15 @@ public partial class LeaderboardViewModel : BaseViewModel
     private async Task LeaderTapped(LeaderViewModel leader)
     {
         if (leader.IsMe)
-            await AppShell.Current.GoToAsync($"myprofile");
+        {
+            var page = ActivatorUtilities.CreateInstance<MyProfilePage>(_provider);
+            await Shell.Current.Navigation.PushAsync(page);
+        }
         else
-            await AppShell.Current.GoToAsync($"othersprofile?UserId={leader.UserId}");
+        {
+            var page = ActivatorUtilities.CreateInstance<OthersProfilePage>(_provider, leader.UserId);
+            await Shell.Current.Navigation.PushAsync(page);
+        }
     }
 
     [RelayCommand]

--- a/src/MobileUI/Features/Network/NetworkPageViewModel.cs
+++ b/src/MobileUI/Features/Network/NetworkPageViewModel.cs
@@ -26,10 +26,12 @@ public partial class NetworkPageViewModel : BaseViewModel
 
     private List<NetworkProfileDto> _profiles = [];
     private readonly IDevService _devService;
+    private readonly IServiceProvider _provider;
     
-    public NetworkPageViewModel(IDevService devService)
+    public NetworkPageViewModel(IDevService devService, IServiceProvider provider)
     {
         _devService = devService;
+        _provider = provider;
     }
     
     public async Task Initialise()
@@ -87,8 +89,9 @@ public partial class NetworkPageViewModel : BaseViewModel
     
     [RelayCommand]
     private async Task UserTapped(NetworkProfileDto leader)
-    { 
-        await AppShell.Current.GoToAsync($"othersprofile?UserId={leader.UserId}");
+    {
+        var page = ActivatorUtilities.CreateInstance<OthersProfilePage>(_provider, leader.UserId);
+        await Shell.Current.Navigation.PushAsync(page);
     }
     
     [RelayCommand]

--- a/src/MobileUI/Features/Profile/OthersProfilePage.xaml.cs
+++ b/src/MobileUI/Features/Profile/OthersProfilePage.xaml.cs
@@ -2,15 +2,12 @@
 
 namespace SSW.Rewards.Mobile.Pages;
 
-[QueryProperty(nameof(UserId), nameof(UserId))]
 public partial class OthersProfilePage
 {
     private readonly OthersProfileViewModel _viewModel;
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
     
-    public string UserId { get; set; }
-    
-    public OthersProfilePage(OthersProfileViewModel vm, IFirebaseAnalyticsService firebaseAnalyticsService)
+    public OthersProfilePage(OthersProfileViewModel vm, IFirebaseAnalyticsService firebaseAnalyticsService, int userId)
     {
         Title = "Profile";
         InitializeComponent();
@@ -19,14 +16,14 @@ public partial class OthersProfilePage
         _viewModel.Navigation = Navigation;
         _firebaseAnalyticsService = firebaseAnalyticsService;
         BindingContext = _viewModel;
+        
+        _viewModel.SetUser(userId);
     }
 
     protected override async void OnAppearing()
     {
         base.OnAppearing();
         _firebaseAnalyticsService.Log("OthersProfilePage");
-        var userId = int.Parse(UserId);
-        _viewModel.SetUser(userId);
         await _viewModel.Initialise();
     }
 

--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml.cs
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml.cs
@@ -3,28 +3,27 @@ using SSW.Rewards.Mobile.Messages;
 
 namespace SSW.Rewards.Mobile.Pages;
 
-[QueryProperty(nameof(QuizId), nameof(QuizId))]
 public partial class QuizDetailsPage
 {
     private QuizDetailsViewModel _viewModel;
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
 
-    public string QuizId { get; set; }
+    private readonly int _quizId;
 
-    public QuizDetailsPage(QuizDetailsViewModel viewModel, IFirebaseAnalyticsService firebaseAnalyticsService)
+    public QuizDetailsPage(QuizDetailsViewModel viewModel, IFirebaseAnalyticsService firebaseAnalyticsService, int quizId)
     {
         InitializeComponent();
         _viewModel = viewModel;
         _firebaseAnalyticsService = firebaseAnalyticsService;
         BindingContext = _viewModel;
+        _quizId = quizId;
     }
 
     protected override async void OnAppearing()
     {
         base.OnAppearing();
         _firebaseAnalyticsService.Log("QuizDetailsPage");
-        int quizId = int.Parse(QuizId);
-        await _viewModel.Initialise(quizId);
+        await _viewModel.Initialise(_quizId);
     }
 
     protected override void OnDisappearing()

--- a/src/MobileUI/Features/Quiz/QuizViewModel.cs
+++ b/src/MobileUI/Features/Quiz/QuizViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using SSW.Rewards.Mobile.Messages;
@@ -11,8 +10,7 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
 {
     private bool _isLoaded;
     private readonly IQuizService _quizService;
-
-    private const string QuizDetailsPageUrl = "///earn/details";
+    private readonly IServiceProvider _provider;
 
     private IDispatcherTimer _timer;
     
@@ -28,9 +26,10 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
 
     public ObservableRangeCollection<QuizItemViewModel> CarouselQuizzes { get; set; } = [];
 
-    public QuizViewModel(IQuizService quizService)
+    public QuizViewModel(IQuizService quizService, IServiceProvider provider)
     {
         _quizService = quizService;
+        _provider = provider;
         WeakReferenceMessenger.Default.Register(this);
         
         _timer = Application.Current.Dispatcher.CreateTimer();
@@ -118,7 +117,8 @@ public partial class QuizViewModel : BaseViewModel, IRecipient<QuizzesUpdatedMes
     [RelayCommand]
     private async Task OpenQuiz(int quizId)
     {
-        await AppShell.Current.GoToAsync($"{QuizDetailsPageUrl}?QuizId={quizId}");
+        var page = ActivatorUtilities.CreateInstance<QuizDetailsPage>(_provider, quizId);
+        await Shell.Current.Navigation.PushAsync(page);
     }
 
     private bool CanOpenQuiz(int quizId)

--- a/src/MobileUI/Features/Scanner/ScanResultViewModel.cs
+++ b/src/MobileUI/Features/Scanner/ScanResultViewModel.cs
@@ -9,8 +9,8 @@ namespace SSW.Rewards.Mobile.ViewModels;
 public partial class ScanResultViewModel : BaseViewModel
 {
     private readonly IUserService _userService;
-
     private readonly IScannerService _scannerService;
+    private readonly IServiceProvider _provider;
     
     private string data;
 
@@ -32,10 +32,11 @@ public partial class ScanResultViewModel : BaseViewModel
     [ObservableProperty]
     private Color _headingColour;
 
-    public ScanResultViewModel(IUserService userService, IScannerService scannerService)
+    public ScanResultViewModel(IUserService userService, IScannerService scannerService, IServiceProvider provider)
     {
         _userService = userService;
         _scannerService = scannerService;
+        _provider = provider;
     }
 
     public void SetScanData(string data)
@@ -76,7 +77,8 @@ public partial class ScanResultViewModel : BaseViewModel
                 
                 if (result.ScannedUserId != null)
                 {
-                    await AppShell.Current.GoToAsync($"othersprofile?UserId={result.ScannedUserId}");
+                    var page = ActivatorUtilities.CreateInstance<OthersProfilePage>(_provider, result.ScannedUserId);
+                    await Shell.Current.Navigation.PushAsync(page);
                 }
                 
                 break;
@@ -94,7 +96,8 @@ public partial class ScanResultViewModel : BaseViewModel
                 {
                     // Dismiss popup and go straight to profile
                     await MopupService.Instance.PopAllAsync();
-                    await AppShell.Current.GoToAsync($"othersprofile?UserId={result.ScannedUserId}");
+                    var page = ActivatorUtilities.CreateInstance<OthersProfilePage>(_provider, result.ScannedUserId);
+                    await Shell.Current.Navigation.PushAsync(page);
                     break;
                 }
                 

--- a/src/MobileUI/Features/Settings/SettingsViewModel.cs
+++ b/src/MobileUI/Features/Settings/SettingsViewModel.cs
@@ -9,7 +9,6 @@ namespace SSW.Rewards.Mobile.ViewModels;
 public partial class SettingsViewModel : BaseViewModel
 {
     private readonly IUserService _userService;
-    private readonly ISnackbarService _snackbarService;
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
     private readonly IServiceProvider _provider;
     
@@ -22,11 +21,9 @@ public partial class SettingsViewModel : BaseViewModel
     [ObservableProperty]
     private bool _isStaff;
 
-    public SettingsViewModel(IUserService userService, ISnackbarService snackbarService,
-        IFirebaseAnalyticsService firebaseAnalyticsService, IServiceProvider provider)
+    public SettingsViewModel(IUserService userService, IFirebaseAnalyticsService firebaseAnalyticsService, IServiceProvider provider)
     {
         _userService = userService;
-        _snackbarService = snackbarService;
         _firebaseAnalyticsService = firebaseAnalyticsService;
         _provider = provider;
         Title = "Settings";
@@ -50,9 +47,10 @@ public partial class SettingsViewModel : BaseViewModel
     }
 
     [RelayCommand]
-    private static async Task ProfileClicked()
+    private async Task ProfileClicked()
     {
-        await AppShell.Current.GoToAsync($"myprofile");
+        var page = ActivatorUtilities.CreateInstance<MyProfilePage>(_provider);
+        await Shell.Current.Navigation.PushAsync(page);
     }
 
     [RelayCommand]

--- a/src/MobileUI/Features/TopBar/TopBarViewModel.cs
+++ b/src/MobileUI/Features/TopBar/TopBarViewModel.cs
@@ -1,26 +1,18 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.Mvvm.Messaging;
-using SSW.Rewards.Mobile.Messages;
 
 namespace SSW.Rewards.Mobile.ViewModels;
 
 public partial class TopBarViewModel : ObservableObject
 {
-    private readonly IPermissionsService _permissionsService;
-    
-    private readonly IUserService _userService;
-
-    private readonly IScannerService _scannerService;
+    private readonly IServiceProvider _provider;
 
     [ObservableProperty]
     private string _profilePic;
 
-    public TopBarViewModel(IPermissionsService permissionsService, IUserService userService, IScannerService scannerService)
+    public TopBarViewModel(IServiceProvider provider, IUserService userService)
     {
-        _permissionsService = permissionsService;
-        _userService = userService;
-        _scannerService = scannerService;
+        _provider = provider;
 
         userService.MyProfilePicObservable().Subscribe(myProfilePage => ProfilePic = myProfilePage);
     }
@@ -35,7 +27,8 @@ public partial class TopBarViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenActivityPage()
     {
-        await Shell.Current.GoToAsync("activity");
+        var page = ActivatorUtilities.CreateInstance<ActivityPage>(_provider);
+        await Shell.Current.Navigation.PushAsync(page);
     }
 
     [RelayCommand]

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -17,7 +17,7 @@
 		<ApplicationIdGuid>fb3c30ce-ab0c-4155-b244-e49513e45a94</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>3.0.51</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>3.0.52</ApplicationDisplayVersion>
 		<ApplicationVersion>2</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

There's an issue with MAUI where navigating between different non-tabbed pages can cause a crash due to the routing using existing navigation stacks between tabs. This works around this by moving away from routing for pages that aren't a part of the Shell tabs and instead instantiating them and pushing them to the stack so the routing can't get them confused with other navigation stacks.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->