### PR TITLE
🐛 Mobile | Fix podium being cut off on manual refresh

### DIFF
--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -99,6 +99,12 @@ public partial class LeaderboardViewModel : BaseViewModel
             return;
         }
 
+        if (leaderboardAction is LeaderboardAction.ManualRefresh)
+        {
+            // IsRefreshing is controlled by the RefreshView, we only need to set it to false here on manual refresh.
+            IsRefreshing = false;
+        }
+
         if (leaderboardAction is LeaderboardAction.LoadMore)
         {
             if (_limitReached || !_loaded)
@@ -174,12 +180,6 @@ public partial class LeaderboardViewModel : BaseViewModel
 
         IsRunning = false;
         _loaded = true;
-
-        if (leaderboardAction is LeaderboardAction.ManualRefresh)
-        {
-            // IsRefreshing is controlled by the RefreshView, we only need to set it to false here on manual refresh.
-            IsRefreshing = false;
-        }
     }
 
     private void ScrollToCard(LeaderViewModel card)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

Re-implements a past change that was lost, that fixes the leaderboard podium being cut off on manual refresh on iOS.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->