### PR TITLE
♻️ Mobile | Update redeem button state on balance change

### DIFF
--- a/src/MobileUI/Features/Redeem/RedeemViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemViewModel.cs
@@ -39,7 +39,7 @@ public partial class RedeemViewModel : BaseViewModel
         _userService = userService;
         _addressService = addressService;
         _firebaseAnalyticsService = firebaseAnalyticsService;
-        _userService.MyBalanceObservable().Subscribe(balance => Credits = balance);
+        _userService.MyBalanceObservable().Subscribe(OnBalanceChanged);
         _userService.MyUserIdObservable().DistinctUntilChanged().Subscribe(OnUserChanged);
         
         _timer = Application.Current.Dispatcher.CreateTimer();
@@ -59,6 +59,25 @@ public partial class RedeemViewModel : BaseViewModel
         _isLoaded = false;
     }
 
+    private void OnBalanceChanged(int balance)
+    {
+        Credits = balance;
+        UpdateRewardsAffordability();
+    }
+
+    private void UpdateRewardsAffordability()
+    {
+        foreach (var reward in Rewards)
+        {
+            reward.CanAfford = reward.Cost <= Credits;
+        }
+        
+        foreach (var reward in CarouselRewards)
+        {
+            reward.CanAfford = reward.Cost <= Credits;
+        }
+    }
+    
     public async Task Initialise()
     {
         if (!_isLoaded)
@@ -147,7 +166,7 @@ public partial class RedeemViewModel : BaseViewModel
     }
 
     [RelayCommand]
-    public async Task RedeemReward(int id)
+    private async Task RedeemReward(int id)
     {
         var reward = Rewards.FirstOrDefault(r => r.Id == id);
         if (reward != null)

--- a/src/MobileUI/Models/Reward.cs
+++ b/src/MobileUI/Models/Reward.cs
@@ -14,11 +14,11 @@ namespace SSW.Rewards.Models
         public string CarouselImageUri { get; set; }
         public bool IsCarousel { get; set; }
         public bool IsHidden { get; set; }
-        
-        [ObservableProperty]
-        private bool _canAfford;
-        
         public bool IsPendingRedemption { get; set; }
         public string PendingRedemptionCode { get; set; }
+        
+                
+        [ObservableProperty]
+        private bool _canAfford;
     }
 }

--- a/src/MobileUI/Models/Reward.cs
+++ b/src/MobileUI/Models/Reward.cs
@@ -1,6 +1,8 @@
-﻿namespace SSW.Rewards.Models
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SSW.Rewards.Models
 {
-    public class Reward
+    public partial class Reward : ObservableObject
     {
         public int Id { get; set; }
         public string Name { get; set; }
@@ -12,7 +14,10 @@
         public string CarouselImageUri { get; set; }
         public bool IsCarousel { get; set; }
         public bool IsHidden { get; set; }
-        public bool CanAfford { get; set; }
+        
+        [ObservableProperty]
+        private bool _canAfford;
+        
         public bool IsPendingRedemption { get; set; }
         public string PendingRedemptionCode { get; set; }
     }

--- a/src/MobileUI/Models/Reward.cs
+++ b/src/MobileUI/Models/Reward.cs
@@ -17,7 +17,6 @@ namespace SSW.Rewards.Models
         public bool IsPendingRedemption { get; set; }
         public string PendingRedemptionCode { get; set; }
         
-                
         [ObservableProperty]
         private bool _canAfford;
     }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1261

> 2. What was changed?

Makes CanAfford observable and updates this when balance changes so that the state of the redeem buttons can always be in sync with the balance.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->