### PR TITLE
💚 Fixing `/` endpoint from 204 to 200 to fix a silent exception

### DIFF
--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -57,8 +57,9 @@ app.Use(async (ctx, next) =>
     // It's for Azure health checks and similar scenarios.
     if (path == "/")
     {
-        ctx.Response.StatusCode = StatusCodes.Status204NoContent;
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
         await ctx.Response.CompleteAsync();
+
         return;
     }
 

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -58,8 +58,6 @@ app.Use(async (ctx, next) =>
     if (path == "/")
     {
         ctx.Response.StatusCode = StatusCodes.Status200OK;
-        await ctx.Response.CompleteAsync();
-
         return;
     }
 
@@ -70,8 +68,6 @@ app.Use(async (ctx, next) =>
         await Task.Delay(Random.Shared.Next(500, 3000));
 
         ctx.Response.StatusCode = StatusCodes.Status404NotFound;
-        await ctx.Response.CompleteAsync();
-
         return;
     }
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ System.NullReferenceException in AppInsights triggered by `await ctx.Response.CompleteAsync();` which should have worked ok.

> 2. What was changed?

✏️ `ctx.Response.StatusCode = StatusCodes.Status200OK;`

Locally, it works perfectly with either approach, and strangely enough, there are no issues with other endpoints that do the same thing.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->