### PR TITLE
Mobile app - Leaderboard - Incremental load duplicates fix

### DIFF
--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -112,6 +112,10 @@ public partial class LeaderboardViewModel : BaseViewModel
     [RelayCommand]
     private async Task LoadMore()
     {
+        // Don't attempt to load more until initial load is complete
+        if (!_loaded)
+            return;
+
         if (_limitReached)
             return;
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Issues encountered after https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/1242 deployment

> 2. What was changed?

fix racing condition that results in duplicates on initial load - stop LoadMore method if the initial load is not complete

> 3. Did you do pair or mob programming?

✏️ 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->