### PR TITLE
🐛 Mobile | Social media popup improvements

### DIFF
--- a/src/Application/Leaderboard/LeaderboardService.cs
+++ b/src/Application/Leaderboard/LeaderboardService.cs
@@ -86,7 +86,7 @@ public class LeaderboardService : ILeaderboardService
             user.Rank = ++rank;
             user.Title = user.Title switch
             {
-                _ when !string.IsNullOrEmpty(user.Title) => RegexHelpers.TitleRegex().Replace(user.Title, string.Empty),
+                _ when !string.IsNullOrEmpty(user.Title) => RegexHelpers.WebsiteRegex().Replace(user.Title, string.Empty),
                 _ when user.Email?.EndsWith("ssw.com.au") == true => "SSW",
                 _ => "Community"
             };

--- a/src/Common/Utils/RegexHelpers.cs
+++ b/src/Common/Utils/RegexHelpers.cs
@@ -2,34 +2,34 @@
 
 namespace SSW.Rewards.Shared.Utils;
 
-public static class RegexHelpers
+public static partial class RegexHelpers
 {
-    private static readonly Regex _titleRegex = new(@"^https?://", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200));
-    private static readonly Regex _linkedInRegex = new(LinkedInValidationPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200));
-    private static readonly Regex _gitHubRegex = new(GitHubValidationPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200));
-    private static readonly Regex _twitterRegex = new(TwitterValidationPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200));
-    private static readonly Regex _companyRegex = new(CompanyValidationPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200));
+    private const string LinkedInValidationPattern = @"^https?://(www\.)?linkedin\.com/in/(?<username>[a-zA-Z0-9._-]+)$";
+    private const string GitHubValidationPattern = @"^https?://(www\.)?github\.com/(?<username>[a-zA-Z0-9._-]+)$";
+    private const string TwitterValidationPattern = @"^https?://(www\.)?(twitter|x)\.com/(?<username>[a-zA-Z0-9._-]+)$";
+    private const string CompanyValidationPattern = @"^https?://\S+";
 
-    public const string LinkedInValidationPattern = "^https?://(www.)?linkedin.com/in/([a-zA-Z0-9._-]+)$";
-    public const string GitHubValidationPattern = "^https?://(www.)?github.com/([a-zA-Z0-9._-]+)$";
-    public const string TwitterValidationPattern = "^https?://(www.)?(twitter|x).com/([a-zA-Z0-9._-]+)$";
-    public const string CompanyValidationPattern = @"^https?://\S+";
+    [GeneratedRegex(@"^https?://", RegexOptions.IgnoreCase, 200)]
+    public static partial Regex TitleRegex();
 
-    /// <summary>
-    /// Use old school compile Regex. In MAUI .NET 8 generated Regex results in infinite compile.
-    /// When upgraded to .NET 9, try
-    /// [GeneratedRegex(@"^https?://")]
-    /// public static Regex HttpRegex ParseTitle();
-    /// </summary>
-    public static Regex TitleRegex() => _titleRegex;
+    [GeneratedRegex(LinkedInValidationPattern, RegexOptions.IgnoreCase, 200)]
+    public static partial Regex LinkedInRegex();
 
-    public static Regex SocialRegexByPattern(string validationPattern)
-        => validationPattern switch
-        {
-            LinkedInValidationPattern => _linkedInRegex,
-            GitHubValidationPattern => _gitHubRegex,
-            TwitterValidationPattern => _twitterRegex,
-            CompanyValidationPattern => _companyRegex,
-            _ => new Regex(validationPattern, RegexOptions.IgnoreCase)
-        };
+    [GeneratedRegex(GitHubValidationPattern, RegexOptions.IgnoreCase, 200)]
+    public static partial Regex GitHubRegex();
+
+    [GeneratedRegex(TwitterValidationPattern, RegexOptions.IgnoreCase, 200)]
+    public static partial Regex TwitterRegex();
+
+    [GeneratedRegex(CompanyValidationPattern, RegexOptions.IgnoreCase, 200)]
+    public static partial Regex CompanyRegex();
+
+    // Extract username from social media URLs
+    public static string ExtractUsername(this Regex regex, string url)
+    {
+        var match = regex.Match(url);
+        return match.Success && match.Groups["username"].Success
+            ? match.Groups["username"].Value
+            : string.Empty;
+    }
 }

--- a/src/Common/Utils/RegexHelpers.cs
+++ b/src/Common/Utils/RegexHelpers.cs
@@ -4,13 +4,10 @@ namespace SSW.Rewards.Shared.Utils;
 
 public static partial class RegexHelpers
 {
-    private const string LinkedInValidationPattern = @"^https?://(www\.)?linkedin\.com/in/(?<handle>[a-zA-Z0-9._-]+)$";
-    private const string GitHubValidationPattern = @"^https?://(www\.)?github\.com/(?<handle>[a-zA-Z0-9._-]+)$";
-    private const string TwitterValidationPattern = @"^https?://(www\.)?(twitter|x)\.com/(?<handle>[a-zA-Z0-9._-]+)$";
-    private const string CompanyValidationPattern = @"^https?://(?<handle>[a-zA-Z0-9._-]+\.[a-zA-Z]{2,})(?:/.*)?$";
-
-    [GeneratedRegex(@"^https?://", RegexOptions.IgnoreCase, 200)]
-    public static partial Regex TitleRegex();
+    private const string LinkedInValidationPattern = @"^https?://(www\.)?linkedin\.com/in/(?<handle>[a-zA-Z0-9._-]+)(?:\?.*)?$";
+    private const string GitHubValidationPattern = @"^https?://(www\.)?github\.com/(?<handle>[a-zA-Z0-9._-]+)(?:\?.*)?$";
+    private const string TwitterValidationPattern = @"^https?://(www\.)?(twitter|x)\.com/(?<handle>[a-zA-Z0-9._-]+)(?:\?.*)?$";
+    private const string WebsitePattern = @"^https?://(?<handle>[a-zA-Z0-9._-]+\.[a-zA-Z]{2,})(?:/.*)?$";
 
     [GeneratedRegex(LinkedInValidationPattern, RegexOptions.IgnoreCase, 200)]
     public static partial Regex LinkedInRegex();
@@ -21,8 +18,8 @@ public static partial class RegexHelpers
     [GeneratedRegex(TwitterValidationPattern, RegexOptions.IgnoreCase, 200)]
     public static partial Regex TwitterRegex();
 
-    [GeneratedRegex(CompanyValidationPattern, RegexOptions.IgnoreCase, 200)]
-    public static partial Regex CompanyRegex();
+    [GeneratedRegex(WebsitePattern, RegexOptions.IgnoreCase, 200)]
+    public static partial Regex WebsiteRegex();
 
     // Extract handle from URLs (username for social media, domain for company websites)
     public static string ExtractHandle(this Regex regex, string url)

--- a/src/Common/Utils/RegexHelpers.cs
+++ b/src/Common/Utils/RegexHelpers.cs
@@ -4,10 +4,10 @@ namespace SSW.Rewards.Shared.Utils;
 
 public static partial class RegexHelpers
 {
-    private const string LinkedInValidationPattern = @"^https?://(www\.)?linkedin\.com/in/(?<username>[a-zA-Z0-9._-]+)$";
-    private const string GitHubValidationPattern = @"^https?://(www\.)?github\.com/(?<username>[a-zA-Z0-9._-]+)$";
-    private const string TwitterValidationPattern = @"^https?://(www\.)?(twitter|x)\.com/(?<username>[a-zA-Z0-9._-]+)$";
-    private const string CompanyValidationPattern = @"^https?://\S+";
+    private const string LinkedInValidationPattern = @"^https?://(www\.)?linkedin\.com/in/(?<handle>[a-zA-Z0-9._-]+)$";
+    private const string GitHubValidationPattern = @"^https?://(www\.)?github\.com/(?<handle>[a-zA-Z0-9._-]+)$";
+    private const string TwitterValidationPattern = @"^https?://(www\.)?(twitter|x)\.com/(?<handle>[a-zA-Z0-9._-]+)$";
+    private const string CompanyValidationPattern = @"^https?://(?<handle>[a-zA-Z0-9._-]+\.[a-zA-Z]{2,})(?:/.*)?$";
 
     [GeneratedRegex(@"^https?://", RegexOptions.IgnoreCase, 200)]
     public static partial Regex TitleRegex();
@@ -24,12 +24,12 @@ public static partial class RegexHelpers
     [GeneratedRegex(CompanyValidationPattern, RegexOptions.IgnoreCase, 200)]
     public static partial Regex CompanyRegex();
 
-    // Extract username from social media URLs
-    public static string ExtractUsername(this Regex regex, string url)
+    // Extract handle from URLs (username for social media, domain for company websites)
+    public static string ExtractHandle(this Regex regex, string url)
     {
         var match = regex.Match(url);
-        return match.Success && match.Groups["username"].Success
-            ? match.Groups["username"].Value
+        return match.Success && match.Groups["handle"].Success
+            ? match.Groups["handle"].Value
             : string.Empty;
     }
 }

--- a/src/MobileUI/Config/SocialMediaConfig.cs
+++ b/src/MobileUI/Config/SocialMediaConfig.cs
@@ -1,0 +1,42 @@
+using SSW.Rewards.Shared.Utils;
+
+namespace SSW.Rewards.Mobile.Config;
+
+public class SocialMediaConfig
+{
+    public Dictionary<int, SocialMediaPlatform> Platforms { get; } = new()
+    {
+        [Constants.SocialMediaPlatformIds.LinkedIn] = new SocialMediaPlatform
+        {
+            PlatformName = "LinkedIn",
+            Url = "https://linkedin.com/in/",
+            Placeholder = "[your-name]",
+            ValidationPattern = RegexHelpers.LinkedInRegex,
+            Icon = "\\uf0e1"
+        },
+        [Constants.SocialMediaPlatformIds.GitHub] = new SocialMediaPlatform
+        {
+            PlatformName = "GitHub",
+            Url = "https://github.com/",
+            Placeholder = "[your-username]",
+            ValidationPattern = RegexHelpers.GitHubRegex,
+            Icon = "\\uf09b"
+        },
+        [Constants.SocialMediaPlatformIds.Twitter] = new SocialMediaPlatform
+        {
+            PlatformName = "Twitter",
+            Url = "https://x.com/",
+            Placeholder = "[your-username]",
+            ValidationPattern = RegexHelpers.TwitterRegex,
+            Icon = "\\ue61b"
+        },
+        [Constants.SocialMediaPlatformIds.Company] = new SocialMediaPlatform
+        {
+            PlatformName = "Company",
+            Url = "https://",
+            Placeholder = "[your-website]",
+            ValidationPattern = RegexHelpers.WebsiteRegex,
+            Icon = "\\uf1ad"
+        }
+    };
+}

--- a/src/MobileUI/Controls/Snackbar.xaml
+++ b/src/MobileUI/Controls/Snackbar.xaml
@@ -4,7 +4,9 @@
            xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
            x:Class="SSW.Rewards.Mobile.Controls.Snackbar"
            VerticalOptions="End"
-           BackgroundColor="Transparent">
+           BackgroundColor="Transparent"
+           Padding="0"
+           Margin="0">
 
     <Border StrokeShape="RoundRectangle 3"
             StrokeThickness="0"

--- a/src/MobileUI/DependencyInjection.cs
+++ b/src/MobileUI/DependencyInjection.cs
@@ -106,6 +106,7 @@ public static class DependencyInjection
 
         // Configuration that in the future will be modifiable by the user or WebAPI
         services.AddSingleton(new ScannerConfig());
+        services.AddSingleton(new SocialMediaConfig());
 
         // Add Firebase logging
         services.AddLogging(builder =>

--- a/src/MobileUI/Features/Activity/ActivityPageViewModel.cs
+++ b/src/MobileUI/Features/Activity/ActivityPageViewModel.cs
@@ -108,7 +108,7 @@ public partial class ActivityPageViewModel : BaseViewModel
                     : x.UserAvatar;
                 x.AchievementMessage = GetMessage(x.Achievement);
                 x.TimeElapsed = DateTimeHelpers.GetTimeElapsed(x.AwardedAt);
-                x.UserTitle = RegexHelpers.TitleRegex().Replace(x.UserTitle, string.Empty);
+                x.UserTitle = RegexHelpers.WebsiteRegex().Replace(x.UserTitle, string.Empty);
                 return x;
             }).ToList();
         }

--- a/src/MobileUI/Features/Leaderboard/LeaderViewModel.cs
+++ b/src/MobileUI/Features/Leaderboard/LeaderViewModel.cs
@@ -25,7 +25,7 @@ public partial class LeaderViewModel : BaseViewModel
         _displayPoints = user.Points;
 
         Title = !string.IsNullOrWhiteSpace(user.Title)
-            ? RegexHelpers.TitleRegex().Replace(user.Title, string.Empty)
+            ? RegexHelpers.WebsiteRegex().Replace(user.Title, string.Empty)
             : string.Empty;
     }
 

--- a/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
+++ b/src/MobileUI/Features/Profile/ProfileViewModelBase.cs
@@ -151,7 +151,7 @@ public partial class ProfileViewModelBase : BaseViewModel
         }
 
         return !string.IsNullOrEmpty(CompanyUrl)
-            ? RegexHelpers.TitleRegex().Replace(CompanyUrl, string.Empty)
+            ? RegexHelpers.WebsiteRegex().Replace(CompanyUrl, string.Empty)
             : "Community";
     }
 

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -70,8 +70,6 @@
                                     BackgroundColor="White"
                                     TextColor="Black">
                                     <controls:BorderlessEntry.Behaviors>
-                                        <toolkit:EventToCommandBehavior EventName="Focused"
-                                                                        Command="{Binding InputFocusedCommand}" />
                                         <toolkit:EventToCommandBehavior EventName="Unfocused"
                                                                         Command="{Binding InputUnfocusedCommand}" />
                                     </controls:BorderlessEntry.Behaviors>

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <pages:PopupPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Mopups.Pages;assembly=Mopups"
-             xmlns:animations="clr-namespace:Mopups.Animations;assembly=Mopups"
-             xmlns:viewModels="clr-namespace:SSW.Rewards.Mobile.ViewModels"
-             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             xmlns:controls="clr-namespace:SSW.Rewards.Mobile.Controls"
-             BackgroundColor="#b3000000"
-             CloseWhenBackgroundIsClicked="False"
-             x:DataType="viewModels:AddSocialMediaViewModel"
-             x:Class="SSW.Rewards.Mobile.PopupPages.AddSocialMediaPage">
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:pages="clr-namespace:Mopups.Pages;assembly=Mopups"
+                 xmlns:animations="clr-namespace:Mopups.Animations;assembly=Mopups"
+                 xmlns:viewModels="clr-namespace:SSW.Rewards.Mobile.ViewModels"
+                 xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+                 xmlns:controls="clr-namespace:SSW.Rewards.Mobile.Controls"
+                 BackgroundColor="#b3000000"
+                 CloseWhenBackgroundIsClicked="False"
+                 x:DataType="viewModels:AddSocialMediaViewModel"
+                 x:Class="SSW.Rewards.Mobile.PopupPages.AddSocialMediaPage">
     <pages:PopupPage.Behaviors>
         <toolkit:StatusBarBehavior StatusBarColor="{OnPlatform iOS='Transparent', Android={StaticResource Background}}"
                                    StatusBarStyle="LightContent" />
@@ -32,80 +32,83 @@
                 StrokeShape="RoundRectangle 10"
                 BackgroundColor="{StaticResource Background}">
 
-                <Grid Padding="0" RowDefinitions="*, Auto">
-                    <VerticalStackLayout Spacing="6" Margin="0,30">
+                <Grid RowDefinitions="*, Auto">
+                    <VerticalStackLayout Spacing="30" Margin="20,30">
                         <Label HorizontalTextAlignment="Center"
                                TextColor="{StaticResource SSWRed}"
-                               FontSize="Large"
-                               Text="{Binding PlatformName}"/>
+                               FontSize="22"
+                               Text="{Binding PlatformName}" />
+
                         <Label HorizontalTextAlignment="Center"
-                               Margin="20"
                                TextColor="White"
                                Text="{Binding Path=PlatformName, StringFormat='Receive ⭐️ 150 points for connecting your {0} with SSW Rewards'}">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label"
                                              Binding="{Binding CurrentUrl, Converter={toolkit:IsStringNullOrEmptyConverter}}"
                                              Value="False">
-                                    <Setter Property="Text" Value="{Binding Path=PlatformName, StringFormat='Update your {0} connection with SSW Rewards'}" />
+                                    <Setter Property="Text"
+                                            Value="{Binding Path=PlatformName, StringFormat='Update your {0} connection with SSW Rewards'}" />
                                 </DataTrigger>
                             </Label.Triggers>
                         </Label>
-                        
-                        <Border
-                            Margin="20,0"
-                            StrokeShape="RoundRectangle 10"
-                            StrokeThickness="0"
-                            HeightRequest="45">
-                            <Entry
-                                Text="{Binding InputText}"
-                                Keyboard="Url"
-                                ReturnType="Done"
-                                Placeholder="{Binding Placeholder}"
-                                CursorPosition="{Binding CursorPosition}"
-                                IsSpellCheckEnabled="False"
-                                PlaceholderColor="Grey"
-                                BackgroundColor="White"
-                                TextColor="Black">
-                                <controls:BorderlessEntry.Behaviors>
-                                    <toolkit:EventToCommandBehavior EventName="Focused" Command="{Binding InputFocusedCommand}"/>
-                                    <toolkit:EventToCommandBehavior EventName="Unfocused" Command="{Binding InputUnfocusedCommand}"/>
-                                </controls:BorderlessEntry.Behaviors>
-                            </Entry>
-                        </Border>
-                        
-                        <VerticalStackLayout HeightRequest="40">
+
+                        <VerticalStackLayout Spacing="5">
+                            <Label HorizontalTextAlignment="Start"
+                                   Text="{Binding Url}" />
+
+                            <Border
+                                StrokeShape="RoundRectangle 10"
+                                StrokeThickness="0">
+                                <Entry
+                                    Text="{Binding InputText}"
+                                    Keyboard="Plain"
+                                    ReturnType="Done"
+                                    Placeholder="{Binding Placeholder}"
+                                    CursorPosition="{Binding CursorPosition}"
+                                    IsSpellCheckEnabled="False"
+                                    PlaceholderColor="Grey"
+                                    BackgroundColor="White"
+                                    TextColor="Black">
+                                    <controls:BorderlessEntry.Behaviors>
+                                        <toolkit:EventToCommandBehavior EventName="Focused"
+                                                                        Command="{Binding InputFocusedCommand}" />
+                                        <toolkit:EventToCommandBehavior EventName="Unfocused"
+                                                                        Command="{Binding InputUnfocusedCommand}" />
+                                    </controls:BorderlessEntry.Behaviors>
+                                </Entry>
+                            </Border>
+
                             <Label
                                 FontSize="11"
-                                Margin="30,0"
+                                HeightRequest="20"
                                 Text="{Binding ErrorText}"
-                                TextColor="{StaticResource SSWRed}"
-                            />
-                            <Label
-                                FontSize="11"
-                                Margin="30,0"
-                                Text="{Binding SuccessText}"
-                                TextColor="White"
-                            />
+                                TextColor="{StaticResource SSWRed}" />
                         </VerticalStackLayout>
-                        
-                        <Label
-                            HorizontalOptions="Center"
-                            FontFamily="FA6Brands"
-                            Text="{Binding Icon}"
-                            FontAutoScalingEnabled="False"
-                            FontSize="50"
-                            TextColor="DimGrey">
-                            <Label.Triggers>
-                                <DataTrigger TargetType="Label"
-                                             Binding="{Binding InputText, Converter={toolkit:IsStringNotNullOrEmptyConverter}}"
-                                             Value="True">
-                                    <Setter Property="TextColor" Value="{StaticResource SSWRed}" />
-                                </DataTrigger>
-                            </Label.Triggers>
-                            <Label.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding OpenLinkCommand}" />
-                            </Label.GestureRecognizers>
-                        </Label>
+
+                        <VerticalStackLayout Spacing="5">
+                            <Label Text="Preview:"
+                                   HorizontalOptions="Start" />
+
+                            <Label
+                                Text="{Binding CompleteUrl}"
+                                FontSize="16"
+                                TextColor="DimGrey"
+                                LineBreakMode="CharacterWrap"
+                                MaxLines="2">
+                                <Label.Triggers>
+                                    <DataTrigger TargetType="Label"
+                                                 Binding="{Binding InputText, Converter={toolkit:IsStringNotNullOrEmptyConverter}}"
+                                                 Value="True">
+                                        <Setter Property="TextColor" Value="{StaticResource SSWRed}" />
+                                        <Setter Property="TextDecorations" Value="Underline" />
+                                    </DataTrigger>
+                                </Label.Triggers>
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding OpenLinkCommand}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </VerticalStackLayout>
+
                     </VerticalStackLayout>
                     <Button
                         Text="Connect"
@@ -114,7 +117,7 @@
                         VerticalOptions="End"
                         Margin="20,30"
                         CornerRadius="10"
-                        HeightRequest="60"/>
+                        HeightRequest="60" />
                 </Grid>
             </Border>
 
@@ -131,9 +134,9 @@
                 VerticalOptions="Start"
                 HorizontalOptions="End">
                 <Border.GestureRecognizers>
-                    <TapGestureRecognizer Command="{Binding ClosePageCommand}"/>
+                    <TapGestureRecognizer Command="{Binding ClosePageCommand}" />
                 </Border.GestureRecognizers>
-                <Image Source="icon_close"/>
+                <Image Source="icon_close" />
             </Border>
         </Grid>
         <ActivityIndicator
@@ -141,6 +144,6 @@
             VerticalOptions="Center"
             Color="{StaticResource SSWRed}"
             IsRunning="{Binding IsBusy}"
-            IsVisible="{Binding IsBusy}"/>
+            IsVisible="{Binding IsBusy}" />
     </Grid>
 </pages:PopupPage>

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml
@@ -97,7 +97,7 @@
                                 MaxLines="2">
                                 <Label.Triggers>
                                     <DataTrigger TargetType="Label"
-                                                 Binding="{Binding InputText, Converter={toolkit:IsStringNotNullOrEmptyConverter}}"
+                                                 Binding="{Binding IsUrlValid}"
                                                  Value="True">
                                         <Setter Property="TextColor" Value="{StaticResource SSWRed}" />
                                         <Setter Property="TextDecorations" Value="Underline" />

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
@@ -3,18 +3,25 @@ namespace SSW.Rewards.Mobile.PopupPages;
 public partial class AddSocialMediaPage
 {
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
+    private readonly AddSocialMediaViewModel _vm;
+    private readonly string _currentUrl;
+    private readonly int _socialMediaPlatformId;
 
     public AddSocialMediaPage(IFirebaseAnalyticsService firebaseAnalyticsService, IServiceProvider provider,
         int socialMediaPlatformId, string currentUrl)
     {
         _firebaseAnalyticsService = firebaseAnalyticsService;
+        _socialMediaPlatformId = socialMediaPlatformId;
+        _currentUrl = currentUrl;
         InitializeComponent();
-        BindingContext = ActivatorUtilities.CreateInstance<AddSocialMediaViewModel>(provider, socialMediaPlatformId, currentUrl);
+        _vm = ActivatorUtilities.CreateInstance<AddSocialMediaViewModel>(provider);
+        BindingContext = _vm;
     }
 
-    protected override void OnAppearing()
+    protected override async void OnAppearing()
     {
         base.OnAppearing();
         _firebaseAnalyticsService.Log("AddSocialMediaPage");
+        await _vm.InitialiseAsync(_currentUrl, _socialMediaPlatformId);
     }
 }

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaPage.xaml.cs
@@ -5,8 +5,7 @@ public partial class AddSocialMediaPage
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
 
     public AddSocialMediaPage(IFirebaseAnalyticsService firebaseAnalyticsService, IServiceProvider provider,
-        int socialMediaPlatformId,
-        string currentUrl)
+        int socialMediaPlatformId, string currentUrl)
     {
         _firebaseAnalyticsService = firebaseAnalyticsService;
         InitializeComponent();

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -152,20 +152,6 @@ public partial class AddSocialMediaViewModel : BaseViewModel
     }
 
     [RelayCommand]
-    private void InputFocused()
-    {
-        if (string.IsNullOrWhiteSpace(InputText))
-        {
-            InputText = Url;
-        }
-
-        MainThread.BeginInvokeOnMainThread(() =>
-        {
-            CursorPosition = InputText.Length;
-        });
-    }
-
-    [RelayCommand]
     private void InputUnfocused()
     {
         InputText = InputText.Trim();

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -207,6 +207,7 @@ public partial class AddSocialMediaViewModel : BaseViewModel
             var result = await _userService.SaveSocialMedia(_platformId, CompleteUrl);
             var snackbarOptions = CreateSnackbarOptions(result);
 
+            // Close window as both true and false are successful states in this case
             if (result.HasValue)
             {
                 await ClosePage();

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -98,7 +98,7 @@ public partial class AddSocialMediaViewModel : BaseViewModel
 
         if (!string.IsNullOrWhiteSpace(currentUrl))
         {
-            InputText = _validationPattern.ExtractUsername(currentUrl);
+            InputText = _validationPattern.ExtractHandle(currentUrl);
         }
     }
 

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -102,6 +102,21 @@ public partial class AddSocialMediaViewModel : BaseViewModel
         }
     }
 
+    partial void OnInputTextChanged(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        // Check if the user pasted or entered a full URL and extract just the handle
+        var extractedHandle = _validationPattern.ExtractHandle(value);
+        if (!string.IsNullOrEmpty(extractedHandle) && extractedHandle != value)
+        {
+            InputText = extractedHandle;
+        }
+    }
+
     [RelayCommand]
     private async Task Connect()
     {

--- a/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
+++ b/src/MobileUI/Features/SocialMedia/AddSocialMediaViewModel.cs
@@ -94,10 +94,9 @@ public partial class AddSocialMediaViewModel : BaseViewModel
             Icon = config.Icon;
             CurrentUrl = currentUrl;
 
-            // Extract handle from current URL if editing
             if (!string.IsNullOrWhiteSpace(currentUrl))
             {
-                InputText = _validationPattern.ExtractHandle(currentUrl);
+                InputText = currentUrl;
             }
         }
         catch (Exception ex)

--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -18,7 +18,7 @@
 		<ApplicationIdGuid>fb3c30ce-ab0c-4155-b244-e49513e45a94</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>3.1.1</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>3.1.2</ApplicationDisplayVersion>
 		<ApplicationVersion>2</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>

--- a/src/MobileUI/Models/SocialMediaPlatform.cs
+++ b/src/MobileUI/Models/SocialMediaPlatform.cs
@@ -1,10 +1,12 @@
+using System.Text.RegularExpressions;
+
 namespace SSW.Rewards.Models;
 
 public class SocialMediaPlatform
 {
-    public int PlatformId { get; set; }
     public string PlatformName { get; set; }
     public string Url { get; set; }
     public string Placeholder { get; set; }
-    public string ValidationPattern { get; set; }
+    public Func<Regex> ValidationPattern { get; set; }
+    public string Icon { get; set; }
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1292 

> 2. What was changed?

Updates the social media popup to be more intuitive and user friendly by only needing the username portion to be entered. The bottom shows a preview of the URL that can also be tapped if valid to test opening the link. The user can also paste in their full URL and it will automatically strip out just the necessary part.

Also improves the code a lot to be cleaner and improves error handling.

Also fixes a small issue with the snackbar showing a large outline that was introduced in .NET 9.

<img width="400" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-11 at 09 59 48" src="https://github.com/user-attachments/assets/e9cc0e94-8a44-4872-9ffb-cf76975f32eb" />

**Figure: Social media popup now only requires the username part of the URL**

<img width="400" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-11 at 09 59 59" src="https://github.com/user-attachments/assets/a5e03dfe-6cf2-4b46-837a-78893d68f47d" />

**Figure: A preview of the link is shown that can be tapped to open**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->