### PR TITLE
🐛 Mobile | Fix crash when camera permissions disabled

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanViewModel.cs
+++ b/src/MobileUI/Features/Scanner/ScanViewModel.cs
@@ -139,9 +139,9 @@ public partial class ScanViewModel : BaseViewModel, IRecipient<EnableScannerMess
     }
 
     [RelayCommand]
-    private void DetectionFinished(BarcodeResult[] result)
+    private void DetectionFinished(IReadOnlySet<BarcodeResult> result)
     {
-        if (!IsCameraEnabled || result.Length == 0)
+        if (!IsCameraEnabled || result.Count == 0)
         {
             return;
         }

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -63,7 +63,7 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BarcodeScanning.Native.Maui" Version="1.5.7" />
+		<PackageReference Include="BarcodeScanning.Native.Maui" Version="1.7.9" />
 		<PackageReference Include="Goldie.MauiPlugins.PageResolver" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
@@ -90,8 +90,8 @@
 
 	<ItemGroup Condition="$(TargetFramework.Contains('android'))">
         <GoogleServicesJson Include="Platforms/Android/google-services.json" />
-		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.7.1" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.4.0" />
+		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.6.1" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.7.0.1" />
         <PackageReference Include="Xamarin.Google.Dagger" Version="2.48.1.2" />
 	</ItemGroup>
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

There's a bug in the version of the barcode scanning library we're using where the scanner can crash if the user has manually disabled camera permissions in settings. This only seems reproducible on physical devices (simulator works okay).

This bug was fixesdin a later version (see https://github.com/afriscic/BarcodeScanning.Native.Maui/issues/133) so this PR bumps this version along with some other conflicting packages.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->