### PR TITLE
♻️ Mobile | Use GUIDs for staff achievements to prevent duplicates

### DIFF
--- a/src/ApiClient/Services/IAchievementAdminService.cs
+++ b/src/ApiClient/Services/IAchievementAdminService.cs
@@ -67,7 +67,7 @@ public class AchievementAdminService : IAchievementAdminService
 
     public async Task DeleteAchievement(int id, CancellationToken cancellationToken)
     {
-        var result = await _httpClient.DeleteAsync($"{_baseRoute}?id={id}", cancellationToken);
+        var result = await _httpClient.DeleteAsync($"{_baseRoute}Delete?id={id}", cancellationToken);
 
         if  (result.IsSuccessStatusCode)
         {

--- a/src/Application/Achievements/Command/CreateAchievement/CreateAchievementCommand.cs
+++ b/src/Application/Achievements/Command/CreateAchievement/CreateAchievementCommand.cs
@@ -31,7 +31,7 @@ public class CreateAchievementCommandHandler : IRequestHandler<CreateAchievement
             Value = request.Value,
             Type = request.Type,
             IsMultiscanEnabled = request.IsMultiscanEnabled,
-            Code = AchievementHelper.GenerateCode(Guid.NewGuid().ToString()),
+            Code = AchievementHelper.GenerateCode(),
         };
 
         _context.Achievements.Add(achievement);

--- a/src/Application/Common/Extensions/UserExtensions.cs
+++ b/src/Application/Common/Extensions/UserExtensions.cs
@@ -26,7 +26,7 @@ public static class UserExtensions
             Value = 100,
             Type = AchievementType.Scanned,
             IsMultiscanEnabled = false,
-            Code = AchievementHelper.GenerateCode(Guid.NewGuid().ToString()),
+            Code = AchievementHelper.GenerateCode(),
         };
 
         user.Achievement = achievement;

--- a/src/Application/Common/Helpers/AchievementHelper.cs
+++ b/src/Application/Common/Helpers/AchievementHelper.cs
@@ -3,9 +3,9 @@
 namespace SSW.Rewards.Application.Common.Helpers;
 public static class AchievementHelper
 {
-    public static string GenerateCode(string inputValue)
+    public static string GenerateCode()
     {
-        var codeData = Encoding.ASCII.GetBytes($"ach:{inputValue}");
+        var codeData = Encoding.ASCII.GetBytes($"ach:{Guid.NewGuid().ToString()}");
         return Convert.ToBase64String(codeData);
     }
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -113,7 +113,7 @@ public class UserService : IUserService, IRolesService
                 staffMemberEntity.StaffAchievement ??= new Achievement
                 {
                     Name = staffMemberEntity.Name,
-                    Code = AchievementHelper.GenerateCode(staffMemberEntity.Name),
+                    Code = AchievementHelper.GenerateCode(),
                     Type = AchievementType.Scanned,
                     Value = 0
                 };

--- a/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
+++ b/src/Application/Staff/Commands/UpsertStaffMemberProfile/UpsertStaffMemberProfileCommand.cs
@@ -73,7 +73,7 @@ public class UpsertStaffMemberProfileCommandHandler : IRequestHandler<UpsertStaf
         staffMemberEntity.StaffAchievement ??= new Achievement
         {
             Name = staffMemberEntity.Name,
-            Code = AchievementHelper.GenerateCode(staffMemberEntity.Name),
+            Code = AchievementHelper.GenerateCode(),
             Type = AchievementType.Scanned
         };
         staffMemberEntity.StaffAchievement.Value = request.Points;

--- a/src/Application/System/Commands/Common/SampleDataSeeder.cs
+++ b/src/Application/System/Commands/Common/SampleDataSeeder.cs
@@ -84,7 +84,7 @@ public class SampleDataSeeder
 
         foreach (var achievement in achievements)
         {
-            achievement.Code = AchievementHelper.GenerateCode(achievement.Name);
+            achievement.Code = AchievementHelper.GenerateCode();
 
             sb.AppendLine(achievement.Code);
         }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Related to #1269

> 2. What was changed?

Looking into #1269 I noticed that there are two "Eli Kent" achievements in the database. I haven't yet worked out how this could have happened in the first place, but this raises an issue in that we can have duplicate achievements sharing the same code, meaning a user scanning that code will just claim whatever is fetched first from the db.

There's no real need to use the user's name in the code itself, so this updates future staff profile achievements to simply use a GUID so we don't run into duplicate codes going forward.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->