### PR TITLE
♻️ API | Clear rankings cache on activation

### DIFF
--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -456,6 +456,8 @@ public class UserService : IUserService, IRolesService
         {
             user.Activated = true;
             await _dbContext.SaveChangesAsync(cancellationToken);
+
+            _cacheService.Remove(CacheTags.NewlyUserCreated);
         }
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing/bug reports

> 2. What was changed?

Clears the cache for rankings and leaderboard when a user is activated as the activation flag affects the rankings in GenerateRanking(). This may be causing crashes for newly created users as they could be trying to get their ranking from a cached list where they don't exist due to their user not being activated yet in the cache.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->