### PR TITLE
♻️ Notifications page delete button improvements

### DIFF
--- a/src/AdminUI/Pages/Notifications.razor
+++ b/src/AdminUI/Pages/Notifications.razor
@@ -3,6 +3,7 @@
 @using SSW.Rewards.Shared.DTOs.Notifications
 @inject NavigationManager Navigation
 @inject SSW.Rewards.ApiClient.Services.INotificationsService NotificationsService
+@inject IDialogService DialogService
 
 <PageTitle>SSW Rewards | Mobile Notifications</PageTitle>
 
@@ -93,9 +94,10 @@
                 }
                 else
                 {
-                    <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small" OnClick="@(() => DeleteNotification(context.Id))" aria-label="Delete">
-                        <MudIcon Icon="@Icons.Material.Filled.Delete" /> &nbsp;
-                    </MudButton>
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                   Color="Color.Error"
+                                   OnClick="@(() => DeleteNotification(context.Id, context.Title))"
+                                   aria-label="Delete" />
                 }
             </MudTd>
         </RowTemplate>

--- a/src/AdminUI/Pages/Notifications.razor.cs
+++ b/src/AdminUI/Pages/Notifications.razor.cs
@@ -1,4 +1,5 @@
 using MudBlazor;
+using SSW.Rewards.Admin.UI.Components.Dialogs.Confirmations;
 using SSW.Rewards.Shared.DTOs.Notifications;
 
 namespace SSW.Rewards.Admin.UI.Pages;
@@ -45,8 +46,20 @@ public partial class Notifications
         }
     }
 
-    private async Task DeleteNotification(int id)
+    private async Task DeleteNotification(int id, string title)
     {
+        var result = await DialogService.Show<SimpleConfirmationDialog>(
+            $"Delete \"{title}\"?",
+            SimpleConfirmationDialog.CreateDialogParams(
+                SimpleConfirmationDialogType.Danger,
+                "Are you sure you want to delete this notification? This action cannot be undone.")
+        ).Result;
+
+        if (result.Canceled || result.Data is not true)
+        {
+            return;
+        }
+
         _loading = true;
         try
         {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1456 

> 2. What was changed?

Changes the delete button on the notifications page to be a red bin, and adds confirmation on deletion.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->