### PR TITLE
♻️ Replace delete button with icon button in Skills table

### DIFF
--- a/src/AdminUI/Pages/Skills.razor
+++ b/src/AdminUI/Pages/Skills.razor
@@ -33,7 +33,7 @@
     <ColGroup>
         <col style="width: 50px"/>
         <col />
-        <col />
+        <col style="width: 60px"/>
     </ColGroup>
     <HeaderContent>
         <MudTh>Thumbnail</MudTh>
@@ -54,7 +54,13 @@
             }
         </MudTd>
         <MudTd DataLabel="Name">@context.Name</MudTd>
-        <MudTd DataLabel="Delete"><MudButton OnClick="@(() => OnDeletedClicked(context))">Delete</MudButton></MudTd>
+        <MudTd DataLabel="Delete">
+            <MudIconButton Icon="@Icons.Material.Filled.Delete" 
+                           Color="Color.Error" 
+                           Size="Size.Small"
+                           OnClick="@(() => OnDeletedClicked(context))" 
+                           aria-label="Delete skill" />
+        </MudTd>
     </RowTemplate>
     <RowEditingTemplate>
         <MudTd DataLabel="Thumbnail">


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1458 

> 2. What was changed?

Replaces the Delete skill button with a red icon.

<img width="1142" height="478" alt="Screenshot 2025-12-05 at 3 41 39 pm" src="https://github.com/user-attachments/assets/70467f8d-16b8-4233-b3dc-3d624b1cbb61" />

**Figure: Delete button is a red icon now**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->