### PR TITLE
🐛 Mobile | Fix Android scan button inconsistencies

### DIFF
--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -17,7 +17,7 @@
 		<ApplicationIdGuid>fb3c30ce-ab0c-4155-b244-e49513e45a94</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>3.0.54</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>3.0.55</ApplicationDisplayVersion>
 		<ApplicationVersion>2</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
@@ -14,11 +14,11 @@ namespace SSW.Rewards.Mobile.Renderers;
 
 internal class CustomShellItemRenderer(IShellContext context) : ShellItemRenderer(context)
 {
-    private const int MiddleViewSizeDp = 80;
-    private const int ButtonSizeDp = 50;
-    private const int StrokeWidthDp = 4;
-    private const int BottomMarginAdjustmentDp = 15;
-    private const int BaseBottomMarginDp = 8;
+    private const int MiddleViewSize = 80;
+    private const int ButtonSize = 50;
+    private const int StrokeWidth = 4;
+    private const int BottomMarginAdjustment = 15;
+    private const int BaseBottomMargin = 8;
 
     public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
     {
@@ -59,9 +59,9 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
             ViewGroup.LayoutParams.WrapContent,
             GravityFlags.CenterHorizontal | GravityFlags.Bottom)
         {
-            BottomMargin = (int)(BaseBottomMarginDp * density),
-            Width = (int)(MiddleViewSizeDp * density),
-            Height = (int)(MiddleViewSizeDp * density)
+            BottomMargin = (int)(BaseBottomMargin * density),
+            Width = (int)(MiddleViewSize * density),
+            Height = (int)(MiddleViewSize * density)
         };
 
     private Button CreateMiddleView(CustomTabBar tabBar, FrameLayout.LayoutParams layoutParams)
@@ -79,9 +79,9 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
         var backgroundDrawable = new GradientDrawable();
         backgroundDrawable.SetShape(ShapeType.Rectangle);
         
-        var strokeWidthPx = (int)(StrokeWidthDp * density);
+        var strokeWidthPx = (int)(StrokeWidth * density);
         backgroundDrawable.SetStroke(strokeWidthPx, Color.White);
-        backgroundDrawable.SetCornerRadius((MiddleViewSizeDp * density) / 2f);
+        backgroundDrawable.SetCornerRadius((MiddleViewSize * density) / 2f);
         backgroundDrawable.SetColor(backgroundColor.ToPlatform(Colors.Transparent));
         
         backgroundView.SetBackground(backgroundDrawable);
@@ -99,12 +99,12 @@ internal class CustomShellItemRenderer(IShellContext context) : ShellItemRendere
             if (result?.Value is not BitmapDrawable drawable || drawable.Bitmap is null)
                 return;
 
-            var buttonSizePx = (int)(ButtonSizeDp * density);
+            var buttonSizePx = (int)(ButtonSize * density);
             middleView.LayoutParameters = new FrameLayout.LayoutParams(
                 buttonSizePx, buttonSizePx,
                 GravityFlags.CenterHorizontal | GravityFlags.Bottom)
             {
-                BottomMargin = originalLayoutParams.BottomMargin + (int)(BottomMarginAdjustmentDp * density)
+                BottomMargin = originalLayoutParams.BottomMargin + (int)(BottomMarginAdjustment * density)
             };
             
             middleView.SetBackground(drawable);

--- a/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/Android/Renderers/CustomShellItemRenderer.cs
@@ -1,8 +1,5 @@
 using SSW.Rewards.Mobile.Controls;
 using Color = Android.Graphics.Color;
-
-namespace SSW.Rewards.Mobile.Renderers;
-
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Views;
@@ -10,78 +7,109 @@ using Android.Widget;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Platform;
+using Button = Android.Widget.Button;
+using View = Android.Views.View;
+
+namespace SSW.Rewards.Mobile.Renderers;
 
 internal class CustomShellItemRenderer(IShellContext context) : ShellItemRenderer(context)
 {
-	public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
-	{
-		var view = base.OnCreateView(inflater, container, savedInstanceState);
-		if (Context is not null && ShellItem is CustomTabBar { CenterViewVisible: true } tabBar)
-		{
-			var rootLayout = new FrameLayout(Context)
-			{
-				LayoutParameters =
-					new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent)
-			};
+    private const int MiddleViewSizeDp = 80;
+    private const int ButtonSizeDp = 50;
+    private const int StrokeWidthDp = 4;
+    private const int BottomMarginAdjustmentDp = 15;
+    private const int BaseBottomMarginDp = 8;
 
-			rootLayout.AddView(view);
-			const int middleViewSize = 280;
-			var middleViewLayoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.WrapContent,
-																	  ViewGroup.LayoutParams.WrapContent,
-																	  GravityFlags.CenterHorizontal |
-																	  GravityFlags.Bottom)
-			{
-				BottomMargin = 30,
-				Width = middleViewSize,
-				Height = middleViewSize
-			};
-			var middleView = new Button(Context)
-			{
-				LayoutParameters = middleViewLayoutParams
-			};
-			middleView.Click += delegate
+    public override View? OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
+    {
+        var view = base.OnCreateView(inflater, container, savedInstanceState);
+        
+        if (Context is null || ShellItem is not CustomTabBar { CenterViewVisible: true } tabBar)
+            return view;
+
+        var density = Context.Resources?.DisplayMetrics?.Density ?? 1.0f;
+        var rootLayout = CreateRootLayout();
+        rootLayout.AddView(view);
+
+        var middleViewLayoutParams = CreateMiddleViewLayoutParams(density);
+        var middleView = CreateMiddleView(tabBar, middleViewLayoutParams);
+        
+        if (tabBar.CenterViewBackgroundColor is not null)
+        {
+            AddBackgroundView(rootLayout, tabBar.CenterViewBackgroundColor, middleViewLayoutParams, density);
+        }
+
+        LoadCenterViewImage(tabBar, middleView, density, middleViewLayoutParams);
+        rootLayout.AddView(middleView);
+        
+        return rootLayout;
+    }
+
+    private FrameLayout CreateRootLayout() =>
+        new(Context)
+        {
+            LayoutParameters = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MatchParent, 
+                ViewGroup.LayoutParams.MatchParent)
+        };
+
+    private static FrameLayout.LayoutParams CreateMiddleViewLayoutParams(float density) =>
+        new(
+            ViewGroup.LayoutParams.WrapContent,
+            ViewGroup.LayoutParams.WrapContent,
+            GravityFlags.CenterHorizontal | GravityFlags.Bottom)
+        {
+            BottomMargin = (int)(BaseBottomMarginDp * density),
+            Width = (int)(MiddleViewSizeDp * density),
+            Height = (int)(MiddleViewSizeDp * density)
+        };
+
+    private Button CreateMiddleView(CustomTabBar tabBar, FrameLayout.LayoutParams layoutParams)
+    {
+        var button = new Button(Context) { LayoutParameters = layoutParams };
+        button.Click += delegate { tabBar.CenterView_Tapped(); };
+        button.SetPadding(0, 0, 0, 0);
+        return button;
+    }
+
+    private void AddBackgroundView(FrameLayout rootLayout, Microsoft.Maui.Graphics.Color backgroundColor,
+        FrameLayout.LayoutParams layoutParams, float density)
+    {
+        var backgroundView = new View(Context) { LayoutParameters = layoutParams };
+        var backgroundDrawable = new GradientDrawable();
+        backgroundDrawable.SetShape(ShapeType.Rectangle);
+        
+        var strokeWidthPx = (int)(StrokeWidthDp * density);
+        backgroundDrawable.SetStroke(strokeWidthPx, Color.White);
+        backgroundDrawable.SetCornerRadius((MiddleViewSizeDp * density) / 2f);
+        backgroundDrawable.SetColor(backgroundColor.ToPlatform(Colors.Transparent));
+        
+        backgroundView.SetBackground(backgroundDrawable);
+        rootLayout.AddView(backgroundView);
+    }
+
+    private static void LoadCenterViewImage(CustomTabBar tabBar, Button middleView, float density, 
+        FrameLayout.LayoutParams originalLayoutParams)
+    {
+        var context = tabBar.Window?.Page?.Handler?.MauiContext ?? 
+                     Application.Current?.Windows.LastOrDefault()?.Page?.Handler?.MauiContext;
+                     
+        tabBar.CenterViewImageSource?.LoadImage(context!, result =>
+        {
+            if (result?.Value is not BitmapDrawable drawable || drawable.Bitmap is null)
+                return;
+
+            var buttonSizePx = (int)(ButtonSizeDp * density);
+            middleView.LayoutParameters = new FrameLayout.LayoutParams(
+                buttonSizePx, buttonSizePx,
+                GravityFlags.CenterHorizontal | GravityFlags.Bottom)
             {
-                tabBar.CenterView_Tapped();
+                BottomMargin = originalLayoutParams.BottomMargin + (int)(BottomMarginAdjustmentDp * density)
             };
-			middleView.SetPadding(0, 0, 0, 0);
-			if (tabBar.CenterViewBackgroundColor is not null)
-			{
-				var backgroundView = new View(Context)
-				{
-					LayoutParameters = middleViewLayoutParams
-				};
-				var backgroundDrawable = new GradientDrawable();
-				backgroundDrawable.SetShape(ShapeType.Rectangle);
-                backgroundDrawable.SetStroke(14, Color.White);
-				backgroundDrawable.SetCornerRadius(middleViewSize / 2f);
-				backgroundDrawable.SetColor(tabBar.CenterViewBackgroundColor.ToPlatform(Colors.Transparent));
-				backgroundView.SetBackground(backgroundDrawable);
-				rootLayout.AddView(backgroundView);
-			}
-
-			var context = tabBar.Window?.Page?.Handler?.MauiContext ?? Application.Current?.Windows.LastOrDefault()?.Page?.Handler?.MauiContext;
-			tabBar.CenterViewImageSource?.LoadImage(context!, result =>
-			{
-				if (result?.Value is not BitmapDrawable drawable || drawable.Bitmap is null)
-				{
-					return;
-				}
-                
-				middleView.LayoutParameters = new FrameLayout.LayoutParams(
-					180, 180,
-					GravityFlags.CenterHorizontal | GravityFlags.Bottom)
-				{
-					BottomMargin = middleViewLayoutParams.BottomMargin + 50
-				};
-				middleView.SetBackground(drawable);
-				middleView.SetMinimumHeight(0);
-				middleView.SetMinimumWidth(0);
-			});
-
-			rootLayout.AddView(middleView);
-			return rootLayout;
-		}
-
-		return view;
-	}
+            
+            middleView.SetBackground(drawable);
+            middleView.SetMinimumHeight(0);
+            middleView.SetMinimumWidth(0);
+        });
+    }
 }

--- a/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
+++ b/src/MobileUI/Platforms/iOS/Renderers/CustomShellItemRenderer.cs
@@ -2,57 +2,57 @@ using CoreGraphics;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using SSW.Rewards.Mobile.Controls;
 using UIKit;
+using Microsoft.Maui.Platform;
 
 namespace SSW.Rewards.Mobile.Renderers;
 
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Platform;
-
 internal class CustomShellItemRenderer(IShellContext context) : ShellItemRenderer(context)
 {
-    private UIButton? middleView;
+    private const float ButtonSize = 70f;
+    private const float ButtonPadding = 30f;
+    private const float BorderWidth = 4f;
+    private UIButton? _middleView;
 
     public override async void ViewDidLayoutSubviews()
     {
         base.ViewDidLayoutSubviews();
-        if (View is not null && ShellItem is CustomTabBar { CenterViewVisible: true } tabbar)
+        if (View is null || ShellItem is not CustomTabBar { CenterViewVisible: true } tabBar)
         {
-            if (middleView is not null)
-            {
-                middleView.RemoveFromSuperview();
-            }
-
-            if (middleView is null)
-            {
-                var context = tabbar.Window?.Page?.Handler?.MauiContext ?? Application.Current?.Windows.LastOrDefault()?.Page?.Handler?.MauiContext;
-                var image = await tabbar.CenterViewImageSource.GetPlatformImageAsync(context!);
-
-                middleView = new UIButton(UIButtonType.Custom);
-                middleView.BackgroundColor = tabbar.CenterViewBackgroundColor?.ToPlatform();
-                middleView.Frame = new CGRect(CGPoint.Empty, new CGSize(70, 70));
-                if (image is not null)
-                {
-                    middleView.SetImage(image.Value, UIControlState.Normal);
-                    middleView.Frame = new CGRect(CGPoint.Empty, image.Value.Size + new CGSize(30, 30));
-                }
-
-                middleView.AutoresizingMask = UIViewAutoresizing.FlexibleRightMargin |
-                                              UIViewAutoresizing.FlexibleLeftMargin |
-                                              UIViewAutoresizing.FlexibleBottomMargin;
-                middleView.Layer.CornerRadius = middleView.Frame.Width / 2;
-                middleView.Layer.BorderWidth = 4;
-                middleView.Layer.BorderColor = UIColor.White.CGColor;
-                middleView.Layer.MasksToBounds = false;
-
-                middleView.TouchUpInside += delegate
-                {
-                    tabbar.CenterView_Tapped();
-                };;
-            }
-
-            middleView.Center = new CGPoint(View.Bounds.GetMidX(), TabBar.Frame.Top + 4);
-
-            View.AddSubview(middleView);
+            return;
         }
+
+        _middleView?.RemoveFromSuperview();
+
+        if (_middleView is null)
+        {
+            var context = tabBar.Window?.Page?.Handler?.MauiContext ?? Application.Current?.Windows.LastOrDefault()?.Page?.Handler?.MauiContext;
+            var image = await tabBar.CenterViewImageSource.GetPlatformImageAsync(context!);
+
+            _middleView = new UIButton(UIButtonType.Custom);
+            _middleView.BackgroundColor = tabBar.CenterViewBackgroundColor?.ToPlatform();
+            _middleView.Frame = new CGRect(CGPoint.Empty, new CGSize(ButtonSize, ButtonSize));
+            if (image is not null)
+            {
+                _middleView.SetImage(image.Value, UIControlState.Normal);
+                _middleView.Frame = new CGRect(CGPoint.Empty, image.Value.Size + new CGSize(ButtonPadding, ButtonPadding));
+            }
+
+            _middleView.AutoresizingMask = UIViewAutoresizing.FlexibleRightMargin |
+                                           UIViewAutoresizing.FlexibleLeftMargin |
+                                           UIViewAutoresizing.FlexibleBottomMargin;
+            _middleView.Layer.CornerRadius = _middleView.Frame.Width / 2;
+            _middleView.Layer.BorderWidth = BorderWidth;
+            _middleView.Layer.BorderColor = UIColor.White.CGColor;
+            _middleView.Layer.MasksToBounds = false;
+
+            _middleView.TouchUpInside += delegate
+            {
+                tabBar.CenterView_Tapped();
+            };;
+        }
+
+        _middleView.Center = new CGPoint(View.Bounds.GetMidX(), TabBar.Frame.Top + BorderWidth);
+
+        View.AddSubview(_middleView);
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

There's an issue on Android where the scan button can appear different on different devices due to variations of pixel densities. This updates the button rendering to take screen density into account so it appears the same across devices.

Also cleans up the code, along with the iOS counterpart.

<img src="https://github.com/user-attachments/assets/6e53b611-c81a-469d-a58e-cc4d2215204d" width="400" />

**❌ Figure: Button appears too large on low-dpi display**


<img src="https://github.com/user-attachments/assets/356970c0-d92a-425e-8606-7e4a777851ac" width="400" />

**✅ Figure: Button now consistent across densities**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->