### PR TITLE
🐛 Fix offline crash on Network page

### DIFF
--- a/src/MobileUI/Features/Network/NetworkPageViewModel.cs
+++ b/src/MobileUI/Features/Network/NetworkPageViewModel.cs
@@ -60,15 +60,15 @@ public partial class NetworkPageViewModel : BaseViewModel
                     _ => false
                 };
 
-            // Disable refreshing when done.
-            AdvancedSearchResults.OnCollectionUpdated += OnCollectionUpdated;
-
             // This is to reduce flickering when loading data.
             AdvancedSearchResults.CompareItems = NetworkProfileDto.IsEqual;
-
-            // Handle errors silently, e.g., log them or show a message.
-            AdvancedSearchResults.OnError += OnCollectionError;
         }
+
+        // Disable refreshing when done.
+        AdvancedSearchResults.OnCollectionUpdated += OnCollectionUpdated;
+
+        // Handle errors silently, e.g., log them or show a message.
+        AdvancedSearchResults.OnError += OnCollectionError;
 
         _pageLoaded = true;
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#1470 

> 2. What was changed?

Fixes a crash when navigating to the Network page a second time while offline, as the error event handler doesn't get re-subscribed to the collection.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->