### PR TITLE
♻️ CI/CD | Bump to macOS 15 and Xcode 16.4

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     environment: ${{ inputs.environment }}
     name: iOS Build
 
@@ -42,8 +42,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          sudo xcode-select -s "/Applications/Xcode_16.2.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.2.app" >> $GITHUB_ENV
+          sudo xcode-select -s "/Applications/Xcode_16.4.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.4.app" >> $GITHUB_ENV
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-ios:
     name: Deploy iOS to TestFlight
-    runs-on: macos-14
+    runs-on: macos-15
     environment: ${{ inputs.environment }}
     steps:
       - name: Download artifact


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Failing iOS pipeline

> 2. What was changed?

Bumps iOS workflows to macOS 15 and Xcode 16.4 to work with newer versions of MAUI.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->