### PR TITLE
💚 Reduce the 404 noise in application insights - part 1

### DIFF
--- a/src/WebAPI/Filters/UrlBlockList.cs
+++ b/src/WebAPI/Filters/UrlBlockList.cs
@@ -1,0 +1,28 @@
+﻿namespace SSW.Rewards.WebAPI.Filters;
+
+public static class UrlBlockList
+{
+    public static readonly string[] SimpleContainsMatch =
+    [
+        ".git/config",
+        "index/leaveMsg/",
+        "kcfinder/",
+        "wlwmanifest",
+        "ALFA_DATA/",
+        "wp-content",
+    ];
+
+    public static readonly string[] SimpleEndWithMatch =
+    [
+        ".php"
+    ];
+
+    public static bool IsBlocked(string url)
+        => url switch
+        {
+            _ when string.IsNullOrWhiteSpace(url) => false,
+            _ when SimpleContainsMatch.Any(x => url.Contains(x, StringComparison.OrdinalIgnoreCase)) => true,
+            _ when SimpleEndWithMatch.Any(x => url.Contains(x, StringComparison.OrdinalIgnoreCase)) => true,
+            _ => false
+        };
+}

--- a/src/WebAPI/Filters/UrlBlockList.cs
+++ b/src/WebAPI/Filters/UrlBlockList.cs
@@ -22,7 +22,7 @@ public static class UrlBlockList
         {
             _ when string.IsNullOrWhiteSpace(url) => false,
             _ when SimpleContainsMatch.Any(x => url.Contains(x, StringComparison.OrdinalIgnoreCase)) => true,
-            _ when SimpleEndWithMatch.Any(x => url.Contains(x, StringComparison.OrdinalIgnoreCase)) => true,
+            _ when SimpleEndWithMatch.Any(x => url.EndsWith(x, StringComparison.OrdinalIgnoreCase)) => true,
             _ => false
         };
 }

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -54,6 +54,15 @@ app.Use(async (ctx, next) =>
 {
     var path = ctx.Request.Path.Value ?? "";
 
+    // It's for Azure health checks and similar scenarios.
+    if (path == "/")
+    {
+        ctx.Response.StatusCode = StatusCodes.Status204NoContent;
+        await ctx.Response.CompleteAsync();
+        return;
+    }
+
+    // Check for spammy bots and crawlers
     if (UrlBlockList.IsBlocked(path))
     {
         // Random 0.5-3 s delay – enough to annoy bots, negligible for you
@@ -76,4 +85,4 @@ app.MapControllerRoute(
 
 //app.MapFallbackToFile("index.html"); ;
 
-app.Run();
+await app.RunAsync();

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -65,7 +65,7 @@ app.Use(async (ctx, next) =>
     // Check for spammy bots and crawlers
     if (UrlBlockList.IsBlocked(path))
     {
-        // Random 0.5-3 s delay – enough to annoy bots, negligible for you
+        // Random 0.5-3 s delay â€” enough to annoy bots, negligible for legitimate users
         await Task.Delay(Random.Shared.Next(500, 3000));
 
         ctx.Response.StatusCode = StatusCodes.Status404NotFound;


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1337 initial work to reduce the noise in Application Insights.

> 2. What was changed?

✏️ React with 204 on `/` URL and very simple URL blocking logic that waits a few seconds before responding 404. It also no longer logs blocked URLs as errors.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->