### PR TITLE
🐛 Mobile | Fix pull-to-refresh cutting off podium on iOS

### DIFF
--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -76,8 +76,8 @@ public partial class LeaderboardViewModel : BaseViewModel
     [RelayCommand]
     private async Task RefreshLeaderboard()
     {
-        await LoadLeaderboard();
         IsRefreshing = false;
+        await LoadLeaderboard();
     }
 
     [RelayCommand]


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

Tiny change to fix an issue on iOS where pull-to-refresh results in the top part of the podium being cut off. Seems it's an issue with the loading circle interfering with the layout of the podium, but unsure why. This small change fixes the issue while still maintaining the same appearance.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->