### PR TITLE
💄 Enhance dropdown and autocomplete styles for better focus visibility

### DIFF
--- a/src/AdminUI/wwwroot/css/app.css
+++ b/src/AdminUI/wwwroot/css/app.css
@@ -14,13 +14,40 @@ input:focus, textarea:focus, select:focus {
     background-color: var(--smokey-white);
 }
 
-/* MudBlazor inputs */
-.mud-input-root:focus-within .mud-input-slot input,
-.mud-input-root:focus-within .mud-input-slot textarea,
+/* MudSelect (dropdowns) - black text on smokey white when focused */
 .mud-select:focus-within .mud-input-slot,
 .mud-select:focus-within .mud-input-slot .mud-input,
 .mud-select:focus-within .mud-input-slot input {
-    background-color: var(--smokey-white);
+    background-color: var(--smokey-white) !important;
+    color: #000000 !important;
+}
+
+.mud-select.mud-input-control-focused .mud-input-slot .mud-input-root input,
+.mud-select.mud-input-control-focused .mud-input-slot input {
+    color: #000000 !important;
+}
+
+/* MudAutocomplete (searchable dropdowns) - black text on smokey white when focused */
+.mud-autocomplete:focus-within .mud-input-slot input,
+.mud-autocomplete:focus-within .mud-input-slot .mud-input,
+.mud-autocomplete .mud-input-root:focus-within .mud-input-slot input {
+    background-color: var(--smokey-white) !important;
+    color: #000000 !important;
+}
+
+.mud-autocomplete:focus-within .mud-input-slot,
+.mud-autocomplete.mud-input-control-focused .mud-input-slot {
+    background-color: var(--smokey-white) !important;
+}
+
+.mud-autocomplete.mud-input-control-focused .mud-input-slot input {
+    color: #000000 !important;
+}
+
+/* Ensure normal state (unfocused) for dropdowns has proper styling */
+.mud-select:not(.mud-input-control-focused) .mud-input-slot input,
+.mud-autocomplete:not(.mud-input-control-focused) .mud-input-slot input {
+    background-color: transparent;
 }
 
 /* Remove red on black background */


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1392 fixing some minor UX issues

> 2. What was changed?

✏️ Fixed white text on white background.

<img width="920" height="234" alt="image" src="https://github.com/user-attachments/assets/ca319ebe-2bcf-4898-bf2b-33e3c614d6a9" />

**Figure: Broken version due some styling issues.**

<img width="913" height="188" alt="image" src="https://github.com/user-attachments/assets/649c081e-5ded-4b3a-bfea-831ed0ae2b7d" />

**Figure: New fix**

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->