### PR TITLE
🐞 Reverted to Docker SQL Server 2022, last good known version for MacOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # SQL Server
   rewards-sqlserver:
     container_name: rewards-sqlserver
-    image: mcr.microsoft.com/mssql/server:latest
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       - MSSQL_SA_PASSWORD=Rewards.Docker1!
       - ACCEPT_EULA=1


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1521 - SQL Server 2025 got released on 18/11/2025 which no longer supports MacOS or at least causes some issues. Reverting back to 2022-latest fixes the problem and we don't need SQL Server 2025 for local dev (or for SSW.Rewards WebAPI).

At the time of writing the PR, the issue is still unresolved: https://github.com/microsoft/mssql-docker/issues/942 

> 2. What was changed?

✏️ After New Year, @zacharykeeping and I pulled latest Docker image instead of working with what was cached. Before New Year we either had a SQL Server 2022 or a stable SQL Server 2025 version. Considering that my old backups worked, it was more likely that it was SQL Server 2022.

> 3. Did you do pair or mob programming?

✏️ Yes, with @zacharykeeping 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->