### PR TITLE
🐛 Mobile | Fix iPad layout issues

### DIFF
--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
@@ -63,6 +63,7 @@
             <CollectionView
                 ItemsSource="{Binding SearchResults}"
                 x:Name="LeadersCollection"
+                SizeChanged="OnSizeChanged"
                 ItemsUpdatingScrollMode="KeepItemsInView"
                 ItemSizingStrategy="MeasureFirstItem"
                 IsVisible="False">

--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace SSW.Rewards.Mobile.Pages;
+﻿using Microsoft.Maui.Controls.Internals;
+
+namespace SSW.Rewards.Mobile.Pages;
 
 public partial class LeaderboardPage
 {
@@ -44,5 +46,14 @@ public partial class LeaderboardPage
         await LeadersCollection.FadeTo(1, 800, Easing.CubicIn);
 
         _viewModel.IsRunning = false;
+    }
+    
+    private void OnSizeChanged(object sender, EventArgs e)
+    {
+        // Fix for CollectionView.Header not resizing when window size changes
+        if (DeviceInfo.Current.Platform == DevicePlatform.iOS && LeadersCollection.Header is VisualElement headerVisualElement)
+        {
+            headerVisualElement.InvalidateMeasureNonVirtual(InvalidationTrigger.Undefined);
+        }
     }
 }

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
@@ -12,9 +12,9 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
 {
     private UIButton? middleView;
 
-    public override async void ViewWillLayoutSubviews()
+    public override async void ViewDidLayoutSubviews()
     {
-        base.ViewWillLayoutSubviews();
+        base.ViewDidLayoutSubviews();
         if (View is not null && ShellItem is CustomTabBar { CenterViewVisible: true } tabbar)
         {
             if (middleView is not null)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

Fixes a couple iPad issues:

1. The podium on the leaderboard page doesn't resize when the window size changes.
2. The scan button gets misaligned when the window size changes.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->