### PR TITLE
Add DateTimeFormatter for consistent date formatting in notifications

### DIFF
--- a/src/AdminUI/Helpers/DateTimeFormatter.cs
+++ b/src/AdminUI/Helpers/DateTimeFormatter.cs
@@ -1,0 +1,10 @@
+namespace SSW.Rewards.Admin.UI.Helpers;
+
+public static class DateTimeFormatter
+{
+    public static string FormatLongDate(DateTime? date)
+        => date.HasValue
+            // Format based on https://www.ssw.com.au/rules/weekdays-on-date-selectors/
+            ? $"{date.Value:ddd}, {date.Value:d} {date.Value:t}"
+            : "-";
+}

--- a/src/AdminUI/Pages/Notifications.razor
+++ b/src/AdminUI/Pages/Notifications.razor
@@ -26,7 +26,7 @@
             <MudTh><MudTableSortLabel T="NotificationHistoryDto" SortLabel="Title">Title</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel T="NotificationHistoryDto" SortLabel="CreatedDateUtc">Created</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel T="NotificationHistoryDto" SortLabel="Status">Status</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel T="NotificationHistoryDto">Delivery Date</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="NotificationHistoryDto">Delivered</MudTableSortLabel></MudTh>
             <MudTh>
                 <MudTooltip Text="This column shows the number of users who received the notification vs the total number of users we tried to send it to. Reasons for not being delivered include expired device tokens or users never approving/registering for notifications.">
                     <span style="cursor: help;">Delivered to<span style="color: red;">*</span></span>
@@ -35,7 +35,7 @@
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Title">@context.Title</MudTd>
-            <MudTd DataLabel="Created">@context.CreatedDateUtc.ToLocalTime().ToString("g")</MudTd>
+            <MudTd DataLabel="Created">@DateTimeFormatter.FormatLongDate(context.CreatedDateUtc.ToLocalTime())</MudTd>
             <MudTd DataLabel="Status">
                 @switch (context.Status)
                 {
@@ -53,14 +53,14 @@
                         break;
                 }
             </MudTd>
-            <MudTd DataLabel="Delivery Date">
+            <MudTd DataLabel="Delivered">
                 @switch (context.Status)
                 {
                     case NotificationStatus.Sent when context.SentOn != null:
-                        @context.SentOn?.ToLocalTime().ToString("g")
+                        @DateTimeFormatter.FormatLongDate(context.SentOn?.ToLocalTime())
                         break;
                     case NotificationStatus.Scheduled when context.ScheduledDate != null:
-                        @context.ScheduledDate?.ToLocalTime().ToString("g") <span> (Scheduled)</span>
+                        @DateTimeFormatter.FormatLongDate(context.ScheduledDate?.ToLocalTime()) <span> (Scheduled)</span>
                         break;
                     default:
                         <span>-</span>

--- a/src/AdminUI/_Imports.razor
+++ b/src/AdminUI/_Imports.razor
@@ -14,3 +14,4 @@
 
 @using SSW.Rewards.Admin.UI
 @using SSW.Rewards.Admin.UI.Shared
+@using SSW.Rewards.Admin.UI.Helpers


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1368 

> 2. What was changed?

✏️ Format rule https://www.ssw.com.au/rules/weekdays-on-date-selectors/ and takes the correct browser language format.

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<img width="1423" height="589" alt="image" src="https://github.com/user-attachments/assets/e44d5ef2-3613-435c-878f-11379c2e0f04" />

**Figure: Australian format.**

<img width="1416" height="582" alt="image" src="https://github.com/user-attachments/assets/3ab09514-1261-4d2b-a98d-0c42e136a37a" />

**Figure: American format.**

<img width="1411" height="585" alt="image" src="https://github.com/user-attachments/assets/57c9306f-211a-4af2-96d8-96b1ca40bc48" />

**Figure: Chinese format.**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->