### PR TITLE
♻️ Admin | Prize draw page improvements

### DIFF
--- a/.github/workflows/api-main.yml
+++ b/.github/workflows/api-main.yml
@@ -17,7 +17,7 @@ jobs:
       RESOURCE_GROUP: SSW.Rewards.Staging
       APP_SERVICE_PLAN: plan-ssw-shared-dev
       APP_SERVICE_PLAN_RESOURCE_GROUP: SSW.AppServicePlans
-      ADMIN_PORTAL_URL: https://stsswrewardsadminstaging.z8.web.core.windows.net
+      ADMIN_PORTAL_URL: https://staging.rewards.ssw.com.au
       IDS_URL: https://app-ssw-ident-staging-api.azurewebsites.net
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/src/AdminUI/Components/LoadingDialog.razor
+++ b/src/AdminUI/Components/LoadingDialog.razor
@@ -1,0 +1,15 @@
+@* LoadingDialog.razor *@
+<MudDialog>
+    <DialogContent>
+        <div class="d-flex flex-column align-center pa-8">
+            <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
+            <MudText Typo="Typo.h6" Class="mt-4" Align="Align.Center">
+                @LoadingText
+            </MudText>
+        </div>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [Parameter] public string LoadingText { get; set; } = "Loading...";
+}

--- a/src/AdminUI/Components/WinnerDialog.razor
+++ b/src/AdminUI/Components/WinnerDialog.razor
@@ -46,6 +46,7 @@
     <DialogActions>
         <MudButton Variant="Variant.Outlined"
                    Color="Color.Warning"
+                   StartIcon="@Icons.Material.Filled.SkipNext"
                    OnClick="SkipCurrentWinner"
                    Disabled="@_isSkipping">
             <span>Skip Winner</span>

--- a/src/AdminUI/Components/WinnerDialog.razor
+++ b/src/AdminUI/Components/WinnerDialog.razor
@@ -1,4 +1,3 @@
-@using Microsoft.AspNetCore.Components
 @using SSW.Rewards.Shared.DTOs.PrizeDraw
 @using SSW.Rewards.Shared.DTOs.Rewards
 @using SSW.Rewards.ApiClient.Services
@@ -7,10 +6,16 @@
 
 <MudDialog>
     <TitleContent>
-        <MudText Typo="Typo.h6">
-            <MudIcon Icon="@MudBlazor.Icons.Material.Filled.EmojiEvents" Class="mr-2" />
-            @Title
-        </MudText>
+        <div class="d-flex justify-space-between align-center">
+            <MudText Typo="Typo.h6">
+                <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Class="mr-2" />
+                @Title
+            </MudText>
+            <MudIconButton Icon="@Icons.Material.Filled.Close"
+                           Color="Color.Inherit"
+                           OnClick="CloseDialog"
+                           Size="Size.Medium" />
+        </div>
     </TitleContent>
     <DialogContent>
         <MudContainer Style="max-height: 500px; overflow-y: auto">
@@ -41,23 +46,14 @@
     <DialogActions>
         <MudButton Variant="Variant.Outlined"
                    Color="Color.Warning"
-                   StartIcon="@(_isSkipping ? null : MudBlazor.Icons.Material.Filled.SkipNext)"
                    OnClick="SkipCurrentWinner"
                    Disabled="@_isSkipping">
-            @if (_isSkipping)
-            {
-                <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true" />
-                <span class="ms-2">Skipping...</span>
-            }
-            else
-            {
-                <span>Skip Winner</span>
-            }
+            <span>Skip Winner</span>
         </MudButton>
         <MudButton Variant="Variant.Filled"
                    Color="Color.Success"
                    Disabled="@(_selectedReward == null || _isSkipping)"
-                   StartIcon="@MudBlazor.Icons.Material.Filled.Celebration"
+                   StartIcon="@Icons.Material.Filled.Celebration"
                    OnClick="ClaimPrize">
             Claim Prize
         </MudButton>
@@ -73,7 +69,7 @@
     [Parameter] public EventCallback<EligibleUserDto> OnSkipWinner { get; set; }
     
     private RewardDto? _selectedReward;
-    private bool _isSkipping = false;
+    private bool _isSkipping;
     
     private async Task<IEnumerable<RewardDto>> SearchRewards(string value, CancellationToken cancellationToken)
     {
@@ -98,9 +94,14 @@
         {
             _isSkipping = true;
             await InvokeAsync(StateHasChanged);
-            
-            await OnSkipWinner.InvokeAsync(Winner);
+
             MudDialog.Close();
+            await OnSkipWinner.InvokeAsync(Winner);
         }
+    }
+
+    private void CloseDialog()
+    {
+        MudDialog.Close();
     }
 }

--- a/src/AdminUI/Models/Winner.cs
+++ b/src/AdminUI/Models/Winner.cs
@@ -1,0 +1,7 @@
+namespace SSW.Rewards.Admin.UI.Models;
+
+public class Winner
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -2,6 +2,8 @@
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using SSW.Rewards.Admin.UI.Components
+@using SSW.Rewards.Admin.UI.Models
+@using SSW.Rewards.Admin.UI.Services
 @using SSW.Rewards.Enums
 @using SSW.Rewards.Shared.DTOs.Achievements
 @using SSW.Rewards.Shared.DTOs.PrizeDraw
@@ -12,10 +14,10 @@
 @attribute [Authorize(Roles = "Admin")]
 
 @inject IAchievementService AchievementService
-@inject IPrizeDrawService PrizeDrawService
+@inject IPrizeDrawManager PrizeDrawManager
 @inject IRewardAdminService RewardAdminService
+@inject IWinnerStorageService WinnerStorageService
 @inject ISnackbar SnackBar
-@inject IJSRuntime JsRuntime
 @inject IDialogService DialogService
 @inject IDateTime DateTimeService
 
@@ -58,12 +60,12 @@
         </MudItem>
 
         <MudItem xs="12" sm="6" md="4">
-            <MudTextField
+            <MudNumericField
                 Label="Leaderboard Top X (Optional)"
                 Variant="Variant.Outlined"
                 Margin="Margin.Dense"
                 Dense="true"
-                Type="InputType.Number"
+                Min="1"
                 Clearable="true"
                 @bind-Value="_top"
                 FullWidth="true"/>
@@ -73,24 +75,27 @@
             <MudPaper Elevation="0" Class="d-flex flex-wrap gap-4">
                 <MudCheckBox T="bool"
                              Color="Color.Primary"
-                             Value="_excludeStaff"
-                             Label="Exclude staff"
-                             ValueChanged="(e) => _excludeStaff = e!"/>
+                             @bind-Value="_excludeStaff"
+                             Label="Exclude staff"/>
                 <MudCheckBox T="bool"
                              Color="Color.Primary"
-                             Value="_excludePreviousWinners"
-                             Label="Exclude previous winners"
-                             ValueChanged="(e) => _excludePreviousWinners = e!"/>
+                             @bind-Value="_excludePreviousWinners"
+                             Label="Exclude previous winners"/>
             </MudPaper>
         </MudItem>
 
         <MudItem xs="4" Class="d-flex justify-end">
             <MudButton
-                OnClick="@(async () => await LoadEligiblePlayers())"
+                OnClick="@LoadEligiblePlayersAsync"
                 Variant="Variant.Filled"
                 StartIcon="@MudBlazor.Icons.Material.Filled.Search"
                 Size="Size.Medium"
-                Color="Color.Primary">
+                Color="Color.Primary"
+                Disabled="@_loading">
+                @if (_loading)
+                {
+                    <MudProgressCircular Class="mr-2" Size="Size.Small" Indeterminate="true"/>
+                }
                 Get eligible winners
             </MudButton>
         </MudItem>
@@ -107,12 +112,19 @@
                 </MudItem>
             </MudGrid>
         }
+        else if (_errorMessage != null)
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-4">
+                @_errorMessage
+                <MudButton Class="ml-2" Size="Size.Small" OnClick="ClearError">Dismiss</MudButton>
+            </MudAlert>
+        }
         else
         {
             <MudGrid Justify="Justify.Center">
                 <MudItem>
                     <MudText Typo="Typo.h5" Align="Align.Center">Eligible Players</MudText>
-                    <MudText Align="Align.Center">Total: @(_players?.Count ?? 0)</MudText>
+                    <MudText Align="Align.Center">@EligiblePlayersCountText</MudText>
                 </MudItem>
             </MudGrid>
 
@@ -133,25 +145,25 @@
                 </MudItem>
             </MudGrid>
 
-            @if (_players is { Count: > 0 } && !_isDrawingPrize)
+            @if (HasEligiblePlayers)
             {
                 <MudDivider DividerType="DividerType.Middle" Class="my-6"/>
 
                 <MudGrid Spacing="2" Justify="Justify.Center">
                     <MudItem>
                         <MudButton
-                            OnClick="DrawPrizeWinner"
+                            OnClick="DrawPrizeWinnerAsync"
                             Variant="Variant.Filled"
                             StartIcon="@MudBlazor.Icons.Material.Filled.Celebration"
                             Color="Color.Primary"
-                            Style="width: 400px; height: 60px;">
+                            Style="width: 400px; height: 60px;"
+                            Disabled="@(!CanDrawPrize)">
                             Draw prize winner!
                         </MudButton>
                     </MudItem>
                 </MudGrid>
             }
         }
-
     </MudItem>
 
     <MudItem xs="12" sm="4">
@@ -165,7 +177,7 @@
                         Color="Color.Error"
                         Size="Size.Small"
                         Variant="Variant.Outlined"
-                        OnClick="@(async () => await ClearPreviousWinners())">
+                        OnClick="@ClearPreviousWinnersAsync">
                         Clear
                     </MudButton>
                 }
@@ -177,8 +189,7 @@
                     foreach (var winner in _previousWinners)
                     {
                         <div class="d-flex align-center pa-1 gap-2">
-                            <MudIcon Icon="@MudBlazor.Icons.Material.Filled.EmojiEvents" Color="Color.Success"
-                                     Size="Size.Small"/>
+                            <MudIcon Icon="@MudBlazor.Icons.Material.Filled.EmojiEvents" Color="Color.Success" Size="Size.Small"/>
                             <MudText Typo="Typo.body1" Color="Color.Success">@winner.Name</MudText>
                         </div>
                     }
@@ -192,51 +203,68 @@
             </div>
         </MudPaper>
     </MudItem>
-
 </MudGrid>
 
 @code {
-    private readonly Color[] _colors = { Color.Primary, Color.Secondary, Color.Tertiary, Color.Info, Color.Warning, Color.Success, Color.Error };
-    private SessionStorage _storage;
-
+    private readonly Color[] _colors = [Color.Primary, Color.Secondary, Color.Tertiary, Color.Info, Color.Warning, Color.Success, Color.Error];
+    
     private static int PrizeDrawSuspenseDelay => 2500;
     private bool _loading;
     private bool _isDrawingPrize;
+    private string? _errorMessage;
 
     private List<EligibleUserDto>? _players = [];
-    AchievementDto? _selectedAchievement;
+    private AchievementDto? _selectedAchievement;
     private LeaderboardFilter _filter = LeaderboardFilter.Today;
     private int? _top;
     private bool _excludeStaff = true;
     private List<Winner> _previousWinners = [];
     private bool _excludePreviousWinners = true;
 
+    private bool CanDrawPrize => _players is { Count: > 0 } && !_isDrawingPrize && !_loading;
+    private bool HasEligiblePlayers => _players?.Count > 0;
+    private string EligiblePlayersCountText => $"Total: {_players?.Count ?? 0}";
+
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        _storage = new SessionStorage(JsRuntime);
-        await LoadPreviousWinners();
+        await LoadPreviousWinnersAsync();
     }
 
-    private async Task LoadPreviousWinners()
+    private async Task LoadPreviousWinnersAsync()
     {
-        _previousWinners = await _storage.LoadWinners();
+        try
+        {
+            _previousWinners = await WinnerStorageService.LoadWinnersAsync();
+        }
+        catch (Exception)
+        {
+            ShowError("Failed to load previous winners");
+        }
     }
 
     private async Task<IEnumerable<AchievementDto>> SearchAchievements(string value, CancellationToken cancellationToken)
     {
-        var achievements = await AchievementService.SearchAchievements(value, cancellationToken);
-
-        return achievements.Achievements;
+        try
+        {
+            var achievements = await AchievementService.SearchAchievements(value, cancellationToken);
+            return achievements.Achievements;
+        }
+        catch (Exception)
+        {
+            ShowError("Failed to search achievements");
+            return [];
+        }
     }
 
-    private async Task LoadEligiblePlayers()
+    private async Task LoadEligiblePlayersAsync()
     {
         try
         {
             _loading = true;
+            _errorMessage = null;
 
-            var (dateFrom, dateTo) = GetDateRangeForFilter(_filter);
+            var (dateFrom, dateTo) = PrizeDrawManager.GetDateRangeForFilter(_filter, DateTimeService);
 
             var filter = new GetEligibleUsersFilter
             {
@@ -247,27 +275,23 @@
                 Top = _top,
             };
 
-            var eligibleUsersVm = await PrizeDrawService.GetEligibleUsers(filter, CancellationToken.None);
-            var eligiblePlayers = eligibleUsersVm.EligibleUsers.ToList();
-
-            if (_excludePreviousWinners)
-            {
-                var previousWinnerIds = _previousWinners.Select(w => w.Id).ToHashSet();
-                eligiblePlayers = eligiblePlayers
-                    .Where(p => !previousWinnerIds.Contains(p.UserId.ToString()))
-                    .ToList();
-            }
-
-            _players = eligiblePlayers;
-            _loading = false;
+            _players = await PrizeDrawManager.GetEligiblePlayersAsync(filter, _previousWinners, _excludePreviousWinners);
         }
         catch (AccessTokenNotAvailableException exception)
         {
             exception.Redirect();
         }
+        catch (Exception)
+        {
+            ShowError("Failed to load eligible players. Please try again.");
+        }
+        finally
+        {
+            _loading = false;
+        }
     }
 
-    private async Task DrawPrizeWinner()
+    private async Task DrawPrizeWinnerAsync()
     {
         var loadingDialog = ShowLoadingDialog();
         
@@ -277,7 +301,7 @@
             await InvokeAsync(StateHasChanged);
             await Task.Delay(PrizeDrawSuspenseDelay);
 
-            var winner = SelectRandomWinner();
+            var winner = PrizeDrawManager.SelectRandomWinner(_players?.ToList() ?? new List<EligibleUserDto>());
             if (winner == null)
             {
                 SnackBar.Add("No eligible players remaining!", Severity.Warning);
@@ -285,6 +309,10 @@
             }
 
             await ShowWinnerDialog(winner);
+        }
+        catch (Exception)
+        {
+            ShowError("Failed to draw prize winner. Please try again.");
         }
         finally
         {
@@ -311,28 +339,15 @@
         return DialogService.Show<LoadingDialog>("", loadingParameters, loadingOptions);
     }
 
-    private EligibleUserDto? SelectRandomWinner()
-    {
-        var eligiblePlayers = _players?.ToList() ?? [];
-        
-        if (!eligiblePlayers.Any())
-        {
-            return null;
-        }
-
-        Random rand = new();
-        return eligiblePlayers.ElementAt(rand.Next(eligiblePlayers.Count()));
-    }
-
     private async Task ShowWinnerDialog(EligibleUserDto winner)
     {
         var parameters = new DialogParameters
         {
             ["Winner"] = winner,
             ["OnClaimPrize"] = EventCallback.Factory.Create<(EligibleUserDto, RewardDto)>(this,
-                async args => await ClaimPrizeForWinner(args.Item1, args.Item2)),
+                async args => await ClaimPrizeForWinnerAsync(args.Item1, args.Item2)),
             ["OnSkipWinner"] = EventCallback.Factory.Create<EligibleUserDto>(this,
-                async user => await SkipWinner(user))
+                async user => await SkipWinnerAsync(user))
         };
 
         var options = new DialogOptions
@@ -346,36 +361,44 @@
         await DialogService.ShowAsync<WinnerDialog>("Prize Winner!", parameters, options);
     }
 
-    private async Task ClaimPrizeForWinner(EligibleUserDto winner, RewardDto reward)
+    private async Task ClaimPrizeForWinnerAsync(EligibleUserDto winner, RewardDto reward)
     {
-        var result = await RewardAdminService.ClaimForUser(reward.Code, winner.UserId ?? 0, false, CancellationToken.None);
-
-        if (result.status == RewardStatus.Claimed)
+        try
         {
-            if (winner.UserId != null)
+            var result = await RewardAdminService.ClaimForUser(reward.Code, winner.UserId ?? 0, false, CancellationToken.None);
+
+            if (result.status == RewardStatus.Claimed)
             {
-                await _storage.SaveWinner(winner.UserId.ToString(), winner.Name ?? string.Empty);
-                await LoadPreviousWinners();
+                if (winner.UserId != null)
+                {
+                    await WinnerStorageService.SaveWinnerAsync(winner.UserId.ToString(), winner.Name ?? string.Empty);
+                    await LoadPreviousWinnersAsync();
+                }
+
+                SnackBar.Add($"{reward.Name} successfully claimed for {winner.Name}!", Severity.Success, 
+                    options => { options.VisibleStateDuration = 10000; });
+
+                _players?.RemoveAll(p => p.UserId == winner.UserId);
             }
-
-            SnackBar.Add($"{reward.Name} successfully claimed for {winner.Name}!", Severity.Success, options => { options.VisibleStateDuration = 10000; });
-
-            _players?.RemoveAll(p => p.UserId == winner.UserId);
+            else
+            {
+                SnackBar.Add($"Could not claim reward!\n\n{result.status}", Severity.Error);
+            }
         }
-        else
+        catch (Exception)
         {
-            SnackBar.Add($"Could not claim reward!\n\n{result.status}", Severity.Error);
+            SnackBar.Add("Failed to claim prize. Please try again.", Severity.Error);
         }
     }
 
-    private async Task SkipWinner(EligibleUserDto winner)
+    private async Task SkipWinnerAsync(EligibleUserDto winner)
     {
         _players?.RemoveAll(p => p.UserId == winner.UserId);
 
         // Only auto-draw another winner if there are still players left
         if (_players?.Count > 0)
         {
-            await DrawPrizeWinner();
+            await DrawPrizeWinnerAsync();
         }
         else
         {
@@ -383,93 +406,44 @@
         }
     }
 
-    private static string GetAchievementName(AchievementDto? achievement)
-    {
-        return achievement?.Name ?? string.Empty;
-    }
+    private static string GetAchievementName(AchievementDto? achievement) => achievement?.Name ?? string.Empty;
 
-    private async Task ClearPreviousWinners()
+    private async Task ClearPreviousWinnersAsync()
     {
-        await _storage.ClearWinners();
-        _previousWinners.Clear();
-        SnackBar.Add("Previous winners cleared!", Severity.Success);
-    }
-
-    private (DateTime? from, DateTime? to) GetDateRangeForFilter(LeaderboardFilter filter)
-    {
-        var now = DateTimeService.Now; // Client's local timezone
-
-        var (localFrom, localTo) = filter switch
+        try
         {
-            LeaderboardFilter.Today => (now.Date, now.Date.AddDays(1).AddTicks(-1)),
-            LeaderboardFilter.ThisWeek => (now.Date.AddDays(-(int)now.DayOfWeek),
-                now.Date.AddDays(7 - (int)now.DayOfWeek).AddTicks(-1)),
-            LeaderboardFilter.ThisMonth => (new DateTime(now.Year, now.Month, 1),
-                new DateTime(now.Year, now.Month, 1).AddMonths(1).AddTicks(-1)),
-            LeaderboardFilter.ThisYear => (new DateTime(now.Year, 1, 1),
-                new DateTime(now.Year + 1, 1, 1).AddTicks(-1)),
-            LeaderboardFilter.Forever => (null, null),
-            _ => ((DateTime?)null, (DateTime?)null)
-        };
-
-        // Convert local times to UTC for server processing
-        if (localFrom.HasValue && localTo.HasValue)
-        {
-            return (localFrom.Value.ToUniversalTime(), localTo.Value.ToUniversalTime());
+            await WinnerStorageService.ClearWinnersAsync();
+            _previousWinners.Clear();
+            SnackBar.Add("Previous winners cleared!", Severity.Success);
         }
-
-        return (null, null);
-    }
-
-    private class Winner
-    {
-        public string Id { get; set; } = string.Empty;
-        public string Name { get; set; } = string.Empty;
-    }
-
-    private class SessionStorage(IJSRuntime jsRuntime)
-    {
-        private const string PreviousWinnersKey = "ssw-rewards-previous-winners";
-
-        public async Task<List<Winner>> LoadWinners()
+        catch (Exception)
         {
-            var winnersJson = await jsRuntime.InvokeAsync<string>("sessionStorage.getItem", PreviousWinnersKey);
-            if (string.IsNullOrEmpty(winnersJson))
-                return [];
-
-            var winners = System.Text.Json.JsonSerializer.Deserialize<List<Winner>>(winnersJson);
-            return winners ?? [];
-        }
-
-        public async Task SaveWinner(string userId, string name)
-        {
-            var winners = await LoadWinners();
-            winners.Add(new Winner { Id = userId, Name = name });
-            var winnersJson = System.Text.Json.JsonSerializer.Serialize(winners);
-            await jsRuntime.InvokeVoidAsync("sessionStorage.setItem", PreviousWinnersKey, winnersJson);
-        }
-
-        public async Task ClearWinners()
-        {
-            await jsRuntime.InvokeVoidAsync("sessionStorage.removeItem", PreviousWinnersKey);
+            ShowError("Failed to clear previous winners");
         }
     }
 
-    private static LeaderboardFilter[] GetOrderedFilters()
+    private void ShowError(string message)
     {
-        return
-        [
-            LeaderboardFilter.Today,
-            LeaderboardFilter.ThisWeek,
-            LeaderboardFilter.ThisMonth,
-            LeaderboardFilter.ThisYear,
-            LeaderboardFilter.Forever
-        ];
+        _errorMessage = message;
+        StateHasChanged();
     }
 
-    private static string GetFilterDisplayName(LeaderboardFilter filter)
+    private void ClearError()
     {
-        return filter switch
+        _errorMessage = null;
+    }
+
+    private static LeaderboardFilter[] GetOrderedFilters() =>
+    [
+        LeaderboardFilter.Today,
+        LeaderboardFilter.ThisWeek,
+        LeaderboardFilter.ThisMonth,
+        LeaderboardFilter.ThisYear,
+        LeaderboardFilter.Forever
+    ];
+
+    private static string GetFilterDisplayName(LeaderboardFilter filter) =>
+        filter switch
         {
             LeaderboardFilter.Today => "Today",
             LeaderboardFilter.ThisWeek => "This Week",
@@ -478,5 +452,4 @@
             LeaderboardFilter.Forever => "All Time",
             _ => filter.ToString()
         };
-    }
 }

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -373,12 +373,12 @@
             }
             else
             {
-                SnackBar.Add($"Could not claim reward!\n\n{result.status}", Severity.Error);
+                ShowError($"Could not claim reward!\n\n{result.status}");
             }
         }
         catch (Exception)
         {
-            SnackBar.Add("Failed to claim prize. Please try again.", Severity.Error);
+            ShowError("Failed to claim prize. Please try again.");
         }
     }
 

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -124,7 +124,7 @@
         {
             <MudGrid Spacing="2">
                 <MudItem>
-                    <MudChipSet MultiSelection="false">
+                    <MudChipSet MultiSelection="false" Filter="false" ReadOnly="true">
                         @if (_players != null)
                         {
                             @foreach (var player in _players.Select((p, index) => new { p, index }))

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -24,22 +24,6 @@
 <MudPaper Elevation="2" Class="pa-4 mb-4">
     <MudGrid Spacing="2">
         <MudItem xs="12" sm="6" md="4">
-            <MudAutocomplete
-                T="AchievementDto"
-                @bind-Value="@_selectedAchievement"
-                Variant="Variant.Outlined"
-                Margin="Margin.Dense"
-                Dense="true"
-                Label="Required Achievement"
-                AnchorOrigin="Origin.BottomCenter"
-                SearchFuncWithCancel="@SearchAchievements"
-                ShowProgressIndicator="true"
-                ToStringFunc="@GetAchievementName"
-                FullWidth="true"
-            />
-        </MudItem>
-
-        <MudItem xs="12" sm="6" md="4">
             <MudSelect
                 T="LeaderboardFilter"
                 @bind-Value="@_filter"
@@ -49,20 +33,38 @@
                 Variant="Variant.Outlined"
                 AnchorOrigin="Origin.BottomCenter"
                 FullWidth="true">
-                @foreach (var when in Enum.GetValues<LeaderboardFilter>())
+                @foreach (var filter in GetOrderedFilters())
                 {
-                    <MudSelectItem T="LeaderboardFilter" Value="@when">@when.ToString()</MudSelectItem>
+                    <MudSelectItem T="LeaderboardFilter" Value="@filter">@GetFilterDisplayName(filter)</MudSelectItem>
                 }
             </MudSelect>
         </MudItem>
 
         <MudItem xs="12" sm="6" md="4">
+            <MudAutocomplete
+                T="AchievementDto"
+                @bind-Value="@_selectedAchievement"
+                Variant="Variant.Outlined"
+                Margin="Margin.Dense"
+                Dense="true"
+                Label="Required Achievement (Optional)"
+                AnchorOrigin="Origin.BottomCenter"
+                SearchFuncWithCancel="@SearchAchievements"
+                ShowProgressIndicator="true"
+                ToStringFunc="@GetAchievementName"
+                FullWidth="true"
+                Clearable="true"
+                ResetValueOnEmptyText="true"/>
+        </MudItem>
+
+        <MudItem xs="12" sm="6" md="4">
             <MudTextField
-                Label="Leaderboard Top X"
+                Label="Leaderboard Top X (Optional)"
                 Variant="Variant.Outlined"
                 Margin="Margin.Dense"
                 Dense="true"
                 Type="InputType.Number"
+                Clearable="true"
                 @bind-Value="_top"
                 FullWidth="true"/>
         </MudItem>
@@ -198,13 +200,13 @@
     private SessionStorage _storage;
 
     private static int PrizeDrawSuspenseDelay => 2500;
-    private bool _loading = false;
-    private bool _isDrawingPrize = false;
+    private bool _loading;
+    private bool _isDrawingPrize;
 
     private List<EligibleUserDto>? _players = [];
     AchievementDto? _selectedAchievement;
     private LeaderboardFilter _filter = LeaderboardFilter.Today;
-    private int _top;
+    private int? _top;
     private bool _excludeStaff = true;
     private List<Winner> _previousWinners = [];
     private bool _excludePreviousWinners = true;
@@ -451,5 +453,30 @@
         {
             await jsRuntime.InvokeVoidAsync("sessionStorage.removeItem", PreviousWinnersKey);
         }
+    }
+
+    private static LeaderboardFilter[] GetOrderedFilters()
+    {
+        return
+        [
+            LeaderboardFilter.Today,
+            LeaderboardFilter.ThisWeek,
+            LeaderboardFilter.ThisMonth,
+            LeaderboardFilter.ThisYear,
+            LeaderboardFilter.Forever
+        ];
+    }
+
+    private static string GetFilterDisplayName(LeaderboardFilter filter)
+    {
+        return filter switch
+        {
+            LeaderboardFilter.Today => "Today",
+            LeaderboardFilter.ThisWeek => "This Week",
+            LeaderboardFilter.ThisMonth => "This Month",
+            LeaderboardFilter.ThisYear => "This Year",
+            LeaderboardFilter.Forever => "All Time",
+            _ => filter.ToString()
+        };
     }
 }

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -416,7 +416,6 @@
     private void ShowError(string message)
     {
         SnackBar.Add(message, Severity.Error);
-        StateHasChanged();
     }
 
     private static LeaderboardFilter[] GetOrderedFilters() =>

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -21,7 +21,6 @@
 
 <MudText Typo="Typo.h2">Prize Draw</MudText>
 
-
 <MudPaper Elevation="2" Class="pa-4 mb-4">
     <MudGrid Spacing="2">
         <MudItem xs="12" sm="6" md="4">
@@ -132,22 +131,6 @@
                 </MudItem>
             </MudGrid>
 
-            @if (_isDrawingPrize)
-            {
-                <MudDivider DividerType="DividerType.Middle" Class="my-12"/>
-
-                <MudGrid Justify="Justify.Center">
-                    <MudItem>
-                        <MudText Align="Align.Center">
-                            Shuffling things around...
-                        </MudText>
-                        <MudText Align="Align.Center">
-                            <MudProgressCircular Color="Color.Success" Indeterminate="true"/>
-                        </MudText>
-                    </MudItem>
-                </MudGrid>
-            }
-
             @if (_players is { Count: > 0 } && !_isDrawingPrize)
             {
                 <MudDivider DividerType="DividerType.Middle" Class="my-6"/>
@@ -209,7 +192,6 @@
     </MudItem>
 
 </MudGrid>
-
 
 @code {
     private readonly Color[] _colors = { Color.Primary, Color.Secondary, Color.Tertiary, Color.Info, Color.Warning, Color.Success, Color.Error };
@@ -285,23 +267,63 @@
 
     private async Task DrawPrizeWinner()
     {
-        _isDrawingPrize = true;
-        await InvokeAsync(StateHasChanged);
-        await Task.Delay(PrizeDrawSuspenseDelay);
+        var loadingDialog = ShowLoadingDialog();
+        
+        try
+        {
+            _isDrawingPrize = true;
+            await InvokeAsync(StateHasChanged);
+            await Task.Delay(PrizeDrawSuspenseDelay);
 
+            var winner = SelectRandomWinner();
+            if (winner == null)
+            {
+                SnackBar.Add("No eligible players remaining!", Severity.Warning);
+                return;
+            }
+
+            await ShowWinnerDialog(winner);
+        }
+        finally
+        {
+            loadingDialog.Close();
+            _isDrawingPrize = false;
+        }
+    }
+
+    private IDialogReference ShowLoadingDialog()
+    {
+        var loadingParameters = new DialogParameters
+        {
+            ["LoadingText"] = "Shuffling things around..."
+        };
+
+        var loadingOptions = new DialogOptions
+        {
+            CloseOnEscapeKey = false,
+            DisableBackdropClick = true,
+            NoHeader = true,
+            MaxWidth = MaxWidth.Small
+        };
+
+        return DialogService.Show<LoadingDialog>("", loadingParameters, loadingOptions);
+    }
+
+    private EligibleUserDto? SelectRandomWinner()
+    {
         var eligiblePlayers = _players?.ToList() ?? [];
-
+        
         if (!eligiblePlayers.Any())
         {
-            SnackBar.Add("No eligible players remaining!", Severity.Warning);
-            _isDrawingPrize = false;
-            return;
+            return null;
         }
 
         Random rand = new();
-        var winner = eligiblePlayers.ElementAt(rand.Next(eligiblePlayers.Count()));
-        _isDrawingPrize = false;
+        return eligiblePlayers.ElementAt(rand.Next(eligiblePlayers.Count()));
+    }
 
+    private async Task ShowWinnerDialog(EligibleUserDto winner)
+    {
         var parameters = new DialogParameters
         {
             ["Winner"] = winner,
@@ -319,8 +341,7 @@
             FullWidth = true
         };
 
-        var dialog = await DialogService.ShowAsync<WinnerDialog>("Prize Winner!", parameters, options);
-        await dialog.Result;
+        await DialogService.ShowAsync<WinnerDialog>("Prize Winner!", parameters, options);
     }
 
     private async Task ClaimPrizeForWinner(EligibleUserDto winner, RewardDto reward)
@@ -431,5 +452,4 @@
             await jsRuntime.InvokeVoidAsync("sessionStorage.removeItem", PreviousWinnersKey);
         }
     }
-
 }

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -112,13 +112,6 @@
                 </MudItem>
             </MudGrid>
         }
-        else if (_errorMessage != null)
-        {
-            <MudAlert Severity="Severity.Error" Class="mb-4">
-                @_errorMessage
-                <MudButton Class="ml-2" Size="Size.Small" OnClick="ClearError">Dismiss</MudButton>
-            </MudAlert>
-        }
         else
         {
             <MudGrid Justify="Justify.Center">
@@ -211,7 +204,6 @@
     private static int PrizeDrawSuspenseDelay => 2500;
     private bool _loading;
     private bool _isDrawingPrize;
-    private string? _errorMessage;
 
     private List<EligibleUserDto>? _players = [];
     private AchievementDto? _selectedAchievement;
@@ -262,7 +254,6 @@
         try
         {
             _loading = true;
-            _errorMessage = null;
 
             var (dateFrom, dateTo) = PrizeDrawManager.GetDateRangeForFilter(_filter, DateTimeService);
 
@@ -424,13 +415,8 @@
 
     private void ShowError(string message)
     {
-        _errorMessage = message;
+        SnackBar.Add(message, Severity.Error);
         StateHasChanged();
-    }
-
-    private void ClearError()
-    {
-        _errorMessage = null;
     }
 
     private static LeaderboardFilter[] GetOrderedFilters() =>

--- a/src/AdminUI/Pages/PrizeDraw.razor
+++ b/src/AdminUI/Pages/PrizeDraw.razor
@@ -104,23 +104,24 @@
 
 <MudGrid>
     <MudItem xs="12" sm="8">
+
+        <MudGrid Justify="Justify.Center">
+            <MudItem>
+                <MudText Typo="Typo.h5" Align="Align.Center">Eligible Players</MudText>
+                <MudText Align="Align.Center">@EligiblePlayersCountText</MudText>
+            </MudItem>
+        </MudGrid>
+
         @if (_loading)
         {
             <MudGrid Justify="Justify.Center">
                 <MudItem>
-                    <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
+                    <MudProgressCircular Color="Color.Secondary" Indeterminate="true"/>
                 </MudItem>
             </MudGrid>
         }
         else
         {
-            <MudGrid Justify="Justify.Center">
-                <MudItem>
-                    <MudText Typo="Typo.h5" Align="Align.Center">Eligible Players</MudText>
-                    <MudText Align="Align.Center">@EligiblePlayersCountText</MudText>
-                </MudItem>
-            </MudGrid>
-
             <MudGrid Spacing="2">
                 <MudItem>
                     <MudChipSet MultiSelection="false">

--- a/src/AdminUI/Program.cs
+++ b/src/AdminUI/Program.cs
@@ -21,6 +21,9 @@ public class Program
 
         builder.Services.AddTransient<IDateTime, DateTimeService>();
 
+        builder.Services.AddScoped<IPrizeDrawManager, PrizeDrawManager>();
+        builder.Services.AddScoped<IWinnerStorageService, WinnerStorageService>();
+
         string? identityUrl = builder.Configuration["Local:Authority"];
         if (identityUrl == null)
         {

--- a/src/AdminUI/Services/PrizeDrawManager.cs
+++ b/src/AdminUI/Services/PrizeDrawManager.cs
@@ -1,0 +1,69 @@
+using SSW.Rewards.Admin.UI.Models;
+using SSW.Rewards.ApiClient.Services;
+using SSW.Rewards.Application.Common.Interfaces;
+using SSW.Rewards.Enums;
+using SSW.Rewards.Shared.DTOs.PrizeDraw;
+
+namespace SSW.Rewards.Admin.UI.Services;
+
+public interface IPrizeDrawManager
+{
+    Task<List<EligibleUserDto>> GetEligiblePlayersAsync(GetEligibleUsersFilter filter, List<Winner> previousWinners, bool excludePreviousWinners);
+    EligibleUserDto? SelectRandomWinner(List<EligibleUserDto> players);
+    (DateTime? from, DateTime? to) GetDateRangeForFilter(LeaderboardFilter filter, IDateTime dateTimeService);
+}
+
+public class PrizeDrawManager(IPrizeDrawService prizeDrawService) : IPrizeDrawManager
+{
+    public async Task<List<EligibleUserDto>> GetEligiblePlayersAsync(
+        GetEligibleUsersFilter filter,
+        List<Winner> previousWinners,
+        bool excludePreviousWinners)
+    {
+        var eligibleUsersVm = await prizeDrawService.GetEligibleUsers(filter, CancellationToken.None);
+        var eligiblePlayers = eligibleUsersVm.EligibleUsers.ToList();
+
+        if (excludePreviousWinners)
+        {
+            var previousWinnerIds = previousWinners.Select(w => w.Id).ToHashSet();
+            eligiblePlayers = eligiblePlayers
+                .Where(p => !previousWinnerIds.Contains(p.UserId.ToString()))
+                .ToList();
+        }
+
+        return eligiblePlayers;
+    }
+
+    public EligibleUserDto? SelectRandomWinner(List<EligibleUserDto> players)
+    {
+        if (players.Count == 0) return null;
+
+        var rand = new Random();
+        return players.ElementAt(rand.Next(players.Count));
+    }
+
+    public (DateTime? from, DateTime? to) GetDateRangeForFilter(LeaderboardFilter filter, IDateTime dateTimeService)
+    {
+        var now = dateTimeService.Now;
+
+        (DateTime? localFrom, DateTime? localTo) = filter switch
+        {
+            LeaderboardFilter.Today => (now.Date, now.Date.AddDays(1).AddTicks(-1)),
+            LeaderboardFilter.ThisWeek => (now.Date.AddDays(-(int)now.DayOfWeek),
+                now.Date.AddDays(7 - (int)now.DayOfWeek).AddTicks(-1)),
+            LeaderboardFilter.ThisMonth => (new DateTime(now.Year, now.Month, 1),
+                new DateTime(now.Year, now.Month, 1).AddMonths(1).AddTicks(-1)),
+            LeaderboardFilter.ThisYear => (new DateTime(now.Year, 1, 1),
+                new DateTime(now.Year + 1, 1, 1).AddTicks(-1)),
+            LeaderboardFilter.Forever => (null, null),
+            _ => ((DateTime?)null, (DateTime?)null)
+        };
+
+        if (localFrom.HasValue && localTo.HasValue)
+        {
+            return (localFrom.Value.ToUniversalTime(), localTo.Value.ToUniversalTime());
+        }
+
+        return (null, null);
+    }
+}

--- a/src/AdminUI/Services/WinnerStorageService.cs
+++ b/src/AdminUI/Services/WinnerStorageService.cs
@@ -1,0 +1,39 @@
+using Microsoft.JSInterop;
+using SSW.Rewards.Admin.UI.Models;
+
+namespace SSW.Rewards.Admin.UI.Services;
+
+public interface IWinnerStorageService
+{
+    Task<List<Winner>> LoadWinnersAsync();
+    Task SaveWinnerAsync(string userId, string name);
+    Task ClearWinnersAsync();
+}
+
+public class WinnerStorageService(IJSRuntime jsRuntime) : IWinnerStorageService
+{
+    private const string PreviousWinnersKey = "ssw-rewards-previous-winners";
+
+    public async Task<List<Winner>> LoadWinnersAsync()
+    {
+        var winnersJson = await jsRuntime.InvokeAsync<string>("sessionStorage.getItem", PreviousWinnersKey);
+        if (string.IsNullOrEmpty(winnersJson))
+            return [];
+
+        var winners = System.Text.Json.JsonSerializer.Deserialize<List<Winner>>(winnersJson);
+        return winners ?? [];
+    }
+
+    public async Task SaveWinnerAsync(string userId, string name)
+    {
+        var winners = await LoadWinnersAsync();
+        winners.Add(new Winner { Id = userId, Name = name });
+        var winnersJson = System.Text.Json.JsonSerializer.Serialize(winners);
+        await jsRuntime.InvokeVoidAsync("sessionStorage.setItem", PreviousWinnersKey, winnersJson);
+    }
+
+    public async Task ClearWinnersAsync()
+    {
+        await jsRuntime.InvokeVoidAsync("sessionStorage.removeItem", PreviousWinnersKey);
+    }
+}

--- a/src/AdminUI/wwwroot/index.html
+++ b/src/AdminUI/wwwroot/index.html
@@ -8,7 +8,6 @@
     <base href="/" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="SSW.Rewards.Admin.styles.css" rel="stylesheet" />
 </head>
 
 <body>

--- a/src/Common/DTOs/PrizeDraw/GetEligibleUsersFilter.cs
+++ b/src/Common/DTOs/PrizeDraw/GetEligibleUsersFilter.cs
@@ -7,5 +7,5 @@ public class GetEligibleUsersFilter
     public DateTime? DateFrom { get; set; }
     public DateTime? DateTo { get; set; }
     public bool? FilterStaff { get; set; }
-    public int Top { get; set; }
+    public int? Top { get; set; }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing on Staging

> 2. What was changed?

Cleans up the prize draw page with some improvements and other behind the scenes changes after testing:

1. Cleans up the filtering so that optional fields are more obvious and grouped more logically.
2. Updates the timeframe dropdown so the items display better human-readable labels and are ordered chronologically rather than the odd ordering they are now.
3. Make the optional fields (achievement and top X) clearable.
4. Make the Top X a numeric field with a minimum of 1 that defaults to blank. Clearing this allows fetching with no limit, which is more obvious than having to set it to 0.
5. Moves the loading spinner to a modal rather than have it sit below everything at the bottom of the page. This modal was also made generic so can be used throughout the app later if needed.
6. Fixes a visual bug where skipping a winner results in multiple modals being stacked on each other.
7. Adds a close button to the winner modal so you can't be stuck if you wish to not continue.
8. Separates some of the code out into services to slim down the PrizeDraw page. Cleans up a lot of the code in general.

Other misc fixes I've slipped in here:

1. Updated the admin portal URL in the pipeline to use our proper staging url (https://staging.rewards.ssw.com.au). This should resolve CORS issues when testing on Staging.
2. Removes a CSS reference to a file that doesn't exist.

> 3. Did you do pair or mob programming?
No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->