### PR TITLE
♻️ Mobile | Warn if camera permissions not enabled

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanPage.xaml
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml
@@ -29,76 +29,104 @@
                 Margin="15"
                 IsVisible="{Binding IsScanVisible}">
             <Grid>
-                <scanner:CameraView x:Name="ScannerView"
-                                    OnDetectionFinishedCommand="{Binding DetectionFinishedCommand}"
-                                    CameraEnabled="{Binding IsCameraEnabled}"
-                                    CurrentZoomFactor="{Binding CurrentZoomFactor, Mode=OneWayToSource}"
-                                    RequestZoomFactor="{Binding RequestZoomFactor}"
-                                    MinZoomFactor="{Binding MinZoomFactor, Mode=OneWayToSource}"
-                                    MaxZoomFactor="{Binding MaxZoomFactor, Mode=OneWayToSource}"
-                                    BarcodeSymbologies="QRCode"
-                                    ViewfinderMode="True"
-                                    TapToFocusEnabled="True"
-                                    VibrationOnDetected="False" />
-                <GraphicsView>
-                    <GraphicsView.Drawable>
-                        <controls:InvertedSquare
-                            SquareSize="200" 
-                            CornerRadius="15"
-                            BackgroundColor="Black"
-                            Opacity="0.5"/>
-                    </GraphicsView.Drawable>
-                </GraphicsView>
-                <Grid VerticalOptions="Center"
-                      HorizontalOptions="Center">
-                    <Image Source="qr_reticle"
-                           WidthRequest="400"/>
-                
-                    <Label Text="Scan QR Code"
-                           VerticalOptions="Start"
-                           VerticalTextAlignment="Center"
-                           HorizontalOptions="Center"
-                           HorizontalTextAlignment="Center"
+                <!-- Show warning if camera permissions not enabled -->
+                <VerticalStackLayout Grid.Row="0"
+                                     IsVisible="{Binding HasScanPermissions, Converter={toolkit:InvertedBoolConverter}}"
+                                     VerticalOptions="Center"
+                                     HorizontalOptions="Center"
+                                     Spacing="20"
+                                     Margin="20">
+                    <Image Source="camera_permission"
+                           HeightRequest="100"
+                           WidthRequest="100"
+                           HorizontalOptions="Center" />
+                    <Label Text="Camera Access Required"
                            Style="{StaticResource LabelBold}"
-                           FontSize="20"
-                           Margin="0,20"
-                           FontAutoScalingEnabled="False"/>
-                </Grid>
+                           FontSize="24"
+                           HorizontalOptions="Center" />
+                    <Label
+                        Text="This app needs camera access to scan QR codes. Please enable it in your device settings to continue."
+                        HorizontalTextAlignment="Center"
+                        FontSize="16" />
+                    <Button Text="Open Settings"
+                            Command="{Binding OpenSettingsCommand}"
+                            Margin="0,20,0,0"
+                            HorizontalOptions="Center" />
+                </VerticalStackLayout>
 
-                <Grid VerticalOptions="End"
-                      x:Name="ZoomButtons"
-                      ColumnDefinitions="Auto,Auto"
-                      HorizontalOptions="Center"
-                      IsVisible="{Binding MaxZoomFactor, Converter={StaticResource GreaterThanOne}}"
-                      ColumnSpacing="80"
-                      Margin="0,0,0,15">
-                    <Button Grid.Column="0"
-                            BorderWidth="0"
-                            BorderColor="White"
-                            Opacity="0.66"
-                            BackgroundColor="Transparent"
-                            Command="{Binding Path=ZoomOutCommand}">
-                        <Button.ImageSource>
-                            <FontImageSource Glyph="&#xf7b1;"
-                                             Size="40"
-                                             FontAutoScalingEnabled="False"
-                                             FontFamily="FluentIcons" />
-                        </Button.ImageSource>
-                    </Button>
+                <!-- Otherwise show all camera controls if permissions enabled -->
+                <Grid IsVisible="{Binding HasScanPermissions}">
+                    <scanner:CameraView x:Name="ScannerView"
+                                        OnDetectionFinishedCommand="{Binding DetectionFinishedCommand}"
+                                        CameraEnabled="{Binding IsCameraEnabled}"
+                                        CurrentZoomFactor="{Binding CurrentZoomFactor, Mode=OneWayToSource}"
+                                        RequestZoomFactor="{Binding RequestZoomFactor}"
+                                        MinZoomFactor="{Binding MinZoomFactor, Mode=OneWayToSource}"
+                                        MaxZoomFactor="{Binding MaxZoomFactor, Mode=OneWayToSource}"
+                                        BarcodeSymbologies="QRCode"
+                                        ViewfinderMode="True"
+                                        TapToFocusEnabled="True"
+                                        VibrationOnDetected="False" />
+                    <GraphicsView>
+                        <GraphicsView.Drawable>
+                            <controls:InvertedSquare
+                                SquareSize="200"
+                                CornerRadius="15"
+                                BackgroundColor="Black"
+                                Opacity="0.5" />
+                        </GraphicsView.Drawable>
+                    </GraphicsView>
+                    <Grid VerticalOptions="Center"
+                          HorizontalOptions="Center">
+                        <Image Source="qr_reticle"
+                               WidthRequest="400" />
 
-                    <Button Grid.Column="1"
-                            BorderWidth="0"
-                            BorderColor="White"
-                            Opacity="0.66"
-                            BackgroundColor="Transparent"
-                            Command="{Binding Path=ZoomInCommand}">
-                        <Button.ImageSource>
-                            <FontImageSource Glyph="&#xf10d;"
-                                             Size="40"
-                                             FontAutoScalingEnabled="False"
-                                             FontFamily="FluentIcons" />
-                        </Button.ImageSource>
-                    </Button>
+                        <Label Text="Scan QR Code"
+                               VerticalOptions="Start"
+                               VerticalTextAlignment="Center"
+                               HorizontalOptions="Center"
+                               HorizontalTextAlignment="Center"
+                               Style="{StaticResource LabelBold}"
+                               FontSize="20"
+                               Margin="0,20"
+                               FontAutoScalingEnabled="False" />
+                    </Grid>
+
+                    <Grid VerticalOptions="End"
+                          x:Name="ZoomButtons"
+                          ColumnDefinitions="Auto,Auto"
+                          HorizontalOptions="Center"
+                          IsVisible="{Binding MaxZoomFactor, Converter={StaticResource GreaterThanOne}}"
+                          ColumnSpacing="80"
+                          Margin="0,0,0,15">
+                        <Button Grid.Column="0"
+                                BorderWidth="0"
+                                BorderColor="White"
+                                Opacity="0.66"
+                                BackgroundColor="Transparent"
+                                Command="{Binding Path=ZoomOutCommand}">
+                            <Button.ImageSource>
+                                <FontImageSource Glyph="&#xf7b1;"
+                                                 Size="40"
+                                                 FontAutoScalingEnabled="False"
+                                                 FontFamily="FluentIcons" />
+                            </Button.ImageSource>
+                        </Button>
+
+                        <Button Grid.Column="1"
+                                BorderWidth="0"
+                                BorderColor="White"
+                                Opacity="0.66"
+                                BackgroundColor="Transparent"
+                                Command="{Binding Path=ZoomInCommand}">
+                            <Button.ImageSource>
+                                <FontImageSource Glyph="&#xf10d;"
+                                                 Size="40"
+                                                 FontAutoScalingEnabled="False"
+                                                 FontFamily="FluentIcons" />
+                            </Button.ImageSource>
+                        </Button>
+                    </Grid>
                 </Grid>
             </Grid>
         </Border>

--- a/src/MobileUI/Features/Scanner/ScanViewModel.cs
+++ b/src/MobileUI/Features/Scanner/ScanViewModel.cs
@@ -73,6 +73,9 @@ public partial class ScanViewModel : BaseViewModel, IRecipient<EnableScannerMess
     [ObservableProperty]
     private ImageSource _qrCode;
 
+    [ObservableProperty]
+    private bool _hasScanPermissions;
+
     public ScanViewModel(IUserService userService, ScanResultViewModel resultViewModel)
     {
         _resultViewModel = resultViewModel;
@@ -93,9 +96,9 @@ public partial class ScanViewModel : BaseViewModel, IRecipient<EnableScannerMess
     {
         WeakReferenceMessenger.Default.Register(this);
         
-        var hasPermissions = await Methods.AskForRequiredPermissionAsync();
+        HasScanPermissions = await Methods.AskForRequiredPermissionAsync();
 
-        if (hasPermissions && IsScanVisible)
+        if (HasScanPermissions && IsScanVisible)
         {
             IsCameraEnabled = true;
         }
@@ -207,5 +210,11 @@ public partial class ScanViewModel : BaseViewModel, IRecipient<EnableScannerMess
         var minZoom = MinZoomFactor;
         
         RequestZoomFactor = Math.Max(currentZoom - ZoomFactorStep, minZoom);
+    }
+    
+    [RelayCommand]
+    private static void OpenSettings()
+    {
+        AppInfo.Current.ShowSettingsUI();
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1305 

> 2. What was changed?

Displays a message if a user hasn't enabled camera permissions on the Scan page, with a button to direct them to settings in order to enable the permissions.

<img src="https://github.com/user-attachments/assets/216a8ad1-f799-493c-b8ef-092141102c35" width="400" />

**Figure: Warns if no permissions**


> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->