### PR TITLE
Mobile App - Leaderboard incremental load by 50 users

### DIFF
--- a/src/ApiClient/Services/ILeaderboardService.cs
+++ b/src/ApiClient/Services/ILeaderboardService.cs
@@ -6,7 +6,7 @@ namespace SSW.Rewards.ApiClient.Services;
 
 public interface ILeaderboardService
 {
-    Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken);
+    Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken, int take = 0, int skip = 0);
     Task<LeaderboardViewModel> GetLeaderboard(LeaderboardFilter filter, CancellationToken cancellationToken);
 }
 
@@ -21,9 +21,9 @@ public class LeaderboardService : ILeaderboardService
         _httpClient = clientFactory.CreateClient(Constants.AuthenticatedClient);
     }
 
-    public async Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken)
+    public async Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken, int take = 0, int skip = 0)
     {
-        var result = await _httpClient.GetAsync($"{_baseRoute}Get", cancellationToken);
+        var result = await _httpClient.GetAsync($"{_baseRoute}Get?skip={skip}&take={take}", cancellationToken);
 
         if  (result.IsSuccessStatusCode)
         {

--- a/src/ApiClient/Services/ILeaderboardService.cs
+++ b/src/ApiClient/Services/ILeaderboardService.cs
@@ -6,7 +6,8 @@ namespace SSW.Rewards.ApiClient.Services;
 
 public interface ILeaderboardService
 {
-    Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken, int take = 0, int skip = 0);
+    Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken);
+    Task<LeaderboardViewModel> GetPaginatedLeaderboard(int take, int skip, LeaderboardFilter currentPeriod, CancellationToken cancellationToken);
     Task<LeaderboardViewModel> GetLeaderboard(LeaderboardFilter filter, CancellationToken cancellationToken);
 }
 
@@ -21,11 +22,29 @@ public class LeaderboardService : ILeaderboardService
         _httpClient = clientFactory.CreateClient(Constants.AuthenticatedClient);
     }
 
-    public async Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken, int take = 0, int skip = 0)
+    public async Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken)
     {
-        var result = await _httpClient.GetAsync($"{_baseRoute}Get?skip={skip}&take={take}", cancellationToken);
+        var result = await _httpClient.GetAsync($"{_baseRoute}Get", cancellationToken);
 
         if  (result.IsSuccessStatusCode)
+        {
+            var response = await result.Content.ReadFromJsonAsync<LeaderboardViewModel>(cancellationToken: cancellationToken);
+
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+        throw new Exception($"Failed to get leaderboard: {responseContent}");
+    }
+
+    public async Task<LeaderboardViewModel> GetPaginatedLeaderboard(int take, int skip, LeaderboardFilter currentPeriod, CancellationToken cancellationToken)
+    {
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetPaginated?skip={skip}&take={take}&currentPeriod={currentPeriod}", cancellationToken);
+
+        if (result.IsSuccessStatusCode)
         {
             var response = await result.Content.ReadFromJsonAsync<LeaderboardViewModel>(cancellationToken: cancellationToken);
 

--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
@@ -67,8 +67,8 @@
                 ItemsUpdatingScrollMode="KeepItemsInView"
                 ItemSizingStrategy="MeasureFirstItem"
                 IsVisible="False"
-                RemainingItemsThreshold="5"
-                RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}">>
+                RemainingItemsThreshold="10"
+                RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}">
                 <CollectionView.Header>
                     <Grid Grid.Row="1" Padding="15,10,15,0" HeightRequest="320" ColumnDefinitions="6*,14*,6*">
                         <!-- 2nd -->

--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
@@ -66,7 +66,9 @@
                 SizeChanged="OnSizeChanged"
                 ItemsUpdatingScrollMode="KeepItemsInView"
                 ItemSizingStrategy="MeasureFirstItem"
-                IsVisible="False">
+                IsVisible="False"
+                RemainingItemsThreshold="5"
+                RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}">>
                 <CollectionView.Header>
                     <Grid Grid.Row="1" Padding="15,10,15,0" HeightRequest="320" ColumnDefinitions="6*,14*,6*">
                         <!-- 2nd -->

--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -130,7 +130,11 @@ public partial class LeaderboardViewModel : BaseViewModel
     {
         CurrentPeriod = (LeaderboardFilter)SelectedPeriod.Value;
         ClearSearch = !ClearSearch;
-        await FilterAndSortLeaders(Leaders, CurrentPeriod);
+
+        Leaders.Clear();
+        _skip = 0;
+
+        await LoadLeaderboard();
     }
 
     [RelayCommand]
@@ -158,7 +162,7 @@ public partial class LeaderboardViewModel : BaseViewModel
 
     private async Task<List<LeaderboardUserDto>> LoadLeaderboard()
     {
-        var summaries = await _leaderService.GetLeadersAsync(Take, _skip, false);
+        var summaries = await _leaderService.GetLeadersAsync(Take, _skip, CurrentPeriod, false);
 
         foreach (var summary in summaries)
         {

--- a/src/MobileUI/Services/LeaderService.cs
+++ b/src/MobileUI/Services/LeaderService.cs
@@ -1,11 +1,12 @@
 ﻿using SSW.Rewards.ApiClient.Services;
+using SSW.Rewards.Enums;
 using SSW.Rewards.Shared.DTOs.Leaderboard;
 
 namespace SSW.Rewards.Mobile.Services;
 
 public interface ILeaderService
 {
-    Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(int take, int skip, bool forceRefresh);
+    Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(int take, int skip, LeaderboardFilter currentPeriod, bool forceRefresh);
 }
 
 public class LeaderService : ILeaderService
@@ -17,13 +18,13 @@ public class LeaderService : ILeaderService
         _leaderBoardClient = leaderBoardClient;
     }
 
-    public async Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(int take, int skip, bool forceRefresh)
+    public async Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(int take, int skip, LeaderboardFilter currentPeriod, bool forceRefresh)
     {
         List<LeaderboardUserDto> summaries = [];
 
         try
         {
-            var apiLeaderList = await _leaderBoardClient.GetLeaderboard(CancellationToken.None, take, skip);
+            var apiLeaderList = await _leaderBoardClient.GetPaginatedLeaderboard(take, skip, currentPeriod, CancellationToken.None);
 
             foreach (var leader in apiLeaderList.Users)
             {

--- a/src/MobileUI/Services/LeaderService.cs
+++ b/src/MobileUI/Services/LeaderService.cs
@@ -5,7 +5,7 @@ namespace SSW.Rewards.Mobile.Services;
 
 public interface ILeaderService
 {
-    Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(bool forceRefresh);
+    Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(int take, int skip, bool forceRefresh);
 }
 
 public class LeaderService : ILeaderService
@@ -17,13 +17,13 @@ public class LeaderService : ILeaderService
         _leaderBoardClient = leaderBoardClient;
     }
 
-    public async Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(bool forceRefresh)
+    public async Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(int take, int skip, bool forceRefresh)
     {
         List<LeaderboardUserDto> summaries = [];
 
         try
         {
-            var apiLeaderList = await _leaderBoardClient.GetLeaderboard(CancellationToken.None);
+            var apiLeaderList = await _leaderBoardClient.GetLeaderboard(CancellationToken.None, take, skip);
 
             foreach (var leader in apiLeaderList.Users)
             {

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -4,18 +4,26 @@ using SSW.Rewards.Shared.DTOs.PrizeDraw;
 using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardList;
 using SSW.Rewards.Application.PrizeDraw.Queries;
 using SSW.Rewards.Enums;
+using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardPaginatedList;
 
 namespace SSW.Rewards.WebAPI.Controllers;
 
 public class LeaderboardController : ApiControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<LeaderboardViewModel>> Get([FromQuery] int take = 0, [FromQuery] int skip = 0)
+    public async Task<ActionResult<LeaderboardViewModel>> Get()
     {
-        return Ok(await Mediator.Send(new GetLeaderboardListQuery() 
+        return Ok(await Mediator.Send(new GetLeaderboardListQuery()));
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<LeaderboardViewModel>> GetPaginated([FromQuery] int take = 0, [FromQuery] int skip = 0, [FromQuery] LeaderboardFilter currentPeriod = LeaderboardFilter.Forever)
+    {
+        return Ok(await Mediator.Send(new GetLeaderboardPaginatedListQuery()
         {
             Take = take,
-            Skip = skip
+            Skip = skip,
+            currentPeriod = currentPeriod
         }));
     }
 

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -10,9 +10,13 @@ namespace SSW.Rewards.WebAPI.Controllers;
 public class LeaderboardController : ApiControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<LeaderboardViewModel>> Get()
+    public async Task<ActionResult<LeaderboardViewModel>> Get([FromQuery] int take = 0, [FromQuery] int skip = 0)
     {
-        return Ok(await Mediator.Send(new GetLeaderboardListQuery()));
+        return Ok(await Mediator.Send(new GetLeaderboardListQuery() 
+        {
+            Take = take,
+            Skip = skip
+        }));
     }
 
     [HttpGet]


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/1242

> 2. What was changed?

- API - Added /Leaderboard/GetPaginated endpoint so the changes do not affect Admin portal
- Mobile App - Leaderboard now incrementally loads 50 users at a time.

> 3. Did you do pair or mob programming?

No

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->