### PR TITLE
🐛 Admin/API | Fix prize draw date issues

### DIFF
--- a/src/AdminUI/AdminUI.csproj
+++ b/src/AdminUI/AdminUI.csproj
@@ -55,6 +55,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\ApiClient\ApiClient.csproj" />
+      <ProjectReference Include="..\Application\SSW.Rewards.Application.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -243,10 +243,13 @@ else
         {
             _loading = true;
 
+            var (dateFrom, dateTo) = GetDateRangeForFilter(_filter);
+
             var filter = new GetEligibleUsersFilter
             {
                 AchievementId = _selectedAchievement?.Id,
-                Filter = _filter,
+                DateFrom = dateFrom,
+                DateTo = dateTo,
                 FilterStaff = _excludeStaff,
                 Top = _top,
             };
@@ -361,6 +364,32 @@ else
         await _storage.ClearWinners();
         _previousWinners.Clear();
         SnackBar.Add("Previous winners cleared!", Severity.Success);
+    }
+
+    private static (DateTime? from, DateTime? to) GetDateRangeForFilter(LeaderboardFilter filter)
+    {
+        var now = DateTime.Now; // Client's local timezone
+
+        var (localFrom, localTo) = filter switch
+        {
+            LeaderboardFilter.Today => (now.Date, now.Date.AddDays(1).AddTicks(-1)),
+            LeaderboardFilter.ThisWeek => (now.Date.AddDays(-(int)now.DayOfWeek),
+                now.Date.AddDays(7 - (int)now.DayOfWeek).AddTicks(-1)),
+            LeaderboardFilter.ThisMonth => (new DateTime(now.Year, now.Month, 1),
+                new DateTime(now.Year, now.Month, 1).AddMonths(1).AddTicks(-1)),
+            LeaderboardFilter.ThisYear => (new DateTime(now.Year, 1, 1),
+                new DateTime(now.Year + 1, 1, 1).AddTicks(-1)),
+            LeaderboardFilter.Forever => (null, null),
+            _ => ((DateTime?)null, (DateTime?)null)
+        };
+
+        // Convert local times to UTC for server processing
+        if (localFrom.HasValue && localTo.HasValue)
+        {
+            return (localFrom.Value.ToUniversalTime(), localTo.Value.ToUniversalTime());
+        }
+
+        return (null, null);
     }
 
     private class Winner

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -9,7 +9,7 @@
 @using SSW.Rewards.ApiClient.Services
 @using SSW.Rewards.Application.Common.Interfaces
 
-@attribute [Authorize (Roles = "Admin")]
+@attribute [Authorize(Roles = "Admin")]
 
 @inject IAchievementService AchievementService
 @inject IPrizeDrawService PrizeDrawService
@@ -21,96 +21,100 @@
 
 <MudText Typo="Typo.h2">Prize Draw</MudText>
 
-@if (_loading)
-{
-    <MudProgressCircular Color="Color.Secondary" Indeterminate="true"/>
-}
-else
-{
-    <MudPaper Elevation="2" Class="pa-4 mb-4">
 
-        <MudGrid Spacing="2">
-            <MudItem xs="12" sm="6" md="4">
-                <MudAutocomplete
-                    T="AchievementDto"
-                    @bind-Value="@_selectedAchievement"
-                    Variant="Variant.Outlined"
-                    Margin="Margin.Dense"
-                    Dense="true"
-                    Label="Required Achievement"
-                    AnchorOrigin="Origin.BottomCenter"
-                    SearchFuncWithCancel="@SearchAchievements"
-                    ShowProgressIndicator="true"
-                    ToStringFunc="@GetAchievementName"
-                    FullWidth="true"
-                />
-            </MudItem>
+<MudPaper Elevation="2" Class="pa-4 mb-4">
+    <MudGrid Spacing="2">
+        <MudItem xs="12" sm="6" md="4">
+            <MudAutocomplete
+                T="AchievementDto"
+                @bind-Value="@_selectedAchievement"
+                Variant="Variant.Outlined"
+                Margin="Margin.Dense"
+                Dense="true"
+                Label="Required Achievement"
+                AnchorOrigin="Origin.BottomCenter"
+                SearchFuncWithCancel="@SearchAchievements"
+                ShowProgressIndicator="true"
+                ToStringFunc="@GetAchievementName"
+                FullWidth="true"
+            />
+        </MudItem>
 
-            <MudItem xs="12" sm="6" md="4">
-                <MudSelect
-                    T="LeaderboardFilter"
-                    @bind-Value="@_filter"
-                    Margin="Margin.Dense"
-                    Dense="true"
-                    Label="Players with Points Since"
-                    Variant="Variant.Outlined"
-                    AnchorOrigin="Origin.BottomCenter"
-                    FullWidth="true">
-                    @foreach (var when in Enum.GetValues<LeaderboardFilter>())
-                    {
-                        <MudSelectItem T="LeaderboardFilter" Value="@when">@when.ToString()</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudItem>
+        <MudItem xs="12" sm="6" md="4">
+            <MudSelect
+                T="LeaderboardFilter"
+                @bind-Value="@_filter"
+                Margin="Margin.Dense"
+                Dense="true"
+                Label="Players with Points Since"
+                Variant="Variant.Outlined"
+                AnchorOrigin="Origin.BottomCenter"
+                FullWidth="true">
+                @foreach (var when in Enum.GetValues<LeaderboardFilter>())
+                {
+                    <MudSelectItem T="LeaderboardFilter" Value="@when">@when.ToString()</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
 
-            <MudItem xs="12" sm="6" md="4">
-                <MudTextField
-                    Label="Leaderboard Top X"
-                    Variant="Variant.Outlined"
-                    Margin="Margin.Dense"
-                    Dense="true"
-                    Type="InputType.Number"
-                    @bind-Value="_top"
-                    FullWidth="true"/>
-            </MudItem>
+        <MudItem xs="12" sm="6" md="4">
+            <MudTextField
+                Label="Leaderboard Top X"
+                Variant="Variant.Outlined"
+                Margin="Margin.Dense"
+                Dense="true"
+                Type="InputType.Number"
+                @bind-Value="_top"
+                FullWidth="true"/>
+        </MudItem>
 
-            <MudItem xs="8">
-                <MudPaper Elevation="0" Class="d-flex flex-wrap gap-4">
-                    <MudCheckBox T="bool"
-                                 Color="Color.Primary"
-                                 Value="_excludeStaff"
-                                 Label="Exclude staff"
-                                 ValueChanged="(e) => _excludeStaff = e!"/>
-                    <MudCheckBox T="bool"
-                                 Color="Color.Primary"
-                                 Value="_excludePreviousWinners"
-                                 Label="Exclude previous winners"
-                                 ValueChanged="(e) => _excludePreviousWinners = e!"/>
-                </MudPaper>
-            </MudItem>
+        <MudItem xs="8">
+            <MudPaper Elevation="0" Class="d-flex flex-wrap gap-4">
+                <MudCheckBox T="bool"
+                             Color="Color.Primary"
+                             Value="_excludeStaff"
+                             Label="Exclude staff"
+                             ValueChanged="(e) => _excludeStaff = e!"/>
+                <MudCheckBox T="bool"
+                             Color="Color.Primary"
+                             Value="_excludePreviousWinners"
+                             Label="Exclude previous winners"
+                             ValueChanged="(e) => _excludePreviousWinners = e!"/>
+            </MudPaper>
+        </MudItem>
 
-            <MudItem xs="4" Class="d-flex justify-end">
-                <MudButton
-                    OnClick="@(async () => await LoadEligiblePlayers())"
-                    Variant="Variant.Filled"
-                    StartIcon="@MudBlazor.Icons.Material.Filled.Search"
-                    Size="Size.Medium"
-                    Color="Color.Primary">
-                    Get eligible winners
-                </MudButton>
-            </MudItem>
-        </MudGrid>
-    </MudPaper>
-    
-    <MudGrid>
-        <MudItem xs="12" sm="8">
+        <MudItem xs="4" Class="d-flex justify-end">
+            <MudButton
+                OnClick="@(async () => await LoadEligiblePlayers())"
+                Variant="Variant.Filled"
+                StartIcon="@MudBlazor.Icons.Material.Filled.Search"
+                Size="Size.Medium"
+                Color="Color.Primary">
+                Get eligible winners
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+</MudPaper>
+
+<MudGrid>
+    <MudItem xs="12" sm="8">
+        @if (_loading)
+        {
+            <MudGrid Justify="Justify.Center">
+                <MudItem>
+                    <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
+                </MudItem>
+            </MudGrid>
+        }
+        else
+        {
             <MudGrid Justify="Justify.Center">
                 <MudItem>
                     <MudText Typo="Typo.h5" Align="Align.Center">Eligible Players</MudText>
                     <MudText Align="Align.Center">Total: @(_players?.Count ?? 0)</MudText>
                 </MudItem>
             </MudGrid>
-            
+
             <MudGrid Spacing="2">
                 <MudItem>
                     <MudChipSet MultiSelection="false">
@@ -122,7 +126,7 @@ else
                                     Size="Size.Small"
                                     Variant="Variant.Text"
                                     Color="@_colors[player.index % _colors.Length]">@(player.p.Name)</MudChip>
-                            }   
+                            }
                         }
                     </MudChipSet>
                 </MudItem>
@@ -131,7 +135,7 @@ else
             @if (_isDrawingPrize)
             {
                 <MudDivider DividerType="DividerType.Middle" Class="my-12"/>
-            
+
                 <MudGrid Justify="Justify.Center">
                     <MudItem>
                         <MudText Align="Align.Center">
@@ -141,10 +145,10 @@ else
                             <MudProgressCircular Color="Color.Success" Indeterminate="true"/>
                         </MudText>
                     </MudItem>
-                </MudGrid>    
+                </MudGrid>
             }
-            
-            @if (_players is {Count: > 0 } && !_isDrawingPrize)
+
+            @if (_players is { Count: > 0 } && !_isDrawingPrize)
             {
                 <MudDivider DividerType="DividerType.Middle" Class="my-6"/>
 
@@ -159,49 +163,53 @@ else
                             Draw prize winner!
                         </MudButton>
                     </MudItem>
-                </MudGrid>    
+                </MudGrid>
             }
-        </MudItem>
+        }
 
-        <MudItem xs="12" sm="4">
-            <MudPaper Elevation="3" Class="pa-4 ml-2 mb-2">
-                <div class="d-flex justify-space-between align-center mb-2">
-                    <MudText Typo="Typo.h5">Previous Winners</MudText>
-                    @if (_previousWinners.Count > 0)
-                    {
-                        <MudButton
-                            StartIcon="@MudBlazor.Icons.Material.Filled.Clear"
-                            Color="Color.Error"
-                            Size="Size.Small"
-                            Variant="Variant.Outlined"
-                            OnClick="@(async () => await ClearPreviousWinners())">
-                            Clear
-                        </MudButton>
-                    }
-                </div>
-                <MudDivider Class="mb-3"/>
-                <div class="d-flex flex-column gap-2">
-                    @if (_previousWinners.Count > 0)
-                    {
-                        foreach (var winner in _previousWinners)
-                        {
-                            <div class="d-flex align-center pa-1 gap-2">
-                                <MudIcon Icon="@MudBlazor.Icons.Material.Filled.EmojiEvents" Color="Color.Success" Size="Size.Small"/>
-                                <MudText Typo="Typo.body1" Color="Color.Success">@winner.Name</MudText>
-                            </div>
-                        }
-                    } else
-                    {
-                        <MudText Typo="Typo.body2" Color="Color.Info" Class="pa-2 text-center">
-                            No previous winners recorded
-                        </MudText>
-                    }
-                </div>
-            </MudPaper>
-        </MudItem>
+    </MudItem>
 
-    </MudGrid>
-}
+    <MudItem xs="12" sm="4">
+        <MudPaper Elevation="3" Class="pa-4 ml-2 mb-2">
+            <div class="d-flex justify-space-between align-center mb-2">
+                <MudText Typo="Typo.h5">Previous Winners</MudText>
+                @if (_previousWinners.Count > 0)
+                {
+                    <MudButton
+                        StartIcon="@MudBlazor.Icons.Material.Filled.Clear"
+                        Color="Color.Error"
+                        Size="Size.Small"
+                        Variant="Variant.Outlined"
+                        OnClick="@(async () => await ClearPreviousWinners())">
+                        Clear
+                    </MudButton>
+                }
+            </div>
+            <MudDivider Class="mb-3"/>
+            <div class="d-flex flex-column gap-2">
+                @if (_previousWinners.Count > 0)
+                {
+                    foreach (var winner in _previousWinners)
+                    {
+                        <div class="d-flex align-center pa-1 gap-2">
+                            <MudIcon Icon="@MudBlazor.Icons.Material.Filled.EmojiEvents" Color="Color.Success"
+                                     Size="Size.Small"/>
+                            <MudText Typo="Typo.body1" Color="Color.Success">@winner.Name</MudText>
+                        </div>
+                    }
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Info" Class="pa-2 text-center">
+                        No previous winners recorded
+                    </MudText>
+                }
+            </div>
+        </MudPaper>
+    </MudItem>
+
+</MudGrid>
+
 
 @code {
     private readonly Color[] _colors = { Color.Primary, Color.Secondary, Color.Tertiary, Color.Info, Color.Warning, Color.Success, Color.Error };
@@ -274,13 +282,13 @@ else
             exception.Redirect();
         }
     }
-    
+
     private async Task DrawPrizeWinner()
     {
         _isDrawingPrize = true;
         await InvokeAsync(StateHasChanged);
         await Task.Delay(PrizeDrawSuspenseDelay);
-        
+
         var eligiblePlayers = _players?.ToList() ?? [];
 
         if (!eligiblePlayers.Any())
@@ -293,7 +301,7 @@ else
         Random rand = new();
         var winner = eligiblePlayers.ElementAt(rand.Next(eligiblePlayers.Count()));
         _isDrawingPrize = false;
-        
+
         var parameters = new DialogParameters
         {
             ["Winner"] = winner,
@@ -302,7 +310,7 @@ else
             ["OnSkipWinner"] = EventCallback.Factory.Create<EligibleUserDto>(this,
                 async user => await SkipWinner(user))
         };
-        
+
         var options = new DialogOptions
         {
             CloseOnEscapeKey = false,
@@ -310,7 +318,7 @@ else
             MaxWidth = MaxWidth.Medium,
             FullWidth = true
         };
-        
+
         var dialog = await DialogService.ShowAsync<WinnerDialog>("Prize Winner!", parameters, options);
         await dialog.Result;
     }
@@ -318,7 +326,7 @@ else
     private async Task ClaimPrizeForWinner(EligibleUserDto winner, RewardDto reward)
     {
         var result = await RewardAdminService.ClaimForUser(reward.Code, winner.UserId ?? 0, false, CancellationToken.None);
-    
+
         if (result.status == RewardStatus.Claimed)
         {
             if (winner.UserId != null)
@@ -326,12 +334,9 @@ else
                 await _storage.SaveWinner(winner.UserId.ToString(), winner.Name ?? string.Empty);
                 await LoadPreviousWinners();
             }
-    
-            SnackBar.Add($"{reward.Name} successfully claimed for {winner.Name}!", Severity.Success, options =>
-            {
-                options.VisibleStateDuration = 10000;
-            });
-    
+
+            SnackBar.Add($"{reward.Name} successfully claimed for {winner.Name}!", Severity.Success, options => { options.VisibleStateDuration = 10000; });
+
             _players?.RemoveAll(p => p.UserId == winner.UserId);
         }
         else
@@ -339,11 +344,11 @@ else
             SnackBar.Add($"Could not claim reward!\n\n{result.status}", Severity.Error);
         }
     }
-    
+
     private async Task SkipWinner(EligibleUserDto winner)
     {
         _players?.RemoveAll(p => p.UserId == winner.UserId);
-        
+
         // Only auto-draw another winner if there are still players left
         if (_players?.Count > 0)
         {
@@ -398,21 +403,21 @@ else
         public string Id { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
     }
-    
+
     private class SessionStorage(IJSRuntime jsRuntime)
     {
         private const string PreviousWinnersKey = "ssw-rewards-previous-winners";
-    
+
         public async Task<List<Winner>> LoadWinners()
         {
             var winnersJson = await jsRuntime.InvokeAsync<string>("sessionStorage.getItem", PreviousWinnersKey);
             if (string.IsNullOrEmpty(winnersJson))
                 return [];
-    
+
             var winners = System.Text.Json.JsonSerializer.Deserialize<List<Winner>>(winnersJson);
             return winners ?? [];
         }
-    
+
         public async Task SaveWinner(string userId, string name)
         {
             var winners = await LoadWinners();
@@ -426,4 +431,5 @@ else
             await jsRuntime.InvokeVoidAsync("sessionStorage.removeItem", PreviousWinnersKey);
         }
     }
+
 }

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -7,16 +7,17 @@
 @using SSW.Rewards.Shared.DTOs.PrizeDraw
 @using SSW.Rewards.Shared.DTOs.Rewards
 @using SSW.Rewards.ApiClient.Services
+@using SSW.Rewards.Application.Common.Interfaces
 
 @attribute [Authorize (Roles = "Admin")]
 
 @inject IAchievementService AchievementService
 @inject IPrizeDrawService PrizeDrawService
-@inject IRewardService RewardService
 @inject IRewardAdminService RewardAdminService
 @inject ISnackbar SnackBar
 @inject IJSRuntime JsRuntime
 @inject IDialogService DialogService
+@inject IDateTime DateTimeService
 
 <MudText Typo="Typo.h2">Prize Draw</MudText>
 
@@ -366,9 +367,9 @@ else
         SnackBar.Add("Previous winners cleared!", Severity.Success);
     }
 
-    private static (DateTime? from, DateTime? to) GetDateRangeForFilter(LeaderboardFilter filter)
+    private (DateTime? from, DateTime? to) GetDateRangeForFilter(LeaderboardFilter filter)
     {
-        var now = DateTime.Now; // Client's local timezone
+        var now = DateTimeService.Now; // Client's local timezone
 
         var (localFrom, localTo) = filter switch
         {

--- a/src/AdminUI/Program.cs
+++ b/src/AdminUI/Program.cs
@@ -2,7 +2,9 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor;
 using MudBlazor.Services;
+using SSW.Rewards.Admin.UI.Services;
 using SSW.Rewards.ApiClient;
+using SSW.Rewards.Application.Common.Interfaces;
 
 namespace SSW.Rewards.Admin.UI;
 
@@ -16,6 +18,8 @@ public class Program
 
         // MessageHandler for adding the JWT to outbound requests to the API
         builder.Services.AddTransient<CustomAuthorizationMessageHandler>();
+
+        builder.Services.AddTransient<IDateTime, DateTimeService>();
 
         string? identityUrl = builder.Configuration["Local:Authority"];
         if (identityUrl == null)

--- a/src/AdminUI/Services/DateTimeService.cs
+++ b/src/AdminUI/Services/DateTimeService.cs
@@ -1,0 +1,9 @@
+using SSW.Rewards.Application.Common.Interfaces;
+
+namespace SSW.Rewards.Admin.UI.Services;
+
+public class DateTimeService : IDateTime
+{
+    public DateTime Now => DateTime.Now;
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/src/ApiClient/Services/ILeaderboardService.cs
+++ b/src/ApiClient/Services/ILeaderboardService.cs
@@ -8,7 +8,6 @@ public interface ILeaderboardService
 {
     Task<LeaderboardViewModel> GetLeaderboard(CancellationToken cancellationToken);
     Task<LeaderboardViewModel> GetPaginatedLeaderboard(int take, int skip, LeaderboardFilter currentPeriod, CancellationToken cancellationToken);
-    Task<LeaderboardViewModel> GetLeaderboard(LeaderboardFilter filter, CancellationToken cancellationToken);
     Task<MobileLeaderboardViewModel> GetMobilePaginatedLeaderboard(int page, int pageSize, LeaderboardFilter currentPeriod, CancellationToken cancellationToken);
 }
 
@@ -62,24 +61,6 @@ public class LeaderboardService : ILeaderboardService
         var result = await _httpClient.GetAsync($"{_baseRoute}GetPaginated?skip={skip}&take={take}&currentPeriod={currentPeriod}", cancellationToken);
 
         if (result.IsSuccessStatusCode)
-        {
-            var response = await result.Content.ReadFromJsonAsync<LeaderboardViewModel>(cancellationToken: cancellationToken);
-
-            if (response is not null)
-            {
-                return response;
-            }
-        }
-
-        var responseContent = await result.Content.ReadAsStringAsync(cancellationToken);
-        throw new Exception($"Failed to get leaderboard: {responseContent}");
-    }
-
-    public async Task<LeaderboardViewModel> GetLeaderboard(LeaderboardFilter filter, CancellationToken cancellationToken)
-    {
-        var result = await _httpClient.GetAsync($"{_baseRoute}GetEligibleUsers?filter={filter}", cancellationToken);
-
-        if  (result.IsSuccessStatusCode)
         {
             var response = await result.Content.ReadFromJsonAsync<LeaderboardViewModel>(cancellationToken: cancellationToken);
 

--- a/src/ApiClient/Services/IPrizeDrawService.cs
+++ b/src/ApiClient/Services/IPrizeDrawService.cs
@@ -22,7 +22,25 @@ public class PrizeDrawService : IPrizeDrawService
 
     public async Task<EligibleUsersViewModel> GetEligibleUsers(GetEligibleUsersFilter filter, CancellationToken cancellationToken)
     {
-        var result = await _httpClient.GetAsync($"{_baseRoute}GetEligibleUsers?filter={filter.Filter}&achievementId={filter.AchievementId}&filterStaff={filter.FilterStaff}&top={filter.Top}", cancellationToken);
+        var queryParams = new List<string>();
+        
+        if (filter.AchievementId.HasValue)
+            queryParams.Add($"achievementId={filter.AchievementId}");
+            
+        if (filter.FilterStaff.HasValue)
+            queryParams.Add($"filterStaff={filter.FilterStaff.Value}");
+            
+        if (filter.Top > 0)
+            queryParams.Add($"top={filter.Top}");
+            
+        if (filter.DateFrom.HasValue)
+            queryParams.Add($"dateFrom={filter.DateFrom.Value:yyyy-MM-ddTHH:mm:ss.fffZ}");
+            
+        if (filter.DateTo.HasValue)
+            queryParams.Add($"dateTo={filter.DateTo.Value:yyyy-MM-ddTHH:mm:ss.fffZ}");
+
+        var queryString = queryParams.Count > 0 ? "?" + string.Join("&", queryParams) : "";
+        var result = await _httpClient.GetAsync($"{_baseRoute}GetEligibleUsers{queryString}", cancellationToken);
 
         if (result.IsSuccessStatusCode)
         {

--- a/src/ApiClient/Services/IPrizeDrawService.cs
+++ b/src/ApiClient/Services/IPrizeDrawService.cs
@@ -22,24 +22,12 @@ public class PrizeDrawService : IPrizeDrawService
 
     public async Task<EligibleUsersViewModel> GetEligibleUsers(GetEligibleUsersFilter filter, CancellationToken cancellationToken)
     {
-        var queryParams = new List<string>();
-        
-        if (filter.AchievementId.HasValue)
-            queryParams.Add($"achievementId={filter.AchievementId}");
-            
-        if (filter.FilterStaff.HasValue)
-            queryParams.Add($"filterStaff={filter.FilterStaff.Value}");
-            
-        if (filter.Top > 0)
-            queryParams.Add($"top={filter.Top}");
-            
-        if (filter.DateFrom.HasValue)
-            queryParams.Add($"dateFrom={filter.DateFrom.Value:yyyy-MM-ddTHH:mm:ss.fffZ}");
-            
-        if (filter.DateTo.HasValue)
-            queryParams.Add($"dateTo={filter.DateTo.Value:yyyy-MM-ddTHH:mm:ss.fffZ}");
+        var queryString = $"?achievementId={filter.AchievementId}" +
+                          $"&filterStaff={filter.FilterStaff}" +
+                          $"&top={filter.Top}" +
+                          $"&dateFrom={filter.DateFrom:yyyy-MM-ddTHH:mm:ss.fffZ}" +
+                          $"&dateTo={filter.DateTo:yyyy-MM-ddTHH:mm:ss.fffZ}";
 
-        var queryString = queryParams.Count > 0 ? "?" + string.Join("&", queryParams) : "";
         var result = await _httpClient.GetAsync($"{_baseRoute}GetEligibleUsers{queryString}", cancellationToken);
 
         if (result.IsSuccessStatusCode)

--- a/src/Application/Achievements/Command/ClaimSocialMediaAchievementForUser/ClaimSocialMediaAchievementForUserCommand.cs
+++ b/src/Application/Achievements/Command/ClaimSocialMediaAchievementForUser/ClaimSocialMediaAchievementForUserCommand.cs
@@ -50,8 +50,8 @@ public sealed class ClaimSocialMediaAchievementForUserCommandHandler : IRequestH
             {
                 Achievement = achievement,
                 User        = user,
-                AwardedAt   = _dateTimeService.Now,
-                CreatedUtc  = _dateTimeService.Now
+                AwardedAt   = _dateTimeService.UtcNow,
+                CreatedUtc  = _dateTimeService.UtcNow
             };
             _context.UserAchievements.Add(userAchievement);
             await _context.SaveChangesAsync(cancellationToken);

--- a/src/Application/Rewards/Commands/ClaimRewardForUser/ClaimRewardForUserCommand.cs
+++ b/src/Application/Rewards/Commands/ClaimRewardForUser/ClaimRewardForUserCommand.cs
@@ -133,7 +133,7 @@ public class ClaimRewardForUserCommandHandler : IRequestHandler<ClaimRewardForUs
                  {
                      UserId = user.Id,
                      RewardId = reward.Id,
-                     AwardedAt = _dateTime.Now,
+                     AwardedAt = _dateTime.UtcNow,
                  });
 
             if (pendingRedemption != null)

--- a/src/Application/Rewards/Commands/CreatePendingRedemption/CreatePendingRedemptionCommand.cs
+++ b/src/Application/Rewards/Commands/CreatePendingRedemption/CreatePendingRedemptionCommand.cs
@@ -96,7 +96,7 @@ public class CreatePendingRedemptionCommandHandler : IRequestHandler<CreatePendi
                 user.PendingRedemptions.Add(new PendingRedemption
                 {
                     Code = code,
-                    ClaimedAt = _dateTime.Now,
+                    ClaimedAt = _dateTime.UtcNow,
                     RewardId = reward.Id,
                     UserId = user.Id
                 });

--- a/src/Application/Skills/Commands/UpsertSkill/UpsertSkillCommand.cs
+++ b/src/Application/Skills/Commands/UpsertSkill/UpsertSkillCommand.cs
@@ -40,7 +40,7 @@ public class UpsertSkillCommandHandler : IRequestHandler<UpsertSkillCommand, int
             {
                 Name = request.Skill,
                 ImageUri = imageUri?.AbsoluteUri,
-                CreatedUtc = _dateTime.Now
+                CreatedUtc = _dateTime.UtcNow
             };
 
             _context.Skills.Add(found);

--- a/src/Application/Users/Commands/UpsertUserSocialMediaId/UpsertUserSocialMediaIdCommand.cs
+++ b/src/Application/Users/Commands/UpsertUserSocialMediaId/UpsertUserSocialMediaIdCommand.cs
@@ -52,7 +52,7 @@ public sealed class UpsertSocialMediaUserIdHandler : IRequestHandler<UpsertUserS
                 SocialMediaPlatformId = platform.Id,
                 UserId                = currentUserId,
                 SocialMediaUserId     = socialMediaUrl,
-                CreatedUtc            = _dateTimeService.Now
+                CreatedUtc            = _dateTimeService.UtcNow
             };
             _context.UserSocialMediaIds.Add(record);
         }

--- a/src/Common/DTOs/PrizeDraw/EligibleUsersViewModel.cs
+++ b/src/Common/DTOs/PrizeDraw/EligibleUsersViewModel.cs
@@ -2,7 +2,7 @@
 
 public class EligibleUsersViewModel
 {
-    public int AchievementId { get; set; }
+    public int? AchievementId { get; set; }
     public string AchievementName { get; set; } = string.Empty;
     public IEnumerable<EligibleUserDto> EligibleUsers { get; set; } = new List<EligibleUserDto>();
 }

--- a/src/Common/DTOs/PrizeDraw/GetEligibleUsersFilter.cs
+++ b/src/Common/DTOs/PrizeDraw/GetEligibleUsersFilter.cs
@@ -4,7 +4,8 @@ namespace SSW.Rewards.Shared.DTOs.PrizeDraw;
 public class GetEligibleUsersFilter
 {
     public int? AchievementId { get; set; }
-    public LeaderboardFilter? Filter { get; set; }
+    public DateTime? DateFrom { get; set; }
+    public DateTime? DateTo { get; set; }
     public bool? FilterStaff { get; set; }
     public int Top { get; set; }
 }

--- a/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
@@ -41,13 +41,13 @@ public class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
             if (entry.State == EntityState.Added)
             {
                 entry.Entity.CreatedBy = _currentUserService.GetUserId();
-                entry.Entity.Created = _dateTime.Now;
+                entry.Entity.Created = _dateTime.UtcNow;
             }
 
             if (entry.State == EntityState.Added || entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
             {
                 entry.Entity.LastModifiedBy = _currentUserService.GetUserId();
-                entry.Entity.LastModified = _dateTime.Now;
+                entry.Entity.LastModified = _dateTime.UtcNow;
             }
         }
 
@@ -58,7 +58,7 @@ public class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
         {
             if (entry.State == EntityState.Added)
             {
-                entry.Entity.CreatedUtc = _dateTime.Now;
+                entry.Entity.CreatedUtc = _dateTime.UtcNow;
             }
         }
     }

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -39,7 +39,7 @@ public class LeaderboardController : ApiControllerBase
         }));
     }
 
-    [HttpGet("GetEligibleUsers")]
+    [HttpGet]
     public async Task<ActionResult<EligibleUsersViewModel>> GetEligibleUsers(
         int? achievementId = null,
         bool filterStaff = false, 

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -39,16 +39,24 @@ public class LeaderboardController : ApiControllerBase
         }));
     }
 
-    [HttpGet]
-    public async Task<ActionResult<EligibleUsersViewModel>> GetEligibleUsers([FromQuery] int achievementId, LeaderboardFilter filter, bool filterStaff, int top)
+    [HttpGet("GetEligibleUsers")]
+    public async Task<ActionResult<EligibleUsersViewModel>> GetEligibleUsers(
+        int? achievementId = null,
+        bool filterStaff = false, 
+        int top = 0,
+        DateTime? dateFrom = null,
+        DateTime? dateTo = null)
     {
-        var getEligibleUsers = new GetEligibleUsers
+        var request = new GetEligibleUsers
         {
             AchievementId = achievementId,
-            Filter = filter,
             FilterStaff = filterStaff,
-            Top = top
+            Top = top,
+            DateFrom = dateFrom,
+            DateTo = dateTo
         };
-        return Ok(await Mediator.Send(getEligibleUsers));
+
+        var result = await Mediator.Send(request);
+        return Ok(result);
     }
 }

--- a/src/WebAPI/Controllers/LeaderboardController.cs
+++ b/src/WebAPI/Controllers/LeaderboardController.cs
@@ -41,11 +41,11 @@ public class LeaderboardController : ApiControllerBase
 
     [HttpGet]
     public async Task<ActionResult<EligibleUsersViewModel>> GetEligibleUsers(
-        int? achievementId = null,
-        bool filterStaff = false, 
-        int top = 0,
-        DateTime? dateFrom = null,
-        DateTime? dateTo = null)
+        [FromQuery] int? achievementId = null,
+        [FromQuery] bool filterStaff = false,
+        [FromQuery] int top = 0,
+        [FromQuery] DateTime? dateFrom = null,
+        [FromQuery] DateTime? dateTo = null)
     {
         var request = new GetEligibleUsers
         {
@@ -56,7 +56,6 @@ public class LeaderboardController : ApiControllerBase
             DateTo = dateTo
         };
 
-        var result = await Mediator.Send(request);
-        return Ok(result);
+        return Ok(await Mediator.Send(request));
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1182 

> 2. What was changed?

The Today filter (and other filters) can be incorrect due to differences between the dates being stored in the DB (which should be UTC, but can vary) and the user's local time, where "today" would be a different time range. This PR:
1. Updates the prize draw filter to accept a date range that's converted from local time to UTC time, and updates the endpoint to work on these ranges instead.
2. Updates other uses in the code that's setting DateTime.Now rather than DateTime.UtcNow so the data going forward should be more consistent.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->