### PR TITLE
🐛 Mobile | Trim whitespace on social media input

### DIFF
--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -68,6 +68,7 @@
                                 TextColor="Black">
                                 <controls:BorderlessEntry.Behaviors>
                                     <toolkit:EventToCommandBehavior EventName="Focused" Command="{Binding InputFocusedCommand}"/>
+                                    <toolkit:EventToCommandBehavior EventName="Unfocused" Command="{Binding InputUnfocusedCommand}"/>
                                 </controls:BorderlessEntry.Behaviors>
                             </Entry>
                         </Border>

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -102,6 +102,8 @@ public partial class AddSocialMediaViewModel : BaseViewModel
     [RelayCommand]
     private async Task Connect()
     {
+        InputText = InputText.Trim();
+
         var isValid = ValidateForm();
 
         if (!isValid) return;
@@ -129,6 +131,12 @@ public partial class AddSocialMediaViewModel : BaseViewModel
         {
             CursorPosition = InputText.Length;
         });
+    }
+
+    [RelayCommand]
+    private void InputUnfocused()
+    {
+        InputText = InputText.Trim();
     }
     
     [RelayCommand]


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1293

> 2. What was changed?

Trims whitespace on the social media input when the input is unfocused and also when the user tries to submit.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->