### PR TITLE
🐛 Mobile | Fix quiz results page not scrollable

### DIFF
--- a/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
+++ b/src/MobileUI/Features/Quiz/QuizDetailsPage.xaml
@@ -281,123 +281,68 @@
                     Grid.Row="0"
                     IsAnimationEnabled="{Binding ShowConfetti}" />
 
-                <VerticalStackLayout Grid.Row="1"
-                                     BindableLayout.ItemsSource="{Binding Results}"
-                                     BackgroundColor="{StaticResource QuizDescriptionBackground}"
-                                     Padding="15"
-                                     Spacing="15">
-                    <BindableLayout.ItemTemplate>
-                        <DataTemplate x:DataType="quizzes:QuestionResultDto">
-                            <Border BackgroundColor="{StaticResource Background}"
-                                    StrokeThickness="0"
-                                    StrokeShape="RoundRectangle 6"
-                                    Padding="15">
-                                <Border.Triggers>
-                                    <DataTrigger TargetType="Border"
-                                                 Binding="{Binding Correct}"
-                                                 Value="False">
-                                        <Setter Property="Stroke" Value="{StaticResource SSWRed}" />
-                                    </DataTrigger>
-                                </Border.Triggers>
-                                <VerticalStackLayout Spacing="5">
-                                    <Label Text="{Binding Index, StringFormat='Question {0}'}"
-                                           FontSize="12">
-                                        <Label.FormattedText>
-                                            <FormattedString>
-                                                <Span Text="Question " />
-                                                <Span Text="{Binding Index}" />
-                                                <Span Text="/" />
-                                                <Span
-                                                    Text="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizDetailsViewModel}}, Path=Questions.Count}" />
-                                            </FormattedString>
-                                        </Label.FormattedText>
-                                    </Label>
+                <ScrollView Grid.Row="1">
+                    <VerticalStackLayout BindableLayout.ItemsSource="{Binding Results}"
+                                         BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                                         Padding="15"
+                                         Spacing="15">
+                        <BindableLayout.ItemTemplate>
+                            <DataTemplate x:DataType="quizzes:QuestionResultDto">
+                                <Border BackgroundColor="{StaticResource Background}"
+                                        StrokeThickness="0"
+                                        StrokeShape="RoundRectangle 6"
+                                        Padding="15">
+                                    <Border.Triggers>
+                                        <DataTrigger TargetType="Border" Binding="{Binding Correct}" Value="False">
+                                            <Setter Property="Stroke" Value="{StaticResource SSWRed}" />
+                                        </DataTrigger>
+                                    </Border.Triggers>
+                                    <VerticalStackLayout Spacing="5">
+                                        <Label Text="{Binding Index, StringFormat='Question {0}'}" FontSize="12">
+                                            <Label.FormattedText>
+                                                <FormattedString>
+                                                    <Span Text="Question " />
+                                                    <Span Text="{Binding Index}" />
+                                                    <Span Text="/" />
+                                                    <Span Text="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizDetailsViewModel}}, Path=Questions.Count}" />
+                                                </FormattedString>
+                                            </Label.FormattedText>
+                                        </Label>
 
-                                    <Label Text="{Binding QuestionText}"
-                                           FontSize="16" />
+                                        <Label Text="{Binding QuestionText}" FontSize="16" />
 
-                                    <Border BackgroundColor="{StaticResource QuizDescriptionBackground}"
-                                            StrokeThickness="0"
-                                            StrokeShape="RoundRectangle 6"
-                                            Padding="10"
-                                            Margin="0,10,0,0">
-                                        <toolkit:Expander
-                                            x:Name="Expander"
-                                            IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
-                                            <toolkit:Expander.Header>
-                                                <Grid
-                                                    ColumnDefinitions="20, *, 20"
-                                                    RowDefinitions="Auto">
-                                                    <Label Grid.Column="0"
-                                                           FontFamily="FA6Regular"
-                                                           TextColor="{StaticResource QuizCheckColor}"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           FontSize="14"
-                                                           Text="&#xf058;"
-                                                           IsVisible="{Binding Correct}" />
-                                                    <Label Grid.Column="0"
-                                                           FontFamily="FA6Regular"
-                                                           TextColor="{StaticResource SSWRed}"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           FontSize="14"
-                                                           Text="&#xf057;"
-                                                           IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
+                                        <Border BackgroundColor="{StaticResource QuizDescriptionBackground}"
+                                                StrokeThickness="0"
+                                                StrokeShape="RoundRectangle 6"
+                                                Padding="10"
+                                                Margin="0,10,0,0">
+                                            <toolkit:Expander x:Name="Expander" IsExpanded="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}">
+                                                <toolkit:Expander.Header>
+                                                    <Grid ColumnDefinitions="20, *, 20" RowDefinitions="Auto">
+                                                        <Label Grid.Column="0" FontFamily="FA6Regular" TextColor="{StaticResource QuizCheckColor}" VerticalTextAlignment="Center" VerticalOptions="Center" FontSize="14" Text="&#xf058;" IsVisible="{Binding Correct}" />
+                                                        <Label Grid.Column="0" FontFamily="FA6Regular" TextColor="{StaticResource SSWRed}" VerticalTextAlignment="Center" VerticalOptions="Center" FontSize="14" Text="&#xf057;" IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" />
 
-                                                    <Label Grid.Column="1"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           Text="Correct"
-                                                           IsVisible="{Binding Correct}"
-                                                           TextColor="{StaticResource QuizCheckColor}"
-                                                           FontSize="14" />
-                                                    <Label Grid.Column="1"
-                                                           VerticalTextAlignment="Center"
-                                                           VerticalOptions="Center"
-                                                           Text="Incorrect"
-                                                           IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}"
-                                                           TextColor="{StaticResource SSWRed}"
-                                                           FontSize="14" />
+                                                        <Label Grid.Column="1" VerticalTextAlignment="Center" VerticalOptions="Center" Text="Correct" IsVisible="{Binding Correct}" TextColor="{StaticResource QuizCheckColor}" FontSize="14" />
+                                                        <Label Grid.Column="1" VerticalTextAlignment="Center" VerticalOptions="Center" Text="Incorrect" IsVisible="{Binding Correct, Converter={toolkit:InvertedBoolConverter}}" TextColor="{StaticResource SSWRed}" FontSize="14" />
 
-                                                    <Image Grid.Column="2"
-                                                           IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}"
-                                                           HeightRequest="12"
-                                                           WidthRequest="12"
-                                                           Source="icon_chevron_right" />
-                                                    <Image Grid.Column="2"
-                                                           IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}"
-                                                           HeightRequest="12"
-                                                           WidthRequest="12"
-                                                           Source="icon_chevron_down" />
-                                                </Grid>
-                                            </toolkit:Expander.Header>
-                                            <VerticalStackLayout Padding="20,10">
-                                                <Label Text="Your response:"
-                                                       FontSize="14"
-                                                       Style="{StaticResource LabelBold}"
-                                                       TextColor="{StaticResource Gray300}" />
-                                                <Label Text="{Binding AnswerText}"
-                                                       FontSize="14"
-                                                       TextColor="{StaticResource Gray300}" />
-                                                <Label Text="Explanation:"
-                                                       Margin="0,8,0,0"
-                                                       FontSize="14"
-                                                       Style="{StaticResource LabelBold}"
-                                                       TextColor="{StaticResource Gray300}" />
-                                                <Label Text="{Binding ExplanationText}"
-                                                       FontSize="14"
-                                                       TextColor="{StaticResource Gray300}" />
-                                            </VerticalStackLayout>
-                                        </toolkit:Expander>
-                                    </Border>
-
-                                </VerticalStackLayout>
-
-                            </Border>
-                        </DataTemplate>
-                    </BindableLayout.ItemTemplate>
-                </VerticalStackLayout>
+                                                        <Image Grid.Column="2" IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded, Converter={toolkit:InvertedBoolConverter}}" HeightRequest="12" WidthRequest="12" Source="icon_chevron_right" />
+                                                        <Image Grid.Column="2" IsVisible="{Binding Source={x:Reference Expander}, Path=IsExpanded}" HeightRequest="12" WidthRequest="12" Source="icon_chevron_down" />
+                                                    </Grid>
+                                                </toolkit:Expander.Header>
+                                                <VerticalStackLayout Padding="20,10">
+                                                    <Label Text="Your response:" FontSize="14" Style="{StaticResource LabelBold}" TextColor="{StaticResource Gray300}" />
+                                                    <Label Text="{Binding AnswerText}" FontSize="14" TextColor="{StaticResource Gray300}" />
+                                                    <Label Text="Explanation:" Margin="0,8,0,0" FontSize="14" Style="{StaticResource LabelBold}" TextColor="{StaticResource Gray300}" />
+                                                    <Label Text="{Binding ExplanationText}" FontSize="14" TextColor="{StaticResource Gray300}" />
+                                                </VerticalStackLayout>
+                                            </toolkit:Expander>
+                                        </Border>
+                                    </VerticalStackLayout>
+                                </Border>
+                            </DataTemplate>
+                        </BindableLayout.ItemTemplate>
+                    </VerticalStackLayout>
+                </ScrollView>
             </Grid>
 
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1411 

> 2. What was changed?

Adds a ScrollView to quiz results so the results can be scrolled and viewed properly.

<img width="1440" height="3120" alt="Screenshot_20251017_150619" src="https://github.com/user-attachments/assets/ca7aa5bb-85b7-4174-b601-312ec213ad80" />

**Figure: Quiz results page can now be scrolled down**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->