### PR TITLE
♻️ Mobile/API | Add paginated loading to leaderboard

### DIFF
--- a/src/Application/Leaderboard/LeaderboardService.cs
+++ b/src/Application/Leaderboard/LeaderboardService.cs
@@ -1,0 +1,96 @@
+﻿using System.Text.RegularExpressions;
+using SSW.Rewards.Shared.DTOs.Leaderboard;
+
+namespace SSW.Rewards.Application.Leaderboard;
+
+public interface ILeaderboardService
+{
+    Task<List<LeaderboardUserDto>> GetFullLeaderboard(CancellationToken cancellationToken);
+}
+
+public class LeaderboardService : ILeaderboardService
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IDateTime _dateTime;
+    private readonly ICacheService _cacheService;
+    private readonly IProfilePicStorageProvider _profilePicStorageProvider;
+
+    public LeaderboardService(IApplicationDbContext context, IDateTime dateTime, ICacheService cacheService, IProfilePicStorageProvider profilePicStorageProvider)
+    {
+        _context = context;
+        _dateTime = dateTime;
+        _cacheService = cacheService;
+        _profilePicStorageProvider = profilePicStorageProvider;
+    }
+
+    public async Task<List<LeaderboardUserDto>> GetFullLeaderboard(CancellationToken cancellationToken)
+    {
+        var users = await _cacheService.GetOrAddAsync(CacheKeys.Leaderboard, () => GenerateLeaderboard(cancellationToken));
+
+        return users;
+    }
+
+    private async Task<List<LeaderboardUserDto>> GenerateLeaderboard(CancellationToken cancellationToken)
+    {
+        DateTime utcNow = _dateTime.UtcNow;
+
+        var users = await _context.Users
+            .AsNoTracking()
+            .AsSplitQuery()
+            .TagWithContext()
+            .Where(x => x.Activated && !string.IsNullOrWhiteSpace(x.FullName))
+            .Select(x => new LeaderboardUserDto
+            {
+                UserId = x.Id,
+                Name = x.FullName,
+                Email = x.Email,
+                ProfilePic = x.Avatar,
+                PointsClaimed = x.UserRewards.Sum(ur => ur.Reward.Cost),
+                TotalPoints = x.UserAchievements.Sum(ua => ua.Achievement.Value),
+                PointsToday = x.UserAchievements
+                    .Where(ua =>
+                        ua.AwardedAt.Year == utcNow.Year &&
+                        ua.AwardedAt.Month == utcNow.Month &&
+                        ua.AwardedAt.Day == utcNow.Day)
+                    .Sum(ua => ua.Achievement.Value),
+                PointsThisWeek = x.UserAchievements
+                    .Where(ua => utcNow.AddDays(-7) <= ua.AwardedAt && ua.AwardedAt <= utcNow)
+                    .Sum(ua => ua.Achievement.Value),
+                PointsThisMonth = x.UserAchievements
+                    .Where(ua => ua.AwardedAt.Year == utcNow.Year && ua.AwardedAt.Month == utcNow.Month)
+                    .Sum(ua => ua.Achievement.Value),
+                PointsThisYear = x.UserAchievements
+                    .Where(ua => ua.AwardedAt.Year == utcNow.Year)
+                    .Sum(ua => ua.Achievement.Value),
+                Title = x.SocialMediaIds
+                    .Where(s => s.SocialMediaPlatform.Name == "Company")
+                    .Select(s => s.SocialMediaUserId)
+                    .FirstOrDefault()
+                    ?? ""
+            })
+            .ToListAsync(cancellationToken);
+
+        var defaultProfilePictureUrl = await _profilePicStorageProvider.GetProfilePicUri("v2sophie.png");
+
+        // Post-processing
+        int rank = 0;
+        Regex checkHttpRegex = new(@"^https?://", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+        foreach (LeaderboardUserDto? user in users.OrderByDescending(lud => lud.TotalPoints))
+        {
+            user.Rank = ++rank;
+            user.Title = user.Title switch
+            {
+                _ when !string.IsNullOrEmpty(user.Title) => checkHttpRegex.Replace(user.Title, string.Empty),
+                _ when user.Email?.EndsWith("ssw.com.au") == true => "SSW",
+                _ => "Community"
+            };
+
+            if (string.IsNullOrEmpty(user.ProfilePic) && defaultProfilePictureUrl != null)
+            {
+                user.ProfilePic = defaultProfilePictureUrl.ToString();
+            }
+        }
+
+        return users;
+    }
+}

--- a/src/Application/Leaderboard/Queries/GetLeaderboardList/GetLeaderboardListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetLeaderboardList/GetLeaderboardListQuery.cs
@@ -1,93 +1,22 @@
-﻿using System.Text.RegularExpressions;
-using SSW.Rewards.Shared.DTOs.Leaderboard;
+﻿using SSW.Rewards.Shared.DTOs.Leaderboard;
 
 namespace SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardList;
 
 public class GetLeaderboardListQuery : IRequest<LeaderboardViewModel> { }
 
-public class Handler : IRequestHandler<GetLeaderboardListQuery, LeaderboardViewModel>
+internal class Handler : IRequestHandler<GetLeaderboardListQuery, LeaderboardViewModel>
 {
-    private readonly IApplicationDbContext _context;
-    private readonly IDateTime _dateTime;
-    private readonly ICacheService _cacheService;
-    private readonly IProfilePicStorageProvider _profilePicStorageProvider;
+    private readonly ILeaderboardService _leaderboardService;
 
-    public Handler(IApplicationDbContext context, IDateTime dateTime, ICacheService cacheService, IProfilePicStorageProvider profilePicStorageProvider)
+    public Handler(ILeaderboardService leaderboardService)
     {
-        _context = context;
-        _dateTime = dateTime;
-        _cacheService = cacheService;
-        _profilePicStorageProvider = profilePicStorageProvider;
+        _leaderboardService = leaderboardService;
     }
 
     public async Task<LeaderboardViewModel> Handle(GetLeaderboardListQuery request, CancellationToken cancellationToken)
     {
-        var users = await _cacheService.GetOrAddAsync(CacheKeys.Leaderboard, () => GenerateLeaderboard(cancellationToken));
+        var users = await _leaderboardService.GetFullLeaderboard(cancellationToken);
 
         return new LeaderboardViewModel { Users = users };
-    }
-
-    private async Task<List<LeaderboardUserDto>> GenerateLeaderboard(CancellationToken cancellationToken)
-    {
-        DateTime utcNow = _dateTime.UtcNow;
-
-        var users = await _context.Users
-            .AsNoTracking()
-            .AsSplitQuery()
-            .TagWithContext()
-            .Where(x => x.Activated && !string.IsNullOrWhiteSpace(x.FullName))
-            .Select(x => new LeaderboardUserDto
-            {
-                UserId = x.Id,
-                Name = x.FullName,
-                Email = x.Email,
-                ProfilePic = x.Avatar,
-                PointsClaimed = x.UserRewards.Sum(ur => ur.Reward.Cost),
-                TotalPoints = x.UserAchievements.Sum(ua => ua.Achievement.Value),
-                PointsToday = x.UserAchievements
-                    .Where(ua =>
-                        ua.AwardedAt.Year == utcNow.Year &&
-                        ua.AwardedAt.Month == utcNow.Month &&
-                        ua.AwardedAt.Day == utcNow.Day)
-                    .Sum(ua => ua.Achievement.Value),
-                PointsThisWeek = x.UserAchievements
-                    .Where(ua => utcNow.AddDays(-7) <= ua.AwardedAt && ua.AwardedAt <= utcNow)
-                    .Sum(ua => ua.Achievement.Value),
-                PointsThisMonth = x.UserAchievements
-                    .Where(ua => ua.AwardedAt.Year == utcNow.Year && ua.AwardedAt.Month == utcNow.Month)
-                    .Sum(ua => ua.Achievement.Value),
-                PointsThisYear = x.UserAchievements
-                    .Where(ua => ua.AwardedAt.Year == utcNow.Year)
-                    .Sum(ua => ua.Achievement.Value),
-                Title = x.SocialMediaIds
-                    .Where(s => s.SocialMediaPlatform.Name == "Company")
-                    .Select(s => s.SocialMediaUserId)
-                    .FirstOrDefault()
-                    ?? ""
-            })
-            .ToListAsync(cancellationToken);
-
-        var defaultProfilePictureUrl = await _profilePicStorageProvider.GetProfilePicUri("v2sophie.png");
-
-        // Post-processing
-        int rank = 0;
-        Regex checkHttpRegex = new(@"^https?://", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
-        foreach (LeaderboardUserDto? user in users.OrderByDescending(lud => lud.TotalPoints))
-        {
-            user.Rank = ++rank;
-            user.Title = user.Title switch
-            {
-                _ when !string.IsNullOrEmpty(user.Title) => checkHttpRegex.Replace(user.Title, string.Empty),
-                _ when user.Email?.EndsWith("ssw.com.au") == true => "SSW",
-                _ => "Community"
-            };
-
-            if (string.IsNullOrEmpty(user.ProfilePic) && defaultProfilePictureUrl != null)
-            {
-                user.ProfilePic = defaultProfilePictureUrl.ToString();
-            }
-        }
-
-        return users;
     }
 }

--- a/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using SSW.Rewards.Shared.DTOs.Leaderboard;
+﻿using SSW.Rewards.Shared.DTOs.Leaderboard;
 
 namespace SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardPaginatedList;
 
@@ -7,116 +6,41 @@ public class GetLeaderboardPaginatedListQuery : IRequest<LeaderboardViewModel>
 {
     public int Skip { get; set; }
     public int Take { get; set; }
-    public LeaderboardFilter currentPeriod { get; set; }
+    public LeaderboardFilter CurrentPeriod { get; set; }
 }
 
-public class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, LeaderboardViewModel>
+internal class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, LeaderboardViewModel>
 {
-    private readonly IApplicationDbContext _context;
-    private readonly IDateTime _dateTime;
-    private readonly IProfilePicStorageProvider _profilePicStorageProvider;
+    private readonly ILeaderboardService _leaderboardService;
 
-    public Handler(IApplicationDbContext context, IDateTime dateTime, IProfilePicStorageProvider profilePicStorageProvider)
+    public Handler(ILeaderboardService leaderboardService)
     {
-        _context = context;
-        _dateTime = dateTime;
-        _profilePicStorageProvider = profilePicStorageProvider;
+        _leaderboardService = leaderboardService;
     }
 
     public async Task<LeaderboardViewModel> Handle(GetLeaderboardPaginatedListQuery request, CancellationToken cancellationToken)
     {
         var skip = request.Skip;
         var take = request.Take;
-        var currentPeriod = request.currentPeriod;
+        var currentPeriod = request.CurrentPeriod;
 
-        var users = await GenerateLeaderboard(take, skip, currentPeriod, cancellationToken);
-
-        return new LeaderboardViewModel { Users = users };
-    }
-
-    private async Task<List<LeaderboardUserDto>> GenerateLeaderboard(int take, int skip, LeaderboardFilter currentPeriod, CancellationToken cancellationToken)
-    {
-        DateTime utcNow = _dateTime.UtcNow;
-
-        var query = _context.Users
-            .AsNoTracking()
-            .AsSplitQuery()
-            .TagWithContext()
-            .Where(x => x.Activated && !string.IsNullOrWhiteSpace(x.FullName))
-            .Select(x => new LeaderboardUserDto
-            {
-                UserId = x.Id,
-                Name = x.FullName,
-                Email = x.Email,
-                ProfilePic = x.Avatar,
-                PointsClaimed = x.UserRewards.Sum(ur => ur.Reward.Cost),
-                TotalPoints = x.UserAchievements.Sum(ua => ua.Achievement.Value),
-                PointsToday = x.UserAchievements
-                    .Where(ua =>
-                        ua.AwardedAt.Year == utcNow.Year &&
-                        ua.AwardedAt.Month == utcNow.Month &&
-                        ua.AwardedAt.Day == utcNow.Day)
-                    .Sum(ua => ua.Achievement.Value),
-                PointsThisWeek = x.UserAchievements
-                    .Where(ua => utcNow.AddDays(-7) <= ua.AwardedAt && ua.AwardedAt <= utcNow)
-                    .Sum(ua => ua.Achievement.Value),
-                PointsThisMonth = x.UserAchievements
-                    .Where(ua => ua.AwardedAt.Year == utcNow.Year && ua.AwardedAt.Month == utcNow.Month)
-                    .Sum(ua => ua.Achievement.Value),
-                PointsThisYear = x.UserAchievements
-                    .Where(ua => ua.AwardedAt.Year == utcNow.Year)
-                    .Sum(ua => ua.Achievement.Value),
-                Title = x.SocialMediaIds
-                    .Where(s => s.SocialMediaPlatform.Name == "Company")
-                    .Select(s => s.SocialMediaUserId)
-                    .FirstOrDefault()
-                    ?? ""
-            });
-        
-        switch (currentPeriod) {
-            case LeaderboardFilter.ThisMonth:
-                query = query.OrderByDescending(x => x.PointsThisMonth);
-                break;
-            case LeaderboardFilter.ThisYear:
-                query = query.OrderByDescending(x => x.PointsThisYear);
-                break;
-            case LeaderboardFilter.Forever:
-                query = query.OrderByDescending(x => x.TotalPoints);
-                break;
-            case LeaderboardFilter.ThisWeek:
-                query = query.OrderByDescending(x => x.PointsThisWeek);
-                break;
-            default:
-                query = query.OrderByDescending(x => x.TotalPoints);
-                break;
-        }
-
-        var users = await query
-                .Skip(skip)
-                .Take(take)
-                .ToListAsync(cancellationToken);
-
-        var defaultProfilePictureUrl = await _profilePicStorageProvider.GetProfilePicUri("v2sophie.png");
-
-        // Post-processing
-        int rank = 0;
-        Regex checkHttpRegex = new(@"^https?://", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
-        foreach (LeaderboardUserDto? user in users)
+        List<LeaderboardUserDto> users = await _leaderboardService.GetFullLeaderboard(cancellationToken);
+        var query = users.AsQueryable();
+        query = request.CurrentPeriod switch
         {
-            user.Rank = ++rank;
-            user.Title = user.Title switch
-            {
-                _ when !string.IsNullOrEmpty(user.Title) => checkHttpRegex.Replace(user.Title, string.Empty),
-                _ when user.Email?.EndsWith("ssw.com.au") == true => "SSW",
-                _ => "Community"
-            };
+            LeaderboardFilter.ThisMonth => query.OrderByDescending(x => x.PointsThisMonth),
+            LeaderboardFilter.ThisYear => query.OrderByDescending(x => x.PointsThisYear),
+            LeaderboardFilter.Forever => query.OrderByDescending(x => x.TotalPoints),
+            LeaderboardFilter.ThisWeek => query.OrderByDescending(x => x.PointsThisWeek),
+            _ => query.OrderByDescending(x => x.TotalPoints),
+        };
 
-            if (string.IsNullOrEmpty(user.ProfilePic) && defaultProfilePictureUrl != null)
-            {
-                user.ProfilePic = defaultProfilePictureUrl.ToString();
-            }
-        }
-
-        return users;
+        return new LeaderboardViewModel
+        {
+            Users = query
+                .Skip(request.Skip)
+                .Take(request.Take)
+                .ToArray()
+        };
     }
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -196,7 +196,14 @@ public class UserService : IUserService, IRolesService
 
         await ActivateUserIfNotActive(user, cancellationToken);
 
-        return _mapper.Map<CurrentUserDto>(user);
+        var currentUserDto = _mapper.Map<CurrentUserDto>(user);
+        var usersRanked =
+            await _cacheService.GetOrAddAsync(CacheKeys.UserRanking, () => GenerateRanking(cancellationToken));
+        var userRank = usersRanked.FirstOrDefault(u => u.Id == user.Id)
+                       ?? throw new NotFoundException(nameof(User), user.Id);
+        currentUserDto.Rank = userRank.Rank;
+        
+        return currentUserDto;
     }
 
     public async Task<int> GetCurrentUserId(CancellationToken cancellationToken)

--- a/src/Common/DTOs/Users/CurrentUserDto.cs
+++ b/src/Common/DTOs/Users/CurrentUserDto.cs
@@ -17,4 +17,6 @@ public class CurrentUserDto
     public string? QRCode { get; set; }
     
     public bool IsStaff { get; set; }
+    
+    public int Rank { get; set; }
 }

--- a/src/Infrastructure/ConfigureServices.cs
+++ b/src/Infrastructure/ConfigureServices.cs
@@ -9,6 +9,7 @@ using SSW.Rewards.Application.AddressLookup;
 using SSW.Rewards.Application.Common.Interfaces;
 using SSW.Rewards.Application.Common.Models;
 using SSW.Rewards.Application.Common.Options;
+using SSW.Rewards.Application.Leaderboard;
 using SSW.Rewards.Infrastructure;
 using SSW.Rewards.Infrastructure.Options;
 using SSW.Rewards.Infrastructure.Persistence;
@@ -76,6 +77,7 @@ public static class ConfigureServices
         services.AddSingleton<IStorageProvider, AzureStorageProvider>();
         services.AddSingleton<INotificationService, NotificationsService>();
 
+        services.AddScoped<ILeaderboardService, LeaderboardService>();
         services.AddScoped<IProfileStorageProvider, ProfileStorageProvider>();
         services.AddScoped<IProfilePicStorageProvider, ProfilePicStorageProvider>();
         services.AddScoped<IRewardPicStorageProvider, RewardPicStorageProvider>();

--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
@@ -62,7 +62,7 @@
             Command="{Binding RefreshLeaderboardCommand}"
             IsRefreshing="{Binding IsRefreshing}">
             <CollectionView
-                ItemsSource="{Binding SearchResults}"
+                ItemsSource="{Binding Leaders}"
                 x:Name="LeadersCollection"
                 SizeChanged="OnSizeChanged"
                 ItemsUpdatingScrollMode="KeepItemsInView"

--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml.cs
@@ -20,7 +20,7 @@ public partial class LeaderboardPage
     {
         base.OnAppearing();
         _firebaseAnalyticsService.Log("LeaderboardPage");
-        await _viewModel.Initialise();
+        _viewModel.Initialise();
         await Animate();
         _viewModel.ScrollTo += ScrollTo;
     }

--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml.cs
@@ -20,7 +20,7 @@ public partial class LeaderboardPage
     {
         base.OnAppearing();
         _firebaseAnalyticsService.Log("LeaderboardPage");
-        _viewModel.Initialise();
+        await _viewModel.Initialise();
         await Animate();
         _viewModel.ScrollTo += ScrollTo;
     }

--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using SSW.Rewards.Enums;
 using SSW.Rewards.Mobile.Controls;
+using SSW.Rewards.Shared.DTOs.Leaderboard;
 
 namespace SSW.Rewards.Mobile.ViewModels;
 
@@ -19,8 +20,6 @@ public partial class LeaderboardViewModel : BaseViewModel
     private int _skip;
     private bool _limitReached;
 
-    public ObservableRangeCollection<LeaderViewModel> SearchResults { get; set; } = [];
-
     public LeaderboardViewModel(ILeaderService leaderService, IUserService userService, IServiceProvider provider)
     {
         Title = "Leaderboard";
@@ -28,18 +27,15 @@ public partial class LeaderboardViewModel : BaseViewModel
         _userService = userService;
         _provider = provider;
         _userService.MyUserIdObservable().Subscribe(myUserId => _myUserId = myUserId);
-        _userService.MyPointsObservable().Subscribe(myPoints => MyPoints = myPoints);
-        _userService.MyBalanceObservable().Subscribe(HandleMyBalanceChange);
     }
 
-    private ObservableCollection<LeaderViewModel> Leaders { get; } = [];
-    private ObservableCollection<LeaderViewModel> LeadersToDisplay { get; } = [];
+    public ObservableCollection<LeaderViewModel> Leaders { get; } = [];
 
     [ObservableProperty]
-    private List<Segment> _periods;
+    private List<Segment> _periods = [];
 
     [ObservableProperty]
-    private bool _isRunning;
+    private bool _isRunning = true;
 
     [ObservableProperty]
     private bool _isRefreshing;
@@ -52,9 +48,6 @@ public partial class LeaderboardViewModel : BaseViewModel
     private Segment _selectedPeriod;
 
     [ObservableProperty]
-    private int _myRank;
-
-    [ObservableProperty]
     private LeaderViewModel _first;
 
     [ObservableProperty]
@@ -63,36 +56,17 @@ public partial class LeaderboardViewModel : BaseViewModel
     [ObservableProperty]
     private LeaderViewModel _third;
 
-    public int MyPoints { get; set; }
-    public int MyBalance { get; set; }
-
-    /// <summary>
-    /// Flip the value to clear search input field
-    /// </summary>
-    [ObservableProperty]
-    private bool _clearSearch;
-
-    public async Task Initialise()
+    public void Initialise()
     {
-        if (Periods is null || !Periods.Any())
+        if (Periods.Count == 0)
         {
-            Periods = new List<Segment>
-            {
-                new() { Name = "Week", Value = LeaderboardFilter.ThisWeek },
-                new() { Name = "Month", Value = LeaderboardFilter.ThisMonth },
-                new() { Name = "Year", Value = LeaderboardFilter.ThisYear },
-                new() { Name = "All Time", Value = LeaderboardFilter.Forever },
-            };
-        }
-
-        if (!_loaded)
-        {
-            IsRunning = true;
-
-            await LoadLeaderboard();
-            _loaded = true;
-
-            IsRunning = false;
+            Periods =
+            [
+                new Segment { Name = "Week", Value = LeaderboardFilter.ThisWeek },
+                new Segment { Name = "Month", Value = LeaderboardFilter.ThisMonth },
+                new Segment { Name = "Year", Value = LeaderboardFilter.ThisYear },
+                new Segment { Name = "All Time", Value = LeaderboardFilter.Forever }
+            ];
         }
     }
 
@@ -112,30 +86,31 @@ public partial class LeaderboardViewModel : BaseViewModel
 
         if (_limitReached)
             return;
-
+        
         _skip += Take;
-        var feed = Leaders.Skip(_skip).Take(Take).ToList();
+    
+        var newLeaders = await _leaderService.GetLeadersAsync(
+            false, 
+            _skip, 
+            Take, 
+            CurrentPeriod == LeaderboardFilter.Forever ? LeaderboardFilter.Forever : CurrentPeriod
+        );
 
-        if (feed.Count == 0)
+        var newLeadersList = newLeaders.ToList();
+        if (newLeadersList.Count == 0)
         {
             _limitReached = true;
             return;
         }
 
-        foreach (var leader in feed)
-        {
-            LeadersToDisplay.Add(leader);
-        }
-
-        await UpdateSearchResults();
+        AddLeadersToLeaderboard(newLeadersList);
     }
 
     [RelayCommand]
     private async Task FilterByPeriod()
     {
         CurrentPeriod = (LeaderboardFilter)SelectedPeriod.Value;
-        ClearSearch = !ClearSearch;
-        await FilterAndSortLeaders(Leaders, CurrentPeriod);
+        await LoadLeaderboard();
     }
 
     [RelayCommand]
@@ -157,10 +132,11 @@ public partial class LeaderboardViewModel : BaseViewModel
     private async Task ScrollToMe()
     {
         LeaderViewModel myCard = null;
+        IsRunning = true;
 
         while (myCard == null)
         {
-            myCard = SearchResults.FirstOrDefault(l => l.IsMe);
+            myCard = Leaders.FirstOrDefault(l => l.IsMe);
 
             if (myCard != null)
             {
@@ -177,132 +153,55 @@ public partial class LeaderboardViewModel : BaseViewModel
 
         if (myCard != null)
         {
-            var myIndex = SearchResults.IndexOf(myCard);
+            var myIndex = Leaders.IndexOf(myCard);
             ScrollTo(myIndex);
         }
+        
+        IsRunning = false;
     }
 
     private async Task LoadLeaderboard()
     {
         Leaders.Clear();
-
-        var summaries = await _leaderService.GetLeadersAsync(false);
-
-        foreach (var summary in summaries)
-        {
-            var isMe = _myUserId == summary.UserId;
-            var vm = new LeaderViewModel(summary, isMe);
-
-            Leaders.Add(vm);
-        }
-
-        await FilterAndSortLeaders(Leaders, CurrentPeriod);
-    }
-
-    private async Task UpdateSearchResults()
-    {
-        await App.Current.MainPage.Dispatcher.DispatchAsync(() =>
-        {
-            SearchResults.ReplaceRange(LeadersToDisplay);
-        });
-    }
-
-    private async Task FilterAndSortLeaders(IEnumerable<LeaderViewModel> list, LeaderboardFilter period, bool keepRank = false)
-    {
-        Func<LeaderViewModel, int> sortKeySelector;
-
-        switch (period)
-        {
-            case LeaderboardFilter.ThisMonth:
-                sortKeySelector = l => l.PointsThisMonth;
-                break;
-            case LeaderboardFilter.ThisYear:
-                sortKeySelector = l => l.PointsThisYear;
-                break;
-            case LeaderboardFilter.Forever:
-                sortKeySelector = l => l.TotalPoints;
-                break;
-            case LeaderboardFilter.ThisWeek:
-            default:
-                sortKeySelector = l => l.PointsThisWeek;
-                break;
-        }
-
-        FilterAndSortBy(list, sortKeySelector, keepRank);
-
-        LeadersToDisplay.Clear();
+        _limitReached = false;
         _skip = 0;
 
-        var initialLeaders = Leaders.Take(Take).ToList();
+        var summaries = await _leaderService.GetLeadersAsync(
+            false, 
+            _skip, 
+            Take, 
+            CurrentPeriod == LeaderboardFilter.Forever ? LeaderboardFilter.Forever : CurrentPeriod
+        );
 
-        foreach (var leader in initialLeaders)
-        {
-            LeadersToDisplay.Add(leader);
-        }
+        AddLeadersToLeaderboard(summaries);
 
-        await UpdateSearchResults();
+        // Update podium positions
+        First = Leaders.FirstOrDefault();
+        Second = Leaders.Skip(1).FirstOrDefault();
+        Third = Leaders.Skip(2).FirstOrDefault();
+        
+        _loaded = true;
     }
 
-    private void FilterAndSortBy(IEnumerable<LeaderViewModel> list, Func<LeaderViewModel, int> sortKeySelector, bool keepRank)
+    private void AddLeadersToLeaderboard(IEnumerable<LeaderboardUserDto> leaders)
     {
-        var leaders = list.OrderByDescending(sortKeySelector).ToList();
-        int rank = 1;
-
-        Leaders.Clear();
-
+        var rank = Leaders.Count + 1;
         foreach (var leader in leaders)
         {
-            if (!keepRank)
+            var isMe = _myUserId == leader.UserId;
+            var vm = new LeaderViewModel(leader, isMe)
             {
-                leader.Rank = rank;
-                rank++;
-            }
-
-            leader.DisplayPoints = sortKeySelector(leader);
-
-            Leaders.Add(leader);
-        }
-
-        var myProfile = leaders.FirstOrDefault(l => l.IsMe);
-        UpdateMyRank(myProfile);
-        UpdateMyAllTimeRank(myProfile);
-
-        // setting to null to trigger PropertyChanged event
-        First = null!;
-        Second = null!;
-        Third = null!;
-        First = leaders.FirstOrDefault();
-        Second = leaders.Skip(1).FirstOrDefault();
-        Third = leaders.Skip(2).FirstOrDefault();
-    }
-
-    private async void HandleMyBalanceChange(int myBalance)
-    {
-        MyBalance = myBalance;
-
-        // Don't attempt to refresh leaderboard until initial load is complete
-        if (!_loaded)
-        {
-            return;
-        }
-
-        await LoadLeaderboard();
-        IsRefreshing = false;
-    }
-
-    private void UpdateMyRank(LeaderViewModel mySummary)
-    {
-        if (mySummary is not null)
-        {
-            MyRank = mySummary.Rank;
-        }
-    }
-
-    private void UpdateMyAllTimeRank(LeaderViewModel me)
-    {
-        if (me is not null)
-        {
-            _userService.UpdateMyAllTimeRank(me.AllTimeRank);
+                Rank = rank,
+                DisplayPoints = CurrentPeriod switch
+                {
+                    LeaderboardFilter.ThisMonth => leader.PointsThisMonth,
+                    LeaderboardFilter.ThisYear => leader.PointsThisYear,
+                    LeaderboardFilter.Forever => leader.TotalPoints,
+                    _ => leader.PointsThisWeek
+                }
+            };
+            rank++;
+            Leaders.Add(vm);
         }
     }
 }

--- a/src/MobileUI/Services/LeaderService.cs
+++ b/src/MobileUI/Services/LeaderService.cs
@@ -6,7 +6,7 @@ namespace SSW.Rewards.Mobile.Services;
 
 public interface ILeaderService
 {
-    Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(bool forceRefresh);
+    Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(bool forceRefresh, int skip = 0, int take = 50, LeaderboardFilter currentPeriod = LeaderboardFilter.Forever);
 }
 
 public class LeaderService : ILeaderService
@@ -18,13 +18,13 @@ public class LeaderService : ILeaderService
         _leaderBoardClient = leaderBoardClient;
     }
 
-    public async Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(bool forceRefresh)
+    public async Task<IEnumerable<LeaderboardUserDto>> GetLeadersAsync(bool forceRefresh, int skip = 0, int take = 50, LeaderboardFilter currentPeriod = LeaderboardFilter.Forever)
     {
         List<LeaderboardUserDto> summaries = [];
 
         try
         {
-            var apiLeaderList = await _leaderBoardClient.GetLeaderboard(CancellationToken.None);
+            var apiLeaderList = await _leaderBoardClient.GetPaginatedLeaderboard(take, skip, currentPeriod, CancellationToken.None);
 
             foreach (var leader in apiLeaderList.Users)
             {

--- a/src/MobileUI/Services/UserService.cs
+++ b/src/MobileUI/Services/UserService.cs
@@ -26,7 +26,6 @@ public interface IUserService
 
     // user details
     Task UpdateMyDetailsAsync();
-    void UpdateMyAllTimeRank(int newRank);
     Task<IEnumerable<Achievement>> GetAchievementsAsync();
     Task<IEnumerable<Achievement>> GetAchievementsAsync(int userId);
     Task<IEnumerable<Achievement>> GetProfileAchievementsAsync();
@@ -118,13 +117,9 @@ public class UserService : IUserService
         _myBalance.OnNext(user.Balance);
         _myQrCode.OnNext(user.QRCode);
         _isStaff.OnNext(user.IsStaff);
+        _myAllTimeRank.OnNext(user.Rank);
     }
-
-    public void UpdateMyAllTimeRank(int newRank)
-    {
-        _myAllTimeRank.OnNext(newRank);
-    }
-
+    
     public async Task<IEnumerable<Achievement>> GetAchievementsAsync()
     {
         return await GetAchievementsForUserAsync(_myUserId.Value);

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -23,7 +23,7 @@ public class LeaderboardController : ApiControllerBase
         {
             Take = take,
             Skip = skip,
-            currentPeriod = currentPeriod
+            CurrentPeriod = currentPeriod
         }));
     }
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1242

> 2. What was changed?

- Improves performance of the paginated leaderboard endpoint and updates the mobile app to properly use this.
- Simplifies LeaderboardViewModel a fair bit.
- Now retrieves the current user's ranking from the current user profile rather than a side effect in the leaderboard.

> 3. Did you do pair or mob programming?

@jernejk started the work on this.

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->