### PR TITLE
⚡ Improve performance for claiming rewards

### DIFF
--- a/src/Application/Common/Constants/CacheKeys.cs
+++ b/src/Application/Common/Constants/CacheKeys.cs
@@ -4,6 +4,7 @@ public static class CacheKeys
 {
     public const string Leaderboard = "LeaderboardAllTime";
     public const string UserRanking = "UserRankingsAllTime";
+    public const string ClaimPrizeAchievementId = "ClaimPrizeAchievementId";
 }
 
 /// <summary>

--- a/src/Application/Rewards/Commands/ClaimReward/ClaimRewardCommand.cs
+++ b/src/Application/Rewards/Commands/ClaimReward/ClaimRewardCommand.cs
@@ -98,7 +98,7 @@ public class ClaimRewardCommandHandler : IRequestHandler<ClaimRewardCommand, Cla
         });
 
         // Award the user an achievement for claiming their first prize.
-        if (!userAndPoints.HasClaimedPrizeAchievement)
+        if (!userAndPoints.HasClaimedPrizeAchievement && claimPrizeAchievementId != -1)
         {
             _context.UserAchievements.Add(new UserAchievement
             {

--- a/src/Application/Rewards/Commands/ClaimReward/ClaimRewardCommand.cs
+++ b/src/Application/Rewards/Commands/ClaimReward/ClaimRewardCommand.cs
@@ -1,4 +1,5 @@
-﻿using SSW.Rewards.Application.System.Commands.Common;
+﻿using Microsoft.Extensions.Logging;
+using SSW.Rewards.Application.System.Commands.Common;
 using SSW.Rewards.Shared.DTOs.AddressTypes;
 using SSW.Rewards.Shared.DTOs.Rewards;
 
@@ -20,50 +21,68 @@ public class ClaimRewardCommandHandler : IRequestHandler<ClaimRewardCommand, Cla
     private readonly IRewardSender _rewardSender;
     private readonly ICurrentUserService _currentUserService;
     private readonly ICacheService _cacheService;
+    private readonly ILogger<ClaimRewardCommandHandler> _logger;
 
     public ClaimRewardCommandHandler(
         IApplicationDbContext context,
         IMapper mapper,
         IRewardSender rewardSender,
         ICurrentUserService currentUserService,
-        ICacheService cacheService)
+        ICacheService cacheService,
+        ILogger<ClaimRewardCommandHandler> logger)
     {
         _context = context;
         _mapper = mapper;
         _rewardSender = rewardSender;
         _currentUserService = currentUserService;
         _cacheService = cacheService;
+        _logger = logger;
     }
 
     public async Task<ClaimRewardResult> Handle(ClaimRewardCommand request, CancellationToken cancellationToken)
     {
         var reward = await _context.Rewards
+            .AsNoTracking()
             .TagWithContext("GetReward")
             .FirstOrDefaultAsync(r => r.Code == request.Code || r.Id == request.Id, cancellationToken);
 
         if (reward == null)
         {
+            _logger.LogWarning("Reward with code {Code} or ID {Id} not found.", request.Code, request.Id);
             return new ClaimRewardResult
             {
                 status = RewardStatus.NotFound
             };
         }
 
-        var user = await _context.Users
+        int claimPrizeAchievementId = await _cacheService.GetOrAddAsync(
+            CacheKeys.ClaimPrizeAchievementId,
+            () => GetClaimPrizeAchievementId(cancellationToken));
+
+        var userAndPoints = await _context.Users
+            .AsNoTracking()
             .TagWithContext("GetUser")
             .Where(u => u.Email == _currentUserService.GetUserEmail())
-            .Include(u => u.UserRewards)
-                .ThenInclude(ur => ur.Reward)
-            .Include(u => u.UserAchievements)
-                .ThenInclude(u => u.Achievement)
+            .Select(x => new
+            {
+                User = x,
+                UserId = x.Id,
+                PointsUsed = x.UserRewards.Sum(ur => ur.Reward.Cost),
+                TotalPoints = x.UserAchievements.Sum(ua => ua.Achievement.Value),
+                HasClaimedPrizeAchievement = x.UserAchievements.Any(ua => ua.AchievementId == claimPrizeAchievementId)
+            })
             .FirstOrDefaultAsync(cancellationToken);
 
-        int pointsUsed = user.UserRewards.Sum(ur => ur.Reward.Cost);
+        if (userAndPoints == null)
+        {
+            _logger.LogWarning("User with email {Email} not found.", _currentUserService.GetUserEmail());
+            return new ClaimRewardResult
+            {
+                status = RewardStatus.Error
+            };
+        }
 
-        int totalPoints = user.UserAchievements.Sum(ua => ua.Achievement.Value);
-
-        int balance = totalPoints - pointsUsed;
-
+        int balance = userAndPoints.TotalPoints - userAndPoints.PointsUsed;
         if (balance < reward.Cost)
         {
             return new ClaimRewardResult
@@ -72,22 +91,21 @@ public class ClaimRewardCommandHandler : IRequestHandler<ClaimRewardCommand, Cla
             };
         }
 
-        // award the user an achievement for claiming their first prize
-        if (!user.UserRewards.Any())
+        _context.UserRewards.Add(new()
         {
-            var achievement = await _context.Achievements
-                .TagWithContext("GetClaimPrizeAchievement")
-                .FirstOrDefaultAsync(a => a.Name == MilestoneAchievements.ClaimPrize, cancellationToken);
-            if (achievement != null)
-            {
-                user.UserAchievements.Add(new UserAchievement { Achievement = achievement });
-            }
-        }
-
-        user.UserRewards.Add(new UserReward
-        {
-            Reward = reward
+            UserId = userAndPoints.UserId,
+            RewardId = reward.Id
         });
+
+        // Award the user an achievement for claiming their first prize.
+        if (!userAndPoints.HasClaimedPrizeAchievement)
+        {
+            _context.UserAchievements.Add(new UserAchievement
+            {
+                UserId = userAndPoints.UserId,
+                AchievementId = claimPrizeAchievementId
+            });
+        }
 
         await _context.SaveChangesAsync(cancellationToken);
 
@@ -95,7 +113,7 @@ public class ClaimRewardCommandHandler : IRequestHandler<ClaimRewardCommand, Cla
 
         if (!request.ClaimInPerson)
         {
-            await _rewardSender.SendRewardAsync(user, reward, request.Address?.freeformAddress??string.Empty, cancellationToken);
+            await _rewardSender.SendRewardAsync(userAndPoints.User, reward, request.Address?.freeformAddress ?? string.Empty, cancellationToken);
         }
 
         var rewardModel = _mapper.Map<RewardDto>(reward);
@@ -105,5 +123,17 @@ public class ClaimRewardCommandHandler : IRequestHandler<ClaimRewardCommand, Cla
             Reward = rewardModel,
             status = RewardStatus.Claimed
         };
+    }
+
+    private async Task<int> GetClaimPrizeAchievementId(CancellationToken ct)
+    {
+        var achievement = await _context.Achievements
+            .AsNoTracking()
+            .TagWithContext("GetClaimPrizeAchievement")
+            .Where(a => a.Name == MilestoneAchievements.ClaimPrize)
+            .Select(x => new { x.Id })
+            .FirstOrDefaultAsync(ct);
+
+        return achievement?.Id ?? -1;
     }
 }

--- a/src/Infrastructure/Persistence/Configurations/AchievementConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/AchievementConfiguration.cs
@@ -10,5 +10,9 @@ public class AchievementConfiguration : IEntityTypeConfiguration<Achievement>
     {
         builder.HasIndex(a => a.IntegrationId)
             .IsUnique();
+
+        builder
+            .HasIndex(x => x.Id)
+            .IncludeProperties(x => x.Value);
     }
 }

--- a/src/Infrastructure/Persistence/Configurations/RewardConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/RewardConfiguration.cs
@@ -8,5 +8,8 @@ public class RewardConfiguration : IEntityTypeConfiguration<Reward>
 {
     public void Configure(EntityTypeBuilder<Reward> builder)
     {
+        builder
+            .HasIndex(x => x.Id)
+            .IncludeProperties(x => x.Cost);
     }
 }

--- a/src/Infrastructure/Persistence/Configurations/UserRewardConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/UserRewardConfiguration.cs
@@ -17,6 +17,10 @@ public class UserRewardConfiguration : IEntityTypeConfiguration<UserReward>
             .WithMany(u => u.UserRewards);
 
         builder
+            .HasIndex(x => x.UserId)
+            .IncludeProperties(x => x.RewardId);
+
+        builder
             .Property(ur => ur.AwardedAt)
             .HasDefaultValueSql("getdate()")
             .ValueGeneratedOnAdd();

--- a/src/Infrastructure/Persistence/Migrations/20250702075823_ClaimRewardIndexes.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20250702075823_ClaimRewardIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SSW.Rewards.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using SSW.Rewards.Infrastructure.Persistence;
 namespace SSW.Rewards.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250702075823_ClaimRewardIndexes")]
+    partial class ClaimRewardIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20250702075823_ClaimRewardIndexes.cs
+++ b/src/Infrastructure/Persistence/Migrations/20250702075823_ClaimRewardIndexes.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SSW.Rewards.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class ClaimRewardIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserRewards_UserId",
+                table: "UserRewards");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRewards_UserId",
+                table: "UserRewards",
+                column: "UserId")
+                .Annotation("SqlServer:Include", new[] { "RewardId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Rewards_Id",
+                table: "Rewards",
+                column: "Id")
+                .Annotation("SqlServer:Include", new[] { "Cost" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Achievements_Id",
+                table: "Achievements",
+                column: "Id")
+                .Annotation("SqlServer:Include", new[] { "Value" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserRewards_UserId",
+                table: "UserRewards");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Rewards_Id",
+                table: "Rewards");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Achievements_Id",
+                table: "Achievements");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRewards_UserId",
+                table: "UserRewards",
+                column: "UserId");
+        }
+    }
+}


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1160 

> 2. What was changed?

✏️ Improved DB indexes and queries to fetch data for claiming rewards.

Original SQL query for the top-most active user returned 1000+ rows with ~42 columns! Now it will always return only 1 row.

The execution plan difference was done based on my account, which only had ~100 rows in the original query; however, the analysis shows very promising improvements. The query was handcrafted and ChatGPT o3 was used to verify the execution plan.

## ChatGPT summary of original vs new SQL query

| Metric | Original plan – fan-out joins | After indexes – scalar sub-queries |
| --- | --- | --- |
| Rows returned to client | 93 detail rows (User × Rewards × Achievements) | 1 row (totals + flag)
| Sub-tree cost | 0.0652 | 0.0301  (- 54 %)
| Actual CPU / elapsed | ≈ 1 ms / 1 ms | 0 ms / < 1 ms
| Logical reads (total) | ≈ 147 pages | ≈ 91 pages  (- 38 %)
| - Users | 4 | 4
| - UserRewards | 6 (clustered scan) | 2 (seek on IX_UserRewards_UserId)
| - Rewards | 18 | 16 (seek on IX_Rewards_Id)
| - UserAchievements | 67 | 3
| - Achievements | 62 (PK look-ups) | 64 (seek on IX_Achievements_Id)
| Memory grant | 1 024 KB granted (16 KB used) | 0 KB
| Compile memory / CPU | 1 568 KB / 10 ms | 1 152 KB / 5 ms
| Network payload | ≈ 340 KB | ≈ 8 KB
| Largest scan | 529-row PK scan of UserRewards | none; all seeks, max 64 look-ups
| Look-ups / rewinds | 62 PK look-ups on Achievements, Lazy-Spool rewinds | 32 Achievements look-ups, 8 Rewards look-ups, no spool
| Wait types / spills | none | none

### Summary

After adding the two covering non-clustered indexes the query:

* Eliminates full clustered scans and the spool.
* Cuts logical reads by ≈ 40 %.
* Needs no memory grant and reports zero CPU/elapsed time.

For a single-user dashboard call this is “good enough”; any further tuning would bring negligible benefit until the tables are at least two orders of magnitude larger.

**NOTE: My computer is too fast with too much RAM (64GB) to make any meaningful performance measurements. (~150 ms)  This is why I used execution plans to verify the performance.**

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->