### PR TITLE
🐛 Mobile | Fix camera toggle freezing the app

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml.cs
@@ -5,16 +5,13 @@ public partial class ScanPage
     private readonly ScanViewModel _viewModel;
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
 
-    public ScanPage(ScanViewModel viewModel, IFirebaseAnalyticsService firebaseAnalyticsService,
-        ScanPageSegments segment = ScanPageSegments.Scan)
+    public ScanPage(ScanViewModel viewModel, IFirebaseAnalyticsService firebaseAnalyticsService)
     {
         InitializeComponent();
         _viewModel = viewModel;
         _viewModel.Navigation = Navigation;
         _firebaseAnalyticsService = firebaseAnalyticsService;
         BindingContext = _viewModel;
-
-        _viewModel.SetSegment(segment);
     }
 
     protected override void OnDisappearing()
@@ -23,10 +20,10 @@ public partial class ScanPage
         _viewModel.OnDisappearing();
     }
 
-    protected override void OnAppearing()
+    protected override async void OnAppearing()
     {
         base.OnAppearing();
-        _viewModel.OnAppearing();
+        await _viewModel.OnAppearing();
         _firebaseAnalyticsService.Log("ScanPage");
     }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1374 

> 2. What was changed?

There seems to be an issue with the camera library on iOS where toggling the CameraEnabled value too quickly after the value was previously changed can cause the entire app to lock up for several seconds. One way to reproduce this is by going to the scanner, tapping My Code, tapping Scan and then soon after tapping one of the tabs at the bottom of the screen.

This change updates this toggling code to prevent this value from changing too quickly by adding a delay, which appears to resolve this issue.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->