### PR TITLE
♻️ Mobile | Update back button handling

### DIFF
--- a/src/MobileUI/Features/AppShell.xaml.cs
+++ b/src/MobileUI/Features/AppShell.xaml.cs
@@ -16,13 +16,21 @@ public partial class AppShell
     
     protected override bool OnBackButtonPressed()
     {
-        if (Application.Current.MainPage.GetType() == typeof(AppShell) && Current.Navigation.NavigationStack.Where(x => x != null).Any())
+        // Close the flyout if it's open instead of closing the app
+        if (Current.FlyoutIsPresented)
         {
-            return base.OnBackButtonPressed();
+            Current.FlyoutIsPresented = false;
+            return true;
         }
 
-        Process.GetCurrentProcess().CloseMainWindow();
-        return true;
+        // Don't attempt to navigate back if there are open popups as this makes it go back twice.
+        // This is due to this being called on both the main page and the popup page.
+        if (Mopups.Services.MopupService.Instance.PopupStack.Any())
+        {
+            return false;
+        }
+
+        return base.OnBackButtonPressed();
     }
     
     private void Button_Clicked(object sender, EventArgs e)

--- a/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml.cs
+++ b/src/MobileUI/Features/OnBoarding/OnBoardingPage.xaml.cs
@@ -13,12 +13,6 @@ public partial class OnBoardingPage
         BindingContext = _viewModel;
     }
 
-    protected override bool OnBackButtonPressed()
-    {
-        _viewModel.ClosePageCommand.ExecuteAsync(null);
-        return true;
-    }
-
     protected override void OnAppearing()
     {
         base.OnAppearing();


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1295

> 2. What was changed?

Updates the back button behaviour to be more standardised:

1. Removes previous OnBackButtonPressed() override as this wasn't really working correctly - the CloseMainWindow() never worked and the default behaviour for the back button is to close the app if there's nothing left in the navigation stack anyway.
2. Adds functionality to close the flyout when the back button is pressed rather than allow the app to close.
3. Updates handling with popups, as pressing back when a popup is open triggers both the back button handling on the popup and back button handling on the shell page underneath, resulting in both the popup closing and the background page navigating back.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->