### PR TITLE
✨ Add leaderboard Kiosk Mode

### DIFF
--- a/src/AdminUI/AdminUI.csproj
+++ b/src/AdminUI/AdminUI.csproj
@@ -28,7 +28,6 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="QRCoder" Version="1.4.3" />
         <PackageReference Include="Toolbelt.Blazor.FileDropZone" Version="2.1.1" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AdminUI/Helpers/NavigationPages.cs
+++ b/src/AdminUI/Helpers/NavigationPages.cs
@@ -2,7 +2,8 @@ using MudBlazor;
 
 namespace SSW.Rewards.Admin.UI.Helpers;
 
-public class NavigationPage {
+public class NavigationPage
+{
     public string Href;
     public string Icon;
     public string Title;
@@ -10,28 +11,27 @@ public class NavigationPage {
 
 public static class NavigationPages
 {
-    public static List<NavigationPage> StaffPages()
-    {
-        return new List<NavigationPage>
-        {
-            new () { Href = "leaderboard", Icon = Icons.Material.Filled.People, Title = "Leaderboard" },
-            new () { Href = "profiles", Icon = Icons.Material.Filled.Person, Title = "Profiles" },
-            new () { Href = "skills", Icon = Icons.Material.Filled.WorkspacePremium, Title = "Skills" },
-        };
-    }
+    public static List<NavigationPage> PublicPages() =>
+        [
+            new() { Href = "kiosk-leaderboard", Icon = Icons.Material.Filled.Leaderboard, Title = "Leaderboard (Kiosk Mode)" }
+        ];
 
-    public static List<NavigationPage> AdminPages()
-    {
-        return new List<NavigationPage>
-        {
-            new () { Href = "achievements", Icon = Icons.Material.Filled.Dashboard, Title = "Achievements" },
-            new () { Href = "rewards", Icon = Icons.Material.Filled.Redeem, Title = "Rewards" },
-            new () { Href = "quizzes", Icon = Icons.Material.Filled.Quiz, Title = "Quizzes" },
-            new () { Href = "users", Icon = Icons.Material.Filled.People, Title = "Users" },
-            new () { Href = "newusers", Icon = Icons.Material.Filled.SupervisedUserCircle, Title = "New Users" },
-            new () { Href = "prizedraw", Icon = Icons.Material.Filled.Celebration, Title = "Prize Draw" },
-            new () { Href = "notifications", Icon = Icons.Material.Filled.Chat, Title = "Notifications" },
-            new () { Href = "delete", Icon = Icons.Material.Filled.Delete, Title = "Delete" },
-        };
-    }
+    public static List<NavigationPage> StaffPages() =>
+        [
+            new() { Href = "leaderboard", Icon = Icons.Material.Filled.People, Title = "Leaderboard" },
+            new() { Href = "profiles", Icon = Icons.Material.Filled.Person, Title = "Profiles" },
+            new() { Href = "skills", Icon = Icons.Material.Filled.WorkspacePremium, Title = "Skills" }
+        ];
+
+    public static List<NavigationPage> AdminPages() =>
+        [
+            new() { Href = "achievements", Icon = Icons.Material.Filled.Dashboard, Title = "Achievements" },
+            new() { Href = "rewards", Icon = Icons.Material.Filled.Redeem, Title = "Rewards" },
+            new() { Href = "quizzes", Icon = Icons.Material.Filled.Quiz, Title = "Quizzes" },
+            new() { Href = "users", Icon = Icons.Material.Filled.People, Title = "Users" },
+            new() { Href = "newusers", Icon = Icons.Material.Filled.SupervisedUserCircle, Title = "New Users" },
+            new() { Href = "prizedraw", Icon = Icons.Material.Filled.Celebration, Title = "Prize Draw" },
+            new() { Href = "notifications", Icon = Icons.Material.Filled.Chat, Title = "Notifications" },
+            new() { Href = "delete", Icon = Icons.Material.Filled.Delete, Title = "Delete" }
+        ];
 }

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -42,22 +42,51 @@
             <MudTablePager PageSizeOptions="@_pageSizeOptions" />
         </PagerContent>
     </MudTable>
+    <div style="text-align: right; margin-top: 2rem; font-size: 1.1rem; color: #bbb;">
+        Last updated: @_lastUpdated?.ToString("yyyy-MM-dd HH:mm:ss")
+    </div>
 </MudPaper>
 
 @code {
     private MudTable<MobileLeaderboardUserDto> table;
     private LeaderboardFilter _selectedFilter = LeaderboardFilter.ThisWeek;
     private readonly int[] _pageSizeOptions = new[] { 5, 10, 25, 50, 100, 250 };
+    private System.Timers.Timer? _refreshTimer;
+    private DateTime? _lastUpdated;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadLeaderboard();
+
+        _refreshTimer = new System.Timers.Timer(60000); // 1 minute
+        _refreshTimer.Elapsed += async (_, __) => await InvokeAsync(LoadLeaderboard);
+        _refreshTimer.AutoReset = true;
+        _refreshTimer.Start();
+    }
 
     private async Task<TableData<MobileLeaderboardUserDto>> ServerReload(TableState state)
     {
         var result = await leaderboardService.GetMobilePaginatedLeaderboard(state.Page, state.PageSize, _selectedFilter, CancellationToken.None);
+        _lastUpdated = DateTime.Now;
+        StateHasChanged();
         return new TableData<MobileLeaderboardUserDto>() { TotalItems = result.Count, Items = result.Items };
     }
 
     private async Task LoadLeaderboard()
     {
         if (table != null)
+        {
             await table.ReloadServerData();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_refreshTimer != null)
+        {
+            _refreshTimer.Stop();
+            _refreshTimer.Dispose();
+            _refreshTimer = null;
+        }
     }
 }

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -12,21 +12,59 @@
     <style>
         .kiosk-tabs .mud-tabs-toolbar {
             justify-content: center;
+            background: #222;
+            border-radius: 12px;
+            padding: 0.5rem 0;
+            gap: 1.2rem;
         }
         .kiosk-tabs .mud-tab {
-            min-width: 110px !important;
-            padding-left: 12px !important;
-            padding-right: 12px !important;
-            font-size: 1.1rem;
+            min-width: 80px !important;
+            padding: 0.4rem 1.2rem !important;
+            font-size: 1rem;
+            color: #fff !important;
+            background: #222 !important;
+            border-radius: 10px !important;
+            margin: 0 0.15rem;
+            transition: background 0.2s, color 0.2s;
+        }
+        .kiosk-tabs .mud-tab.mud-tab-active {
+            background: #CC4141 !important;
+            color: #fff !important;
+            border-radius: 10px !important;
+        }
+        .kiosk-tabs .mud-tabs-indicator,
+        .kiosk-tabs .mud-tab-active .mud-tab-indicator,
+        .kiosk-tabs .mud-tab-slider {
+            display: none !important;
+            height: 0 !important;
+        }
+        .kiosk-tabs .mud-tabs-scroll-button {
+            display: none !important;
+        }
+
+        .kiosk-leaderboard-table .mud-table {
+            font-size: 2.2rem;
+        }
+        .kiosk-leaderboard-table .mud-table-row {
+            background-color: #222;
+        }
+        .kiosk-leaderboard-table .mud-table-row:nth-child(3n+1) {
+            background-color: #525252;
+        }
+        .kiosk-leaderboard-table .mud-table-row:nth-child(3n+2) {
+            background-color: #222;
+        }
+        .kiosk-leaderboard-table .mud-table-row:nth-child(3n) {
+            background-color: #333;
         }
     </style>
-    <div style="position: relative; margin-bottom: 2rem; height: 60px;">
-        <MudImage Src="/images/ssw-rewards-logo.svg" Class="mb-0" Style="height: 60px; position: absolute; left: 0; top: 0;" />
-        <MudText Typo="Typo.h2" Align="Align.Center" Class="mb-0" Style="font-size: 3rem; margin: 0 auto; display: block; width: fit-content; position: absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); text-align: center;">Leaderboard</MudText>
+    <div style="display: flex; flex-direction: column; align-items: center; margin-bottom: 1rem;">
+        <MudImage Src="/images/ssw-rewards-logo.svg" Class="mb-2" Style="height: 60px; margin: 0 auto; display: block;" />
+        <MudText Typo="Typo.h4" Align="Align.Center" Class="mb-0" Style="font-size: 2rem; margin-top: 0.5rem;">Leaderboard</MudText>
     </div>
     <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 1.5rem;">
         <div style="width: 600px; max-width: 100%;">
-            <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs">
+            <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs" Style="background: transparent; box-shadow: none;">
                 <MudTabPanel Text="This Week" />
                 <MudTabPanel Text="This Month" />
                 <MudTabPanel Text="This Year" />
@@ -36,11 +74,11 @@
     </div>
     <div style="display: flex; justify-content: center;">
         <div style="width: 600px; max-width: 100%;">
-            <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem; border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.3); overflow: hidden; background: #181818;">
+            <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="false" Class="kiosk-leaderboard-table" Style="border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.3); overflow: hidden; background: #181818;">
                 <HeaderContent>
                     <MudTh Style="width: 80px; text-align: center; background-color: #CC4141;">Rank</MudTh>
                     <MudTh Style="width: 320px; background-color: #CC4141;">Name</MudTh>
-                    <MudTh Style="width: 160px; text-align: right; background-color: #CC4141;">Total Points</MudTh>
+                    <MudTh Style="width: 160px; text-align: center; background-color: #CC4141;">Total Points</MudTh>
                 </HeaderContent>
                 <RowTemplate Context="row">
                     <MudTd Style="width: 80px; text-align: center;" DataLabel="Rank">@row.Rank</MudTd>
@@ -54,7 +92,7 @@
                             }
                         </div>
                     </MudTd>
-                    <MudTd Style="width: 160px; text-align: right;" DataLabel="Points">@row.Points</MudTd>
+                    <MudTd Style="width: 160px; text-align: center;" DataLabel="Points">@row.Points</MudTd>
                 </RowTemplate>
                 <PagerContent>
                     <MudTablePager PageSizeOptions="@_pageSizeOptions" />
@@ -63,7 +101,7 @@
         </div>
     </div>
     <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #ccc;">
-        Last updated: @_lastUpdated?.ToString("yyyy-MM-dd HH:mm")
+        Last updated: @_lastUpdated?.ToString("dd MMMM yyyy HH:mm")
     </div>
     @if (_hasErrorsOnUpdate)
     {
@@ -131,6 +169,7 @@
             3 => LeaderboardFilter.Forever,
             _ => LeaderboardFilter.ThisWeek
         };
+
         await LoadLeaderboard();
     }
 

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -85,11 +85,11 @@
     </div>
     <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 1rem;">
         <div style="width: 600px; max-width: 100%;">
-            <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs" Style="background: transparent; box-shadow: none; width: 100%;">
-                <MudTabPanel Text="Week" />
-                <MudTabPanel Text="Month" />
-                <MudTabPanel Text="Year" />
-                <MudTabPanel Text="All Time" />
+            <MudTabs Rounded="true" Centered="true" Class="kiosk-tabs" Style="background: transparent; box-shadow: none; width: 100%;">
+                <MudTabPanel Text="Week" OnClick="eventArgs => OnTabChanged(0)" />
+                <MudTabPanel Text="Month" OnClick="eventArgs => OnTabChanged(1)" />
+                <MudTabPanel Text="Year" OnClick="eventArgs => OnTabChanged(2)" />
+                <MudTabPanel Text="All Time" OnClick="eventArgs => OnTabChanged(3)" />
             </MudTabs>
         </div>
     </div>
@@ -140,7 +140,7 @@
     private MudTable<MobileLeaderboardUserDto> table;
     private LeaderboardFilter _selectedFilter = LeaderboardFilter.ThisWeek;
     private int _activeTabIndex = 0;
-    private readonly int[] _pageSizeOptions = new[] { 5, 10, 25, 50, 100, 250 };
+    private readonly int[] _pageSizeOptions = new[] { 10, 25, 50, 100, 250 };
     private System.Timers.Timer? _refreshTimer;
     private DateTime? _lastUpdated;
     private bool _hasErrorsOnUpdate = false;

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -14,7 +14,7 @@
             justify-content: center;
             background: #222;
             border-radius: 12px;
-            padding: 0.5rem 0;
+            padding: 0.3rem;
             gap: 1.2rem;
         }
         .kiosk-tabs .mud-tab {
@@ -41,6 +41,13 @@
         .kiosk-tabs .mud-tabs-scroll-button {
             display: none !important;
         }
+        .kiosk-tabs .mud-tooltip-root {
+            width: 100%;
+        }
+        .kiosk-tabs .mud-tabs-toolbar-content .mud-tabs-toolbar-wrapper {
+            width: 100%;
+            transform: translateX(-2px) !important;
+        }
 
         .kiosk-leaderboard-table .mud-table {
             font-size: 2.2rem;
@@ -64,10 +71,10 @@
     </div>
     <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 1.5rem;">
         <div style="width: 600px; max-width: 100%;">
-            <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs" Style="background: transparent; box-shadow: none;">
-                <MudTabPanel Text="This Week" />
-                <MudTabPanel Text="This Month" />
-                <MudTabPanel Text="This Year" />
+            <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs" Style="background: transparent; box-shadow: none; width: 100%;">
+                <MudTabPanel Text="Week" />
+                <MudTabPanel Text="Month" />
+                <MudTabPanel Text="Year" />
                 <MudTabPanel Text="All Time" />
             </MudTabs>
         </div>

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -41,9 +41,17 @@
             <MudTablePager PageSizeOptions="@_pageSizeOptions" />
         </PagerContent>
     </MudTable>
-    <div style="text-align: right; margin-top: 2rem; font-size: 1.1rem; color: #bbb;">
-        Last updated: @_lastUpdated?.ToString("yyyy-MM-dd HH:mm:ss")
+        </div>
     </div>
+    <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #ccc;">
+        Last updated: @_lastUpdated?.ToString("yyyy-MM-dd HH:mm")
+    </div>
+    @if (_hasErrorsOnUpdate)
+    {
+    <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #FF7A7A;">
+        ⚠️ Error loading leaderboard data. Retrying in 1 minute.
+    </div>
+    }
 </MudPaper>
 
 @code {
@@ -52,6 +60,9 @@
     private readonly int[] _pageSizeOptions = new[] { 5, 10, 25, 50, 100, 250 };
     private System.Timers.Timer? _refreshTimer;
     private DateTime? _lastUpdated;
+    private bool _hasErrorsOnUpdate = false;
+
+    private TableData<MobileLeaderboardUserDto> _lastTableCache = new() { TotalItems = 0, Items = [] };
 
     protected override async Task OnInitializedAsync()
     {
@@ -65,10 +76,20 @@
 
     private async Task<TableData<MobileLeaderboardUserDto>> ServerReload(TableState state)
     {
+        try
+        {
         var result = await leaderboardService.GetMobilePaginatedLeaderboard(state.Page, state.PageSize, _selectedFilter, CancellationToken.None);
         _lastUpdated = DateTime.Now;
+            _hasErrorsOnUpdate = false;
+            _lastTableCache = new() { TotalItems = result.Count, Items = result.Items };
+        }
+        catch (Exception ex)
+        {
+            _hasErrorsOnUpdate = true;
+            Console.WriteLine($"Error in ServerReload: {ex.Message}");
+        }
         StateHasChanged();
-        return new TableData<MobileLeaderboardUserDto>() { TotalItems = result.Count, Items = result.Items };
+        return _lastTableCache;
     }
 
     private async Task LoadLeaderboard()

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -9,10 +9,10 @@
 @inject ILeaderboardService leaderboardService
 
 <MudPaper Class="kiosk-leaderboard" Style="padding: 2rem; min-height: 100vh; background: #111; color: #fff;">
-    <MudImage Src="/images/ssw-rewards-logo.svg" Align="Align.Center" Class="mb-4" />
-    <MudText Typo="Typo.h2" Align="Align.Center" Class="mb-4" Style="font-size: 3rem;">
-        Leaderboard
-    </MudText>
+    <div style="position: relative; margin-bottom: 2rem; height: 60px;">
+        <MudImage Src="/images/ssw-rewards-logo.svg" Class="mb-0" Style="height: 60px; position: absolute; left: 0; top: 0;" />
+        <MudText Typo="Typo.h2" Align="Align.Center" Class="mb-0" Style="font-size: 3rem; margin: 0 auto; display: block; width: fit-content; position: absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); text-align: center;">Leaderboard</MudText>
+    </div>
     <MudStack Row="true" Spacing="2" Class="mb-4" Justify="Justify.Center">
         <MudSelect @bind-Value="_selectedFilter" Label="Period" Style="min-width: 200px;">
             <MudSelectItem Value="@LeaderboardFilter.ThisWeek">This Week</MudSelectItem>
@@ -39,7 +39,7 @@
             <MudTd DataLabel="Points">@context.Points</MudTd>
         </RowTemplate>
         <PagerContent>
-            <MudTablePager />
+            <MudTablePager PageSizeOptions="@_pageSizeOptions" />
         </PagerContent>
     </MudTable>
 </MudPaper>
@@ -47,6 +47,7 @@
 @code {
     private MudTable<MobileLeaderboardUserDto> table;
     private LeaderboardFilter _selectedFilter = LeaderboardFilter.ThisWeek;
+    private readonly int[] _pageSizeOptions = new[] { 5, 10, 25, 50, 100, 250 };
 
     private async Task<TableData<MobileLeaderboardUserDto>> ServerReload(TableState state)
     {

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -22,20 +22,27 @@
         </MudSelect>
     </MudStack>
     <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem;">
+    <div style="display: flex; justify-content: center;">
+        <div style="width: 600px; max-width: 100%;">
+            <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem; border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.3); overflow: hidden; background: #181818;">
         <HeaderContent>
-            <MudTh>Rank</MudTh>
-            <MudTh>Name</MudTh>
-            <MudTh>Total Points</MudTh>
+                    <MudTh Style="width: 80px; text-align: center; background-color: #CC4141;">Rank</MudTh>
+                    <MudTh Style="width: 320px; background-color: #CC4141;">Name</MudTh>
+                    <MudTh Style="width: 160px; text-align: right; background-color: #CC4141;">Total Points</MudTh>
         </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Rank">@context.Rank</MudTd>
-            <MudTd DataLabel="Name">
+                <RowTemplate Context="row">
+                    <MudTd Style="width: 80px; text-align: center;" DataLabel="Rank">@row.Rank</MudTd>
+                    <MudTd Style="width: 320px;" DataLabel="Name">
                 <div class="d-flex flex-nowrap gap-2 align-center">
-                    <Avatar Url="@context.ProfilePic"/>
-                    <MudText Typo="Typo.body1">@context.Name</MudText>
+                            <Avatar Url="@row.ProfilePic"/>
+                            <MudText Typo="Typo.body1">@row.Name</MudText>
+                            @if (row.Rank == 1)
+                            {
+                                <MudText Typo="Typo.body1">👑</MudText>                                
+                            }
                 </div>
             </MudTd>
-            <MudTd DataLabel="Points">@context.Points</MudTd>
+                    <MudTd Style="width: 160px; text-align: right;" DataLabel="Points">@row.Points</MudTd>
         </RowTemplate>
         <PagerContent>
             <MudTablePager PageSizeOptions="@_pageSizeOptions" />

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -8,7 +8,7 @@
 
 @inject ILeaderboardService leaderboardService
 
-<MudPaper Class="kiosk-leaderboard" Style="padding: 2rem; min-height: 100vh; background: #121212; color: #fafafa;">
+<MudPaper Class="kiosk-leaderboard" Style="padding: 2rem; margin-top: 0.5rem; min-height: 100vh; background: #121212; color: #fafafa;">
     <style>
         .kiosk-tabs .mud-tabs-toolbar {
             justify-content: center;
@@ -17,7 +17,12 @@
             padding: 0.3rem;
             gap: 1.2rem;
         }
+        .kiosk-tabs .mud-tabs-toolbar .mud-tabs-toolbar-inner {
+            min-height: 2.5rem;
+        }
+
         .kiosk-tabs .mud-tab {
+            min-height: 2.5rem;
             min-width: 80px !important;
             padding: 0.4rem 1.2rem !important;
             font-size: 1rem;
@@ -27,23 +32,28 @@
             margin: 0 0.15rem;
             transition: background 0.2s, color 0.2s;
         }
+
         .kiosk-tabs .mud-tab.mud-tab-active {
             background: #CC4141 !important;
             color: #fff !important;
             border-radius: 10px !important;
         }
+
         .kiosk-tabs .mud-tabs-indicator,
         .kiosk-tabs .mud-tab-active .mud-tab-indicator,
         .kiosk-tabs .mud-tab-slider {
             display: none !important;
             height: 0 !important;
         }
+
         .kiosk-tabs .mud-tabs-scroll-button {
             display: none !important;
         }
+
         .kiosk-tabs .mud-tooltip-root {
             width: 100%;
         }
+
         .kiosk-tabs .mud-tabs-toolbar-content .mud-tabs-toolbar-wrapper {
             width: 100%;
             transform: translateX(-2px) !important;
@@ -52,24 +62,28 @@
         .kiosk-leaderboard-table .mud-table {
             font-size: 2.2rem;
         }
-        .kiosk-leaderboard-table .mud-table-row {
-            background-color: #222;
+
+        .kiosk-leaderboard-table .mud-table-head .mud-table-cell {
+            background-color: #525252 !important;
         }
-        .kiosk-leaderboard-table .mud-table-row:nth-child(3n+1) {
-            background-color: #525252;
-        }
-        .kiosk-leaderboard-table .mud-table-row:nth-child(3n+2) {
-            background-color: #222;
-        }
-        .kiosk-leaderboard-table .mud-table-row:nth-child(3n) {
+
+        .kiosk-leaderboard-table .mud-table-row:nth-child(2n) {
             background-color: #333;
         }
+
+        .kiosk-leaderboard-table .mud-table-row:nth-child(2n+1) {
+            background-color: #222;
+        }
+
+        .kiosk-leaderboard-table .mud-table-cell {
+            font-size: 1rem;
+            padding: 0.7rem;
+        }
     </style>
-    <div style="display: flex; flex-direction: column; align-items: center; margin-bottom: 1rem;">
+    <div style="display: flex; flex-direction: column; align-items: center; margin-bottom: 1.25rem;">
         <MudImage Src="/images/ssw-rewards-logo.svg" Class="mb-2" Style="height: 60px; margin: 0 auto; display: block;" />
-        <MudText Typo="Typo.h4" Align="Align.Center" Class="mb-0" Style="font-size: 2rem; margin-top: 0.5rem;">Leaderboard</MudText>
     </div>
-    <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 1.5rem;">
+    <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 1rem;">
         <div style="width: 600px; max-width: 100%;">
             <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs" Style="background: transparent; box-shadow: none; width: 100%;">
                 <MudTabPanel Text="Week" />
@@ -83,19 +97,19 @@
         <div style="width: 600px; max-width: 100%;">
             <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="false" Class="kiosk-leaderboard-table" Style="border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.3); overflow: hidden; background: #181818;">
                 <HeaderContent>
-                    <MudTh Style="width: 80px; text-align: center; background-color: #CC4141;">Rank</MudTh>
-                    <MudTh Style="width: 320px; background-color: #CC4141;">Name</MudTh>
-                    <MudTh Style="width: 160px; text-align: center; background-color: #CC4141;">Total Points</MudTh>
+                    <MudTh Style="width: 80px; text-align: center;">Rank</MudTh>
+                    <MudTh Style="width: 320px;">Name</MudTh>
+                    <MudTh Style="width: 160px; text-align: center;">Total Points</MudTh>
                 </HeaderContent>
                 <RowTemplate Context="row">
                     <MudTd Style="width: 80px; text-align: center;" DataLabel="Rank">@row.Rank</MudTd>
                     <MudTd Style="width: 320px;" DataLabel="Name">
                         <div class="d-flex flex-nowrap gap-2 align-center">
-                            <Avatar Url="@row.ProfilePic"/>
+                            <Avatar Url="@row.ProfilePic" />
                             <MudText Typo="Typo.body1">@row.Name</MudText>
                             @if (row.Rank == 1)
                             {
-                                <MudText Typo="Typo.body1">👑</MudText>                                
+                                <MudText Typo="Typo.body1">👑</MudText>
                             }
                         </div>
                     </MudTd>
@@ -107,14 +121,18 @@
             </MudTable>
         </div>
     </div>
-    <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #ccc;">
-        Last updated: @_lastUpdated?.ToString("dd MMMM yyyy HH:mm")
-    </div>
-    @if (_hasErrorsOnUpdate)
+    @if (!_hasErrorsOnUpdate)
     {
-    <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #FF7A7A;">
-        ⚠️ Error loading leaderboard data. Retrying in 1 minute.
-    </div>
+        <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #ccc;">
+            Last updated: @(_lastUpdated != null ? _lastUpdated?.ToString("dd MMMM yyyy HH:mm") : "never")
+        </div>
+    }
+    else
+    {
+        <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #FF7A7A;">
+            ⚠️ We couldn't refresh the leaderboard. Retrying in 1 min.<br />
+            Last updated: @(_lastUpdated != null ? _lastUpdated?.ToString("dd MMMM yyyy HH:mm") : "never")
+        </div>
     }
 </MudPaper>
 

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -14,13 +14,12 @@
         <MudText Typo="Typo.h2" Align="Align.Center" Class="mb-0" Style="font-size: 3rem; margin: 0 auto; display: block; width: fit-content; position: absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); text-align: center;">Leaderboard</MudText>
     </div>
     <MudStack Row="true" Spacing="2" Class="mb-4" Justify="Justify.Center">
-        <MudSelect @bind-Value="_selectedFilter" Label="Period" Style="min-width: 200px;">
+        <MudSelect Value="_selectedFilter" ValueChanged="@((LeaderboardFilter filter) => OnFilterChanged(filter))" Label="Period" Style="min-width: 200px;">
             <MudSelectItem Value="@LeaderboardFilter.ThisWeek">This Week</MudSelectItem>
             <MudSelectItem Value="@LeaderboardFilter.ThisMonth">This Month</MudSelectItem>
             <MudSelectItem Value="@LeaderboardFilter.ThisYear">This Year</MudSelectItem>
             <MudSelectItem Value="@LeaderboardFilter.Forever">All Time</MudSelectItem>
         </MudSelect>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@LoadLeaderboard">Go</MudButton>
     </MudStack>
     <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem;">
         <HeaderContent>
@@ -78,6 +77,12 @@
         {
             await table.ReloadServerData();
         }
+    }
+
+    private async Task OnFilterChanged(LeaderboardFilter filter)
+    {
+        _selectedFilter = filter;
+        await LoadLeaderboard();
     }
 
     public void Dispose()

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -1,0 +1,67 @@
+@page "/kiosk-leaderboard"
+
+<h1>Hello World</h1>
+
+@* @layout KioskLayout
+@page "/kiosk-leaderboard"
+
+@using SSW.Rewards.Shared.DTOs.Leaderboard
+@using SSW.Rewards.ApiClient.Services
+@using SSW.Rewards.Admin.UI.Components
+@using SSW.Rewards.Enums
+
+@inject ILeaderboardService leaderboardService
+
+<MudPaper Class="kiosk-leaderboard" Style="padding: 2rem; min-height: 100vh; background: #111; color: #fff;">
+    <MudImage Src="/images/ssw-rewards-logo.svg" Align="Align.Center" Class="mb-4" />
+    <MudText Typo="Typo.h2" Align="Align.Center" Class="mb-4" Style="font-size: 3rem;">
+        Leaderboard
+    </MudText>
+    <MudStack Row="true" Spacing="2" Class="mb-4" Justify="Justify.Center">
+        <MudSelect @bind-Value="_selectedFilter" Label="Period" Style="min-width: 200px;">
+            <MudSelectItem Value="@LeaderboardFilter.ThisWeek">This Week</MudSelectItem>
+            <MudSelectItem Value="@LeaderboardFilter.ThisMonth">This Month</MudSelectItem>
+            <MudSelectItem Value="@LeaderboardFilter.ThisYear">This Year</MudSelectItem>
+            <MudSelectItem Value="@LeaderboardFilter.Forever">All Time</MudSelectItem>
+        </MudSelect>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@LoadLeaderboard">Go</MudButton>
+    </MudStack>
+    <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem;">
+        <HeaderContent>
+            <MudTh>Rank</MudTh>
+            <MudTh>Name</MudTh>
+            <MudTh>Total Points</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Rank">@context.Rank</MudTd>
+            <MudTd DataLabel="Name">
+                <div class="d-flex flex-nowrap gap-2 align-center">
+                    <Avatar Url="@context.ProfilePic"/>
+                    <MudText Typo="Typo.body1">@context.Name</MudText>
+                </div>
+            </MudTd>
+            <MudTd DataLabel="Points">@context.Points</MudTd>
+        </RowTemplate>
+        <PagerContent>
+            <MudTablePager />
+        </PagerContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    private MudTable<MobileLeaderboardUserDto> table;
+    private LeaderboardFilter _selectedFilter = LeaderboardFilter.ThisWeek;
+
+    private async Task<TableData<MobileLeaderboardUserDto>> ServerReload(TableState state)
+    {
+        var result = await leaderboardService.GetMobilePaginatedLeaderboard(state.Page, state.PageSize, _selectedFilter, CancellationToken.None);
+        return new TableData<MobileLeaderboardUserDto>() { TotalItems = result.Count, Items = result.Items };
+    }
+
+    private async Task LoadLeaderboard()
+    {
+        if (table != null)
+            await table.ReloadServerData();
+    }
+}
+ *@

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -1,8 +1,4 @@
-@page "/kiosk-leaderboard"
-
-<h1>Hello World</h1>
-
-@* @layout KioskLayout
+@layout KioskLayout
 @page "/kiosk-leaderboard"
 
 @using SSW.Rewards.Shared.DTOs.Leaderboard
@@ -64,4 +60,3 @@
             await table.ReloadServerData();
     }
 }
- *@

--- a/src/AdminUI/Pages/KioskLeaderboard.razor
+++ b/src/AdminUI/Pages/KioskLeaderboard.razor
@@ -1,4 +1,4 @@
-@layout KioskLayout
+﻿@layout KioskLayout
 @page "/kiosk-leaderboard"
 
 @using SSW.Rewards.Shared.DTOs.Leaderboard
@@ -8,46 +8,58 @@
 
 @inject ILeaderboardService leaderboardService
 
-<MudPaper Class="kiosk-leaderboard" Style="padding: 2rem; min-height: 100vh; background: #111; color: #fff;">
+<MudPaper Class="kiosk-leaderboard" Style="padding: 2rem; min-height: 100vh; background: #121212; color: #fafafa;">
+    <style>
+        .kiosk-tabs .mud-tabs-toolbar {
+            justify-content: center;
+        }
+        .kiosk-tabs .mud-tab {
+            min-width: 110px !important;
+            padding-left: 12px !important;
+            padding-right: 12px !important;
+            font-size: 1.1rem;
+        }
+    </style>
     <div style="position: relative; margin-bottom: 2rem; height: 60px;">
         <MudImage Src="/images/ssw-rewards-logo.svg" Class="mb-0" Style="height: 60px; position: absolute; left: 0; top: 0;" />
         <MudText Typo="Typo.h2" Align="Align.Center" Class="mb-0" Style="font-size: 3rem; margin: 0 auto; display: block; width: fit-content; position: absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); text-align: center;">Leaderboard</MudText>
     </div>
-    <MudStack Row="true" Spacing="2" Class="mb-4" Justify="Justify.Center">
-        <MudSelect Value="_selectedFilter" ValueChanged="@((LeaderboardFilter filter) => OnFilterChanged(filter))" Label="Period" Style="min-width: 200px;">
-            <MudSelectItem Value="@LeaderboardFilter.ThisWeek">This Week</MudSelectItem>
-            <MudSelectItem Value="@LeaderboardFilter.ThisMonth">This Month</MudSelectItem>
-            <MudSelectItem Value="@LeaderboardFilter.ThisYear">This Year</MudSelectItem>
-            <MudSelectItem Value="@LeaderboardFilter.Forever">All Time</MudSelectItem>
-        </MudSelect>
-    </MudStack>
-    <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem;">
+    <div style="display: flex; justify-content: center; align-items: center; margin-bottom: 1.5rem;">
+        <div style="width: 600px; max-width: 100%;">
+            <MudTabs @bind-ActivePanelIndex="_activeTabIndex" Rounded="true" Centered="true" OnActivePanelIndexChanged="OnTabChanged" Class="kiosk-tabs">
+                <MudTabPanel Text="This Week" />
+                <MudTabPanel Text="This Month" />
+                <MudTabPanel Text="This Year" />
+                <MudTabPanel Text="All Time" />
+            </MudTabs>
+        </div>
+    </div>
     <div style="display: flex; justify-content: center;">
         <div style="width: 600px; max-width: 100%;">
             <MudTable @ref="table" TItem="MobileLeaderboardUserDto" ServerData="@ServerReload" FixedHeader="true" Dense="false" Hover="true" Bordered="false" Striped="true" Style="font-size: 2rem; border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.3); overflow: hidden; background: #181818;">
-        <HeaderContent>
+                <HeaderContent>
                     <MudTh Style="width: 80px; text-align: center; background-color: #CC4141;">Rank</MudTh>
                     <MudTh Style="width: 320px; background-color: #CC4141;">Name</MudTh>
                     <MudTh Style="width: 160px; text-align: right; background-color: #CC4141;">Total Points</MudTh>
-        </HeaderContent>
+                </HeaderContent>
                 <RowTemplate Context="row">
                     <MudTd Style="width: 80px; text-align: center;" DataLabel="Rank">@row.Rank</MudTd>
                     <MudTd Style="width: 320px;" DataLabel="Name">
-                <div class="d-flex flex-nowrap gap-2 align-center">
+                        <div class="d-flex flex-nowrap gap-2 align-center">
                             <Avatar Url="@row.ProfilePic"/>
                             <MudText Typo="Typo.body1">@row.Name</MudText>
                             @if (row.Rank == 1)
                             {
                                 <MudText Typo="Typo.body1">👑</MudText>                                
                             }
-                </div>
-            </MudTd>
+                        </div>
+                    </MudTd>
                     <MudTd Style="width: 160px; text-align: right;" DataLabel="Points">@row.Points</MudTd>
-        </RowTemplate>
-        <PagerContent>
-            <MudTablePager PageSizeOptions="@_pageSizeOptions" />
-        </PagerContent>
-    </MudTable>
+                </RowTemplate>
+                <PagerContent>
+                    <MudTablePager PageSizeOptions="@_pageSizeOptions" />
+                </PagerContent>
+            </MudTable>
         </div>
     </div>
     <div style="text-align: center; margin-top: 2rem; font-size: 1.1rem; color: #ccc;">
@@ -64,6 +76,7 @@
 @code {
     private MudTable<MobileLeaderboardUserDto> table;
     private LeaderboardFilter _selectedFilter = LeaderboardFilter.ThisWeek;
+    private int _activeTabIndex = 0;
     private readonly int[] _pageSizeOptions = new[] { 5, 10, 25, 50, 100, 250 };
     private System.Timers.Timer? _refreshTimer;
     private DateTime? _lastUpdated;
@@ -85,8 +98,8 @@
     {
         try
         {
-        var result = await leaderboardService.GetMobilePaginatedLeaderboard(state.Page, state.PageSize, _selectedFilter, CancellationToken.None);
-        _lastUpdated = DateTime.Now;
+            var result = await leaderboardService.GetMobilePaginatedLeaderboard(state.Page, state.PageSize, _selectedFilter, CancellationToken.None);
+            _lastUpdated = DateTime.Now;
             _hasErrorsOnUpdate = false;
             _lastTableCache = new() { TotalItems = result.Count, Items = result.Items };
         }
@@ -107,9 +120,17 @@
         }
     }
 
-    private async Task OnFilterChanged(LeaderboardFilter filter)
+    private async Task OnTabChanged(int tabIndex)
     {
-        _selectedFilter = filter;
+        _activeTabIndex = tabIndex;
+        _selectedFilter = tabIndex switch
+        {
+            0 => LeaderboardFilter.ThisWeek,
+            1 => LeaderboardFilter.ThisMonth,
+            2 => LeaderboardFilter.ThisYear,
+            3 => LeaderboardFilter.Forever,
+            _ => LeaderboardFilter.ThisWeek
+        };
         await LoadLeaderboard();
     }
 

--- a/src/AdminUI/Shared/KioskLayout.razor
+++ b/src/AdminUI/Shared/KioskLayout.razor
@@ -1,0 +1,31 @@
+﻿@using Microsoft.AspNetCore.Authorization
+
+@inherits LayoutComponentBase
+
+<PageTitle>@_title</PageTitle>
+
+<MudThemeProvider @ref="@_mudThemeProvider" @bind-IsDarkMode="@_isDarkMode" Theme="AdminPortalMudTheme.Theme"/>
+<MudDialogProvider/>
+<MudSnackbarProvider/>
+
+@Body
+
+
+@code {
+    private bool _isDarkMode;
+    private MudThemeProvider? _mudThemeProvider;
+
+    private string _title = "Kiosk Mode";
+    
+    [CascadingParameter]
+    protected Task<AuthenticationState> AuthStat { get; set; } = null!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && _mudThemeProvider is not null)
+        {
+            _isDarkMode = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/AdminUI/Shared/KioskLayout.razor.css
+++ b/src/AdminUI/Shared/KioskLayout.razor.css
@@ -1,0 +1,81 @@
+.page {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+main {
+    flex: 1;
+}
+
+.sidebar {
+    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+}
+
+.top-row {
+    background-color: #f7f7f7;
+    border-bottom: 1px solid #d6d5d5;
+    justify-content: flex-end;
+    height: 3.5rem;
+    display: flex;
+    align-items: center;
+}
+
+    .top-row ::deep a, .top-row ::deep .btn-link {
+        white-space: nowrap;
+        margin-left: 1.5rem;
+        text-decoration: none;
+    }
+
+    .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
+        text-decoration: underline;
+    }
+
+    .top-row ::deep a:first-child {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+@media (max-width: 640.98px) {
+    .top-row:not(.auth) {
+        display: none;
+    }
+
+    .top-row.auth {
+        justify-content: space-between;
+    }
+
+    .top-row ::deep a, .top-row ::deep .btn-link {
+        margin-left: 0;
+    }
+}
+
+@media (min-width: 641px) {
+    .page {
+        flex-direction: row;
+    }
+
+    .sidebar {
+        width: 250px;
+        height: 100vh;
+        position: sticky;
+        top: 0;
+    }
+
+    .top-row {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    .top-row.auth ::deep a:first-child {
+        flex: 1;
+        text-align: right;
+        width: 0;
+    }
+
+    .top-row, article {
+        padding-left: 2rem !important;
+        padding-right: 1.5rem !important;
+    }
+}

--- a/src/AdminUI/Shared/NavMenu.razor
+++ b/src/AdminUI/Shared/NavMenu.razor
@@ -7,7 +7,8 @@
 
 <MudDivider Style="background-color: black"/>
 <MudNavMenu Style="margin-top: 8px; display:flex; flex-direction: column; justify-content: space-between; height: 100vh; margin-bottom: 16px; overflow: hidden;">
-    <MudStack Spacing="2"  >
+    <MudStack Spacing="2">
+        <!-- For staff and admins -->
         <AuthorizeView Roles="Admin, Staff">
             @foreach (var staffPage in NavigationPages.StaffPages())
             {
@@ -17,6 +18,7 @@
                 <MudDivider Style="background-color: black"/>
             }
         </AuthorizeView>
+
         <!-- Admin only links -->
         <AuthorizeView Roles="Admin" Context="sub_context">
             @foreach (var adminPage in NavigationPages.AdminPages())
@@ -26,6 +28,19 @@
                             Icon="@adminPage.Icon">@adminPage.Title</MudNavLink>
                 <MudDivider Style="background-color: black"/>
             }
+        </AuthorizeView>
+
+        <!-- Used for Kiosk mode and does not need roles -->
+        <AuthorizeView>
+            <Authorized>
+                @foreach (var publicPage in NavigationPages.PublicPages())
+                {
+                    <MudNavLink Href="@publicPage.Href"
+                                Match="NavLinkMatch.Prefix"
+                                Icon="@publicPage.Icon">@publicPage.Title</MudNavLink>
+                    <MudDivider Style="background-color: black" />
+                }
+            </Authorized>
         </AuthorizeView>
     </MudStack>
     

--- a/src/ApiClient/Services/ILeaderboardService.cs
+++ b/src/ApiClient/Services/ILeaderboardService.cs
@@ -9,6 +9,7 @@ public interface ILeaderboardService
     Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken);
     Task<LeaderboardViewModel> GetPaginatedLeaderboard(int take, int skip, LeaderboardFilter currentPeriod, CancellationToken cancellationToken);
     Task<LeaderboardViewModel> GetLeaderboard(LeaderboardFilter filter, CancellationToken cancellationToken);
+    Task<MobileLeaderboardViewModel> GetMobilePaginatedLeaderboard(int page, int pageSize, LeaderboardFilter currentPeriod, CancellationToken cancellationToken);
 }
 
 public class LeaderboardService : ILeaderboardService
@@ -30,6 +31,22 @@ public class LeaderboardService : ILeaderboardService
         {
             var response = await result.Content.ReadFromJsonAsync<LeaderboardViewModel>(cancellationToken: cancellationToken);
 
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
+        throw new Exception($"Failed to get leaderboard: {responseContent}");
+    }
+
+    public async Task<MobileLeaderboardViewModel> GetMobilePaginatedLeaderboard(int page, int pageSize, LeaderboardFilter currentPeriod, CancellationToken cancellationToken)
+    {
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetMobilePaginated?page={page}&pageSize={pageSize}&currentPeriod={currentPeriod}", cancellationToken);
+        if (result.IsSuccessStatusCode)
+        {
+            var response = await result.Content.ReadFromJsonAsync<MobileLeaderboardViewModel>(cancellationToken: cancellationToken);
             if (response is not null)
             {
                 return response;

--- a/src/Application/Common/Extensions/PaginationResultExtensions.cs
+++ b/src/Application/Common/Extensions/PaginationResultExtensions.cs
@@ -1,0 +1,53 @@
+﻿using SSW.Rewards.Shared.DTOs.Pagination;
+
+namespace SSW.Rewards.Application.Common.Extensions;
+
+/// <summary>
+/// This has sync and async implementation depending if it's in-memory or EF Core query.
+/// </summary>
+public static class PaginationResultExtensions
+{
+    public static TPagination ToPaginatedResult<TPagination, TItem>(this IEnumerable<TItem> query, int page, int pageSize)
+        where TPagination : IPaginationResult<TItem>, new()
+    {
+        var count = query.Count();
+        var items = query.AsQueryable().ApplyPagination(page, pageSize);
+
+        return new()
+        {
+            Items = items,
+            Count = count,
+            Page = page,
+            PageSize = pageSize
+        };
+    }
+
+    public static TPagination ToPaginatedResult<TPagination, TItem>(this IEnumerable<TItem> query, IPagedRequest pagedRequest)
+        where TPagination : IPaginationResult<TItem>, new()
+        => query.ToPaginatedResult<TPagination, TItem>(pagedRequest.Page, pagedRequest.PageSize);
+
+    public static async Task<TPagination> ToPaginatedResultAsync<TPagination, TItem>(this IQueryable<TItem> query, int page, int pageSize, CancellationToken ct)
+        where TPagination : IPaginationResult<TItem>, new()
+    {
+        var count = await query
+            .TagWithContext("Count")
+            .CountAsync(ct);
+
+        var items = await query
+            .TagWithContext("Paged")
+            .ApplyPagination(page, pageSize)
+            .ToListAsync(ct);
+
+        return new()
+        {
+            Items = items,
+            Count = count,
+            Page = page,
+            PageSize = pageSize
+        };
+    }
+
+    public static async Task<TPagination> ToPaginatedResultAsync<TPagination, TItem>(this IQueryable<TItem> query, IPagedRequest pagedRequest, CancellationToken ct)
+        where TPagination : IPaginationResult<TItem>, new()
+        => await query.ToPaginatedResultAsync<TPagination, TItem>(pagedRequest.Page, pagedRequest.PageSize, ct);
+}

--- a/src/Application/Leaderboard/Queries/GetKioskLeaderbaoard/GetMobileLeaderbaoard.cs
+++ b/src/Application/Leaderboard/Queries/GetKioskLeaderbaoard/GetMobileLeaderbaoard.cs
@@ -1,0 +1,50 @@
+﻿using SSW.Rewards.Shared.DTOs.Leaderboard;
+
+namespace SSW.Rewards.Application.Leaderboard.Queries.GetKioskLeaderbaoard;
+
+public class GetMobileLeaderboardQuery : IRequest<MobileLeaderboardViewModel>, IPagedRequest
+{
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public LeaderboardFilter CurrentPeriod { get; set; }
+}
+
+internal class GetMobileLeaderboardQueryHandler(ILeaderboardService leaderboardService) : IRequestHandler<GetMobileLeaderboardQuery, MobileLeaderboardViewModel>
+{
+    public async Task<MobileLeaderboardViewModel> Handle(GetMobileLeaderboardQuery request, CancellationToken cancellationToken)
+    {
+        List<LeaderboardUserDto> users = await leaderboardService.GetFullLeaderboard(cancellationToken);
+
+        // Remap to a lighter DTO for the Kiosk leaderboard with only what we need.
+        IEnumerable<MobileLeaderboardUserDto> query = request.CurrentPeriod switch
+        {
+            LeaderboardFilter.ThisMonth => users.Select(x => Map(x, x.PointsThisMonth)),
+            LeaderboardFilter.ThisYear => users.Select(x => Map(x, x.PointsThisYear)),
+            LeaderboardFilter.ThisWeek => users.Select(x => Map(x, x.PointsThisWeek)),
+            _ => users.OrderByDescending(x => x.TotalPoints).Select(x => Map(x, x.PointsThisMonth)),
+        };
+
+        // Sort and recalculate the rank based on the current period.
+        query = query
+            .OrderByDescending(x => x.Points)
+            .Select((x, i) =>
+            {
+                x.Rank = i + 1;
+                return x;
+            });
+
+        var result = query.ToPaginatedResult<MobileLeaderboardViewModel, MobileLeaderboardUserDto>(request);
+        result.CurrentPeriod = request.CurrentPeriod;
+        return result;
+    }
+
+    private static MobileLeaderboardUserDto Map(LeaderboardUserDto user, int selectedPoints)
+        => new()
+        {
+            Name = user.Name,
+            Rank = user.Rank,
+            UserId = user.UserId,
+            Points = selectedPoints,
+            ProfilePic = user.ProfilePic
+        };
+}

--- a/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
@@ -20,10 +20,6 @@ internal class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, Leade
 
     public async Task<LeaderboardViewModel> Handle(GetLeaderboardPaginatedListQuery request, CancellationToken cancellationToken)
     {
-        var skip = request.Skip;
-        var take = request.Take;
-        var currentPeriod = request.CurrentPeriod;
-
         List<LeaderboardUserDto> users = await _leaderboardService.GetFullLeaderboard(cancellationToken);
         var query = users.AsQueryable();
         query = request.CurrentPeriod switch

--- a/src/Common/DTOs/Leaderboard/LeaderboardUserDto.cs
+++ b/src/Common/DTOs/Leaderboard/LeaderboardUserDto.cs
@@ -1,7 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using SSW.Rewards.Domain.Entities;
-
-namespace SSW.Rewards.Shared.DTOs.Leaderboard;
+﻿namespace SSW.Rewards.Shared.DTOs.Leaderboard;
 
 public class LeaderboardUserDto
 {

--- a/src/Common/DTOs/Leaderboard/MobileLeaderboardViewModel.cs
+++ b/src/Common/DTOs/Leaderboard/MobileLeaderboardViewModel.cs
@@ -1,0 +1,23 @@
+﻿using SSW.Rewards.Shared.DTOs.Pagination;
+
+namespace SSW.Rewards.Shared.DTOs.Leaderboard;
+
+public class MobileLeaderboardViewModel : IPaginationResult<MobileLeaderboardUserDto>
+{
+    public IEnumerable<MobileLeaderboardUserDto> Items { get; set; } = [];
+
+    public LeaderboardFilter CurrentPeriod { get; set; }
+
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int Count { get; set; }
+}
+
+public class MobileLeaderboardUserDto
+{
+    public int Rank { get; set; }
+    public int UserId { get; set; }
+    public string? Name { get; set; }
+    public string? ProfilePic { get; set; }
+    public int Points { get; set; }
+}

--- a/src/Common/DTOs/Pagination/IPaginationResult.cs
+++ b/src/Common/DTOs/Pagination/IPaginationResult.cs
@@ -1,0 +1,10 @@
+﻿namespace SSW.Rewards.Shared.DTOs.Pagination;
+
+public interface IPaginationResult<TItem>
+{
+    IEnumerable<TItem> Items { get; set; }
+
+    int Page { get; set; }
+    int PageSize { get; set; }
+    int Count { get; set; }
+}

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using SSW.Rewards.Shared.DTOs.Leaderboard;
-using SSW.Rewards.Shared.DTOs.PrizeDraw;
+using SSW.Rewards.Application.Leaderboard.Queries.GetKioskLeaderbaoard;
 using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardList;
+using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardPaginatedList;
 using SSW.Rewards.Application.PrizeDraw.Queries;
 using SSW.Rewards.Enums;
-using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardPaginatedList;
+using SSW.Rewards.Shared.DTOs.Leaderboard;
+using SSW.Rewards.Shared.DTOs.PrizeDraw;
 
 namespace SSW.Rewards.WebAPI.Controllers;
 
@@ -23,6 +24,17 @@ public class LeaderboardController : ApiControllerBase
         {
             Take = take,
             Skip = skip,
+            CurrentPeriod = currentPeriod
+        }));
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<MobileLeaderboardViewModel>> GetMobilePaginated([FromQuery] int page = 0, [FromQuery] int pageSize = 10, [FromQuery] LeaderboardFilter currentPeriod = LeaderboardFilter.ThisWeek)
+    {
+        return Ok(await Mediator.Send(new GetMobileLeaderboardQuery
+        {
+            Page = page,
+            PageSize = pageSize,
             CurrentPeriod = currentPeriod
         }));
     }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️  By #1267 for NDC Porto next week.

> 2. What was changed?

✏️ Added new kiosk leaderboard mode and new mobile-centric leaderboard endpoints.

The new `/api/Leaderboard/GetKioskPaginated` reduces the size of the leaderboard significantly which can be essential when conference WiFi is starting to drop.

| Endpoint | 10 users / size | 10 users @ 50kB/s | 50 users | 50 users @ 50kB/s |
| ------------------------------------------ | --------- | ------- | --------- | ------- |
| /api/Leaderboard/Get                            | 400+kB | 8+ sec | 400+kB | 8+ sec |
| /api/Leaderboard/GetPaginated            | 3.2kB    | 64 ms   | 16kB     | 320 ms |
| /api/Leaderboard/GetMobilePaginated | 1.7kB    | 34 ms   | 8.2kB    | 164 ms |

On conferences, dropping WiFi and very slow WiFi (eg. 50kB/s) can be quite common. New endpoint is not only 50% smaller but also should be faster to parse and easier to build a leaderboard than GetPaginated. (for future mobile update)

New Leaderboard (Kiosk mode) will be accessible via https://rewards.ssw.com.au/kiosk-leaderboard and can be accessed via AdminUI as well. Kiosk mode removes all of the UI so that we can focus only on the content. The content is automatically updated every minute. Due to previous performance improvements on leaderboard endpoints, this change is expected to have a minimal impact on the overall system performance.

I have worked with Betty to make it NDC Porto ready.

![image](https://github.com/user-attachments/assets/7a7220a5-e312-4ea5-a9a6-2e9d99454817)
**Figure: The new Leaderboard (Kiosk mode).**

![image](https://github.com/user-attachments/assets/02905367-2c19-4658-a494-26ba90f9e035)
**Figure: It's accessible via the menu as well.**

> 3. Did you do pair or mob programming?

✏️ Yes, Betty for design.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->

PS: This PR also has a standardized way with dealing with pagination for requests and responses for future endpoints.