### PR TITLE
♻️ Update navigation and naming for deletion requests page

### DIFF
--- a/src/AdminUI/Helpers/NavigationPages.cs
+++ b/src/AdminUI/Helpers/NavigationPages.cs
@@ -32,6 +32,6 @@ public static class NavigationPages
             new() { Href = "newusers", Icon = Icons.Material.Filled.SupervisedUserCircle, Title = "New Users" },
             new() { Href = "prizedraw", Icon = Icons.Material.Filled.Celebration, Title = "Prize Draw" },
             new() { Href = "notifications", Icon = Icons.Material.Filled.Chat, Title = "Notifications" },
-            new() { Href = "deletion-requests", Icon = Icons.Material.Filled.AssignmentLate, Title = "Deletion Requests" }
+            new() { Href = "deletion-approvals", Icon = Icons.Material.Filled.AssignmentLate, Title = "Account Deletion Approvals" }
         ];
 }

--- a/src/AdminUI/Pages/ProfileDeletions.razor
+++ b/src/AdminUI/Pages/ProfileDeletions.razor
@@ -1,4 +1,4 @@
-﻿@page "/deletion-requests"
+﻿@page "/deletion-approvals"
 
 @using Microsoft.AspNetCore.Authorization
 @using SSW.Rewards.Admin.UI.Components
@@ -12,8 +12,8 @@
 
 @attribute [Authorize(Roles = "Staff, Admin")]
 
-<MudText Typo="Typo.h2">Deletion Requests</MudText>
-<MudText Typo="Typo.body1">Users who have requested that their profile be deleted</MudText>
+<MudText Typo="Typo.h2">Account Deletion Approvals</MudText>
+<MudText Typo="Typo.body1">As per the GDPR rules, users have the right to ask to be deleted. Pending requests are listed below.</MudText>
 
 
 <Table TItem="ProfileDeletionRequestDto"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1457 

> 2. What was changed?

Updates the naming for the "Delete" page to "Account Deletion Approvals" to be more specific.

<img width="1151" height="748" alt="Screenshot 2025-12-05 at 3 40 01 pm" src="https://github.com/user-attachments/assets/e9dc4273-3fb3-4bec-ad34-680c7fe7dec8" />

**Figure: Renamed Delete page**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->