### PR TITLE
Fix time display on notifications

### DIFF
--- a/src/AdminUI/Pages/SendNotification.razor.cs
+++ b/src/AdminUI/Pages/SendNotification.razor.cs
@@ -88,7 +88,7 @@ public partial class SendNotification
 
             var impactedUsers = await NotificationsService.GetNumberOfImpactedUsers(command, CancellationToken.None);
             var deliveryTime = _model.DeliveryOption == Delivery.Schedule && _model.ScheduleDate.HasValue && _model.ScheduleTime.HasValue
-                ? $"at {DateTimeFormatter.FormatLongDate(_model.ScheduleDate.Value)}"
+                ? $"at {DateTimeFormatter.FormatLongDate(DateTime.SpecifyKind((_model.ScheduleDate.Value.Date + _model.ScheduleTime.Value), DateTimeKind.Utc))} ({_model.SelectedTimeZone})"
                 : "immediately";
 
             RenderFragment confirmationContent = builder =>
@@ -101,8 +101,8 @@ public partial class SendNotification
                 builder.AddMarkupContent(5, "<p>Are you sure you want to continue?</p>");
                 builder.CloseElement();
             };
-            
-            string confirmationText = $"{(_model.DeliveryOption == Delivery.Now ? "Send" : "Schedule")} Notification"; 
+
+            string confirmationText = $"{(_model.DeliveryOption == Delivery.Now ? "Send" : "Schedule")} Notification";
             var parameters = new DialogParameters
             {
                 { "Content", confirmationContent },


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1412

> 2. What was changed?

Fixes the time display on the new notification popup which was incorrectly showing midnight.

<img width="1891" height="1016" alt="Screenshot 2025-11-07 at 11 34 09 am" src="https://github.com/user-attachments/assets/8d2d87b4-8224-48ac-9e56-9e3391f0da35" />

**Figure: Popup now shows correct time and time zone**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->