### PR TITLE
🐛 Mobile | Fix tap passing through flyout

### DIFF
--- a/src/MobileUI/Features/Flyout/FlyoutFooter.xaml
+++ b/src/MobileUI/Features/Flyout/FlyoutFooter.xaml
@@ -7,11 +7,15 @@
                      x:DataType="vm:FlyoutFooterViewModel"
                      Margin="0,0,0,5"
                      Padding="20,0"
-                     Spacing="10">
+                     Spacing="10"
+                     InputTransparent="False">
     <VerticalStackLayout.BindingContext>
         <resolver:ResolveViewModel x:TypeArguments="vm:FlyoutFooterViewModel"/>
     </VerticalStackLayout.BindingContext>
-    
+    <VerticalStackLayout.GestureRecognizers>
+        <!-- Consume tap events to prevent passthrough -->
+        <TapGestureRecognizer />
+    </VerticalStackLayout.GestureRecognizers>
     <VerticalStackLayout Spacing="10">
         <VerticalStackLayout.Triggers>
             <!-- Setting Opacity to hide here as using IsVisible can mess up the layout -->


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Fixes #1403 

> 2. What was changed?

Fixes an issue on Android where tapping just outside the buttons in the flyout meant passing the tap through to whatever is underneath the flyout.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->