### PR TITLE
♻️ Admin/Mobile | Update URL associations

### DIFF
--- a/src/AdminUI/Shared/MainLayout.razor
+++ b/src/AdminUI/Shared/MainLayout.razor
@@ -37,7 +37,7 @@
     private bool _isDarkMode;
     private MudThemeProvider? _mudThemeProvider;
 
-    private string _title = "Admin Portal";
+    private string _title = "";
     private string _titleImage = "/images/ssw-rewards-logo.svg";
     
     [CascadingParameter]

--- a/src/AdminUI/wwwroot/.well-known/apple-app-site-association
+++ b/src/AdminUI/wwwroot/.well-known/apple-app-site-association
@@ -4,7 +4,7 @@
         "details": [
             {
                 "appID": "B5652JTA7Q.com.SSW.SSW.Consulting",
-                "paths": ["*"],
+                "paths": ["/redeem"],
             }
         ]
     }

--- a/src/ApiClient/Constants.cs
+++ b/src/ApiClient/Constants.cs
@@ -27,7 +27,7 @@ public class Constants
         RewardsQRCodePendingRewardPrefix
     ];
 
-    public static readonly string RewardsQRCodeUrlFormat = 
-        $"{RewardsQRCodeProtocol}://redeem?{RewardsQRCodeProtocolQueryName}={{0}}";
+    public static readonly string RewardsQRCodeUrlFormat =
+        $"https://{RewardsWebDomain}/redeem?{RewardsQRCodeProtocolQueryName}={{0}}";
 
 }

--- a/src/MobileUI/Platforms/Android/MainActivity.cs
+++ b/src/MobileUI/Platforms/Android/MainActivity.cs
@@ -16,7 +16,8 @@ namespace SSW.Rewards.Mobile;
         Android.Content.Intent.CategoryBrowsable
     },
     DataScheme = "https",
-    DataHost = "rewards.ssw.com.au"
+    DataHost = "rewards.ssw.com.au",
+    DataPath = "/redeem"
 )]
 [IntentFilter(
     [Android.Content.Intent.ActionView],


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Testing

> 2. What was changed?

1. Updates URL associations for app/universal links to only support the /redeem path, as this is the only path we want to navigate to the app currently.
2. Now defaults to generating QR codes using our domain by default, as we now have enough users on the latest version of the app.
3. Small tweak to the admin UI to not show "Admin Portal" as this can show briefly to the end user when navigating to one of these redeem URLs.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->