### PR TITLE
♻️ Mobile | Show "Me" on location button

### DIFF
--- a/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardPage.xaml
@@ -41,20 +41,31 @@
                 Margin="0,10,15,15"
                 StrokeThickness="0"
                 StrokeShape="RoundRectangle 5"
-                WidthRequest="45"
+                WidthRequest="65"
                 HorizontalOptions="End"
                 BackgroundColor="{StaticResource Background}"
                 Padding="5,1">
                 <Border.GestureRecognizers>
                     <TapGestureRecognizer NumberOfTapsRequired="1" Command="{Binding ScrollToMeCommand}" />
                 </Border.GestureRecognizers>
-                <Label HorizontalOptions="Fill"
+                <StackLayout Orientation="Horizontal" 
+                 HorizontalOptions="Center"
+                 VerticalOptions="Center"
+                 Spacing="3">
+                    <Label HorizontalOptions="Center"
                        VerticalOptions="Center"
                        HorizontalTextAlignment="Center"
                        VerticalTextAlignment="Center"
                        FontFamily="FluentIcons"
-                       FontSize="20"
+                       FontSize="16"
                        Text="&#xe85d;" />
+                    <Label HorizontalOptions="Center"
+                       VerticalOptions="Center"
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center"
+                       FontSize="14"
+                       Text="Me" />
+                </StackLayout>
             </Border>
         </Grid>
         <RefreshView

--- a/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderboardViewModel.cs
@@ -31,7 +31,7 @@ public partial class LeaderboardViewModel : BaseViewModel
         new() { Name = "Week", Value = LeaderboardFilter.ThisWeek },
         new() { Name = "Month", Value = LeaderboardFilter.ThisMonth },
         new() { Name = "Year", Value = LeaderboardFilter.ThisYear },
-        new() { Name = "All Time", Value = LeaderboardFilter.Forever }
+        new() { Name = "All", Value = LeaderboardFilter.Forever }
     ];
 
     [ObservableProperty]


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Adam's comment here https://github.com/SSWConsulting/SSW.Rewards.Mobile/issues/1284#issuecomment-2933779604

> 2. What was changed?

Adds "Me" to the location button in the top right of the leaderboard page to make it clearer what the button actually does.

<img src="https://github.com/user-attachments/assets/fd2e2f1f-a7ec-4477-a661-3f6c753e6c3c" width="400" />

**✅ Figure: Button is now clearer**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->