### PR TITLE
Mobile App - Android - Fix crash on QR code scanning

### DIFF
--- a/src/MobileUI/Platforms/Android/AndroidManifest.xml
+++ b/src/MobileUI/Platforms/Android/AndroidManifest.xml
@@ -16,6 +16,7 @@
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+	<uses-permission android:name="android.permission.VIBRATE" />
 	<!-- Required only if your app targets Android 13. -->
 	<!-- Declare one or more the following permissions only if your app needs
     to access data that's protected by them. -->


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Crashing when scanning QR code with Android phone

> 2. What was changed?

Fix crash on android when scanning QR Code - Add VIBRATE permission to AndroidManifest

> 3. Did you do pair or mob programming?

No

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->