### PR TITLE
🐛 Fixed /api/Leaderboard/GetMobilePaginated not showing correct points

### DIFF
--- a/src/Application/Leaderboard/Queries/GetMobileLeaderbaoard/GetMobileLeaderbaoard.cs
+++ b/src/Application/Leaderboard/Queries/GetMobileLeaderbaoard/GetMobileLeaderbaoard.cs
@@ -1,6 +1,6 @@
 ﻿using SSW.Rewards.Shared.DTOs.Leaderboard;
 
-namespace SSW.Rewards.Application.Leaderboard.Queries.GetKioskLeaderbaoard;
+namespace SSW.Rewards.Application.Leaderboard.Queries.GetMobileLeaderbaoard;
 
 public class GetMobileLeaderboardQuery : IRequest<MobileLeaderboardViewModel>, IPagedRequest
 {
@@ -21,7 +21,7 @@ internal class GetMobileLeaderboardQueryHandler(ILeaderboardService leaderboardS
             LeaderboardFilter.ThisMonth => users.Select(x => Map(x, x.PointsThisMonth)),
             LeaderboardFilter.ThisYear => users.Select(x => Map(x, x.PointsThisYear)),
             LeaderboardFilter.ThisWeek => users.Select(x => Map(x, x.PointsThisWeek)),
-            _ => users.OrderByDescending(x => x.TotalPoints).Select(x => Map(x, x.PointsThisMonth)),
+            _ => users.OrderByDescending(x => x.TotalPoints).Select(x => Map(x, x.TotalPoints))
         };
 
         // Sort and recalculate the rank based on the current period.

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using SSW.Rewards.Application.Leaderboard.Queries.GetKioskLeaderbaoard;
 using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardList;
 using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardPaginatedList;
+using SSW.Rewards.Application.Leaderboard.Queries.GetMobileLeaderbaoard;
 using SSW.Rewards.Application.PrizeDraw.Queries;
 using SSW.Rewards.Enums;
 using SSW.Rewards.Shared.DTOs.Leaderboard;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ To fix a bug for #1267 

> 2. What was changed?

✏️ Points for kiosk leaderboard for "All Time" is now correct.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->