### PR TITLE
🐛 API | Fix user not provisioned

### DIFF
--- a/src/Application/Common/Interfaces/IUserService.cs
+++ b/src/Application/Common/Interfaces/IUserService.cs
@@ -21,8 +21,8 @@ public interface IUserService
 
 
     // Create user
-    int CreateUser(User user);
-    Task<int> CreateUser(User user, CancellationToken cancellationToken);
+    User CreateUser(User user);
+    Task<User> CreateUser(User user, CancellationToken cancellationToken);
 
 
     // Update user

--- a/src/Application/Users/Commands/RegisterUser/RegisterUserCommand.cs
+++ b/src/Application/Users/Commands/RegisterUser/RegisterUserCommand.cs
@@ -1,10 +1,6 @@
-﻿using SSW.Rewards.Application.Common.Extensions;
+﻿namespace SSW.Rewards.Application.Users.Commands.RegisterUser;
 
-namespace SSW.Rewards.Application.Users.Commands.RegisterUser;
-
-public class RegisterUserCommand : IRequest
-{
-}
+public class RegisterUserCommand : IRequest;
 
 public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
 {
@@ -19,7 +15,7 @@ public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
 
     public async Task Handle(RegisterUserCommand request, CancellationToken cancellationToken)
     {
-        var newUser = new Domain.Entities.User
+        var newUser = new User
         {
             Email = _currentUserService.GetUserEmail(),
             FullName = _currentUserService.GetUserFullName(),
@@ -27,11 +23,6 @@ public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
             Avatar = _currentUserService.GetUserProfilePic(),
             CreatedUtc = DateTime.UtcNow
         };
-
-        if (!newUser.Email.ToLower().Contains("ssw.com.au"))
-        {
-            newUser.GenerateAchievement();
-        }
 
         await _userService.CreateUser(newUser, cancellationToken);
     }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #815 

> 2. What was changed?

Updates the code for retrieving the current user to handle the rare instance where a user might have registered and logged in to IdentityServer but for some reason a user hasn't been provisioned on our end. This will handle it so that a user gets provisioned in our DB using their email and other details and won't just crash the app and leave the user in limbo.

Also cleans up a lot of the UserService as many of these methods were getting large and complicated. This also should handle errors a bit better as well.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->