### PR TITLE
♻️ Mobile | Capture only centred QR codes

### DIFF
--- a/src/MobileUI/Features/Scanner/ScanPage.xaml
+++ b/src/MobileUI/Features/Scanner/ScanPage.xaml
@@ -73,11 +73,14 @@
                         </GraphicsView.Drawable>
                     </GraphicsView>
 
-                    <!-- Cover red dot from library when AimMode=True -->
+                    <!-- Cover red dot from scanning library when AimMode=True -->
                     <BoxView
                         WidthRequest="16"
                         HeightRequest="16"
                         CornerRadius="8"
+                        Color="LightGrey"
+                        VerticalOptions="Center"
+                        HorizontalOptions="Center"
                         InputTransparent="True" />
 
                     <Grid VerticalOptions="Center"


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #1449

> 2. What was changed?

Turns on AimMode=True in our scanner library which only picks up codes in the centre of the viewfinder. Unfortunately this forces an ugly dot to appear in the centre of the screen, so I'm covering it with a grey dot which matches rest of the design.

This seems to be the only way I can tackle this for the time being. I tried to handle this manually by using the coordinates of the detected barcodes but there seems to be too much variance between different screen and camera sizes and resolutions returned by the library to be reliable. Maybe we can revisit if the library (or others) get updated.

<img width="400" alt="Screenshot_20260109_160805" src="https://github.com/user-attachments/assets/40e57426-9ce2-40fa-8453-cc1c8dcb9ddb" />

**Figure: Covered dot in the overlay with AimMode now enabled**

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->