### PR TITLE
♻️ Mobile | Improve performance of Redeem page

### DIFF
--- a/src/MobileUI/Controls/ListItem.xaml
+++ b/src/MobileUI/Controls/ListItem.xaml
@@ -21,8 +21,8 @@
     <Grid ColumnSpacing="12"
           ColumnDefinitions="Auto, *, Auto">
         <Border Grid.Column="0"
-                WidthRequest="64"
                 HeightRequest="64"
+                WidthRequest="64"
                 BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                 StrokeThickness="0"
                 StrokeShape="RoundRectangle 6">

--- a/src/MobileUI/Controls/ListItem.xaml
+++ b/src/MobileUI/Controls/ListItem.xaml
@@ -21,15 +21,17 @@
     <Grid ColumnSpacing="12"
           ColumnDefinitions="Auto, *, Auto">
         <Border Grid.Column="0"
-                HeightRequest="64"
-                WidthRequest="64"
                 BackgroundColor="{StaticResource FlyoutBackgroundColour}"
                 StrokeThickness="0"
+                WidthRequest="64"
+                HeightRequest="64"
                 StrokeShape="RoundRectangle 6">
             <Grid>
                 <Image HorizontalOptions="Center"
                        VerticalOptions="Center"
                        Aspect="AspectFill"
+                       WidthRequest="64"
+                       HeightRequest="64"
                        Source="{Binding ThumbnailImage, Source={x:Reference this}}"
                        IsVisible="{Binding ThumbnailImage, Source={x:Reference this}, Converter={StaticResource IsStringNotNullOrEmpty}}" />
                 <Label FontFamily="FA6Solid"

--- a/src/MobileUI/Controls/ListItem.xaml
+++ b/src/MobileUI/Controls/ListItem.xaml
@@ -21,10 +21,10 @@
     <Grid ColumnSpacing="12"
           ColumnDefinitions="Auto, *, Auto">
         <Border Grid.Column="0"
-                BackgroundColor="{StaticResource FlyoutBackgroundColour}"
-                StrokeThickness="0"
                 WidthRequest="64"
                 HeightRequest="64"
+                BackgroundColor="{StaticResource FlyoutBackgroundColour}"
+                StrokeThickness="0"
                 StrokeShape="RoundRectangle 6">
             <Grid>
                 <Image HorizontalOptions="Center"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1303 #1296

> 2. What was changed?

It seems the slowness on the Redeem page (particularly on Android) is due to very large thumbnails being uploaded for these prizes. The current prizes seem to be using the same image sizes for both the main image and the thumbnails when they shouldn't be (perhaps we could implement something in the future to auto generate thumbnails?).

Setting a WidthRequest and HeightRequest on the image works around this by not trying to render the full size and improves performance significantly. But we should still update the thumbnails in the Admin portal so we're not serving these full size images when we don't need to be.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->