### PR TITLE
🐛 Mobile (Android) | Fix being able to navigate back after logout

### DIFF
--- a/src/MobileUI/Common/ExceptionHelper.cs
+++ b/src/MobileUI/Common/ExceptionHelper.cs
@@ -28,6 +28,6 @@ public static class ExceptionHandler
     private static async Task NavigateToLoginPage()
     {
         await App.Current.MainPage.DisplayAlert("Authentication Failure", "Your session has expired. Please log in again.", "OK");
-        await Application.Current.MainPage.Navigation.PushModalAsync<LoginPage>();
+        App.NavigateToLoginPage();
     }
 }

--- a/src/MobileUI/Features/App.xaml.cs
+++ b/src/MobileUI/Features/App.xaml.cs
@@ -8,7 +8,6 @@ public partial class App : Application
     private static IServiceProvider _provider;
     private static IAuthenticationService _authService;
     private static IFirstRunService _firstRunService;
-    public static object UIParent { get; set; }
 
     public App(LoginPage page, IServiceProvider serviceProvider, IAuthenticationService authService, IFirstRunService firstRunService)
     {
@@ -70,6 +69,11 @@ public partial class App : Application
     public static async Task InitialiseMainPage()
     {
         await _firstRunService.InitialiseAfterLogin();
+    }
+
+    public static void NavigateToLoginPage()
+    {
+        _authService.NavigateToLoginPage();
     }
 
     private async Task CheckApiCompatibilityAsync()

--- a/src/MobileUI/Features/Flyout/FlyoutFooterViewModel.cs
+++ b/src/MobileUI/Features/Flyout/FlyoutFooterViewModel.cs
@@ -48,7 +48,7 @@ public partial class FlyoutFooterViewModel : ObservableObject
         if (sure)
         {
             await _authService.SignOut();
-            await App.Current.MainPage.Navigation.PushModalAsync<LoginPage>();
+            App.NavigateToLoginPage();
         }
     }
 }

--- a/src/MobileUI/Features/Settings/DeleteProfilePage.xaml.cs
+++ b/src/MobileUI/Features/Settings/DeleteProfilePage.xaml.cs
@@ -67,7 +67,7 @@ public partial class DeleteProfilePage
             if (requestSubmitted)
             {
                 await App.Current.MainPage.DisplayAlert("Request Submitted", "Your request has been received and you will be contacted within 5 business days. You will now be logged out.", "OK");
-                await Application.Current.MainPage.Navigation.PushModalAsync<LoginPage>();
+                App.NavigateToLoginPage();
             }
             else
             {

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -17,7 +17,7 @@
 		<ApplicationIdGuid>fb3c30ce-ab0c-4155-b244-e49513e45a94</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>3.0.55</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>3.0.56</ApplicationDisplayVersion>
 		<ApplicationVersion>2</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>

--- a/src/MobileUI/Services/AuthenticationService.cs
+++ b/src/MobileUI/Services/AuthenticationService.cs
@@ -16,11 +16,13 @@ public interface IAuthenticationService
     bool HasCachedAccount { get; }
     bool IsLoggedIn { get; }
     event EventHandler DetailsUpdated;
+    void NavigateToLoginPage();
 }
 
 public class AuthenticationService : IAuthenticationService
 {
     private readonly OidcClientOptions _options;
+    private readonly IServiceProvider _provider;
 
     private string RefreshToken;
 
@@ -32,7 +34,7 @@ public class AuthenticationService : IAuthenticationService
     
     public bool IsLoggedIn { get => !string.IsNullOrWhiteSpace(_accessToken); }
 
-    public AuthenticationService(IBrowser browser)
+    public AuthenticationService(IBrowser browser, IServiceProvider provider)
     {
         _options = new OidcClientOptions
         {
@@ -42,6 +44,7 @@ public class AuthenticationService : IAuthenticationService
             RedirectUri = Constants.AuthRedirectUrl,
             Browser = browser,
         };
+        _provider = provider;
     }
 
     public async Task AutologinAsync(string accessToken)
@@ -263,6 +266,11 @@ public class AuthenticationService : IAuthenticationService
         }
 
         return false;
+    }
+
+    public void NavigateToLoginPage()
+    {
+        App.Current.MainPage = ActivatorUtilities.CreateInstance<LoginPage>(_provider);
     }
 
     private AuthResult GetAuthResult<TResult> (TResult result)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1295

> 2. What was changed?

There's a bug where if you sign out, on Android you can tap the back button and it will close the login page and allow you to interact with the app as normal. This is due to the previous behaviour simply pushing the login page as a modal on top of the current navigation stack. This change fixes that by replacing MainPage entirely by LoginPage whenever we're signing out.

Note: MainPage is being deprecated in .NET 9 so this will need to change again, but this should solve the issue for the time being.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->