### PR TITLE
💄 Improve Notifications UX - Enhance layout and styling for send notifications

### DIFF
--- a/src/AdminUI/Pages/SendNotification.razor
+++ b/src/AdminUI/Pages/SendNotification.razor
@@ -11,7 +11,7 @@
 <PageTitle>SSW Rewards | Send Notification</PageTitle>
 
 <div class="send-notification-page">
-    <MudText Typo="Typo.h3" id="page-title">Create Notification</MudText>
+    <MudText Typo="Typo.h3" id="page-title" data-testid="page-title">Create Notification</MudText>
 
     <div class="send-notification-layout">
         <!-- Form Column -->
@@ -21,11 +21,8 @@
                     <DataAnnotationsValidator />
                     <MudGrid Spacing="3">
                         <MudItem xs="12">
-                            <MudTooltip
-                                Text="This shows how many users got the notification out of everyone we tried to send it to. Some may not get it if they haven't enabled notifications or their device token expired.">
-                                <MudText Typo="Typo.h5" Class="section-header" Style="display: inline; cursor: help;"
-                                    id="delivery-section-label">Delivery<span class="required-indicator">*</span></MudText>
-                            </MudTooltip>
+                            <MudText Typo="Typo.h5" Class="section-header" id="delivery-section-label">
+                                Delivery<span class="required-indicator">*</span></MudText>
                             <MudRadioGroup @bind-Value="@_model.DeliveryOption" aria-labelledby="delivery-section-label"
                                 data-testid="delivery-radio-group" Class="radio-group-large">
                                 <MudRadio Option="@Delivery.Now" Color="Color.Primary" data-testid="delivery-now"
@@ -39,18 +36,20 @@
                         <!-- Always visible Date/Time/Timezone; disabled when not scheduling -->
                         <MudItem xs="12">
                             <div class="schedule-controls-container">
-                                <MudDatePicker Label="Date" Date="@_model.ScheduleDate" DateChanged="@OnDateChanged"
-                                    For="@(() => _model.ScheduleDate)"
-                                    Required="@(_model.DeliveryOption == Delivery.Schedule)"
-                                    Disabled="@(_model.DeliveryOption != Delivery.Schedule)" MinDate="@DateTime.Today"
-                                    data-testid="schedule-date" aria-label="Schedule date for notification"
-                                    Class="schedule-field-large schedule-date-picker" />
-                                <MudTimePicker Label="Time" Time="@_model.ScheduleTime" TimeChanged="@OnTimeChanged"
-                                    For="@(() => _model.ScheduleTime)"
-                                    Required="@(_model.DeliveryOption == Delivery.Schedule)"
-                                    Disabled="@(_model.DeliveryOption != Delivery.Schedule)" data-testid="schedule-time"
-                                    aria-label="Schedule time for notification"
-                                    Class="schedule-field-large schedule-time-picker" />
+                                <div class="schedule-date-time-row">
+                                    <MudDatePicker Label="Date" Date="@_model.ScheduleDate" DateChanged="@OnDateChanged"
+                                        For="@(() => _model.ScheduleDate)"
+                                        Required="@(_model.DeliveryOption == Delivery.Schedule)"
+                                        Disabled="@(_model.DeliveryOption != Delivery.Schedule)" MinDate="@DateTime.Today"
+                                        data-testid="schedule-date" aria-label="Schedule date for notification"
+                                        Class="schedule-field-large schedule-date-picker" />
+                                    <MudTimePicker Label="Time" Time="@_model.ScheduleTime" TimeChanged="@OnTimeChanged"
+                                        For="@(() => _model.ScheduleTime)"
+                                        Required="@(_model.DeliveryOption == Delivery.Schedule)"
+                                        Disabled="@(_model.DeliveryOption != Delivery.Schedule)" data-testid="schedule-time"
+                                        aria-label="Schedule time for notification"
+                                        Class="schedule-field-large schedule-time-picker" />
+                                </div>
                                 <MudSelect @bind-Value="@_model.SelectedTimeZone" Label="Timezone"
                                     For="@(() => _model.SelectedTimeZone)"
                                     Required="@(_model.DeliveryOption == Delivery.Schedule)"
@@ -117,25 +116,31 @@
                         </MudItem>
 
                         <MudItem xs="12">
-                            <MudTextField @bind-Value="@_model.Title" Label="Title"
+                            <MudText Typo="Typo.body1" Class="notification-field-label">Title<span class="required-indicator">*</span></MudText>
+                            <MudTextField @bind-Value="@_model.Title"
                                 For="@(() => _model.Title)" Required="true" MaxLength="100" Counter="100"
                                 data-testid="notification-title"
                                 aria-label="Enter notification title, maximum 100 characters"
-                                aria-describedby="content-section-label" Immediate="true" />
+                                aria-describedby="content-section-label" Immediate="true"
+                                Variant="Variant.Outlined" Class="notification-input-outlined" />
                         </MudItem>
 
                         <MudItem xs="12">
-                            <MudTextField @bind-Value="@_model.Body" Label="Body"
+                            <MudText Typo="Typo.body1" Class="notification-field-label">Body<span class="required-indicator">*</span></MudText>
+                            <MudTextField @bind-Value="@_model.Body"
                                 For="@(() => _model.Body)" Required="true" Lines="3" MaxLength="250" Counter="250"
                                 data-testid="notification-body"
                                 aria-label="Enter notification body text, maximum 250 characters"
-                                aria-describedby="content-section-label" Immediate="true" />
+                                aria-describedby="content-section-label" Immediate="true"
+                                Variant="Variant.Outlined" Class="notification-input-outlined" />
                         </MudItem>
 
                         <MudItem xs="12">
-                            <MudTextField @bind-Value="@_model.ImageUrl" Label="Notification Image URL (Optional)"
+                            <MudText Typo="Typo.body1" Class="notification-field-label">Notification Image URL (Optional)</MudText>
+                            <MudTextField @bind-Value="@_model.ImageUrl"
                                 For="@(() => _model.ImageUrl)" data-testid="notification-image-url"
-                                aria-label="Enter optional image URL for notification" Immediate="true" />
+                                aria-label="Enter optional image URL for notification" Immediate="true"
+                                Variant="Variant.Outlined" Class="notification-input-outlined" />
                         </MudItem>
 
                         <MudItem xs="12" Class="d-flex justify-end mt-4">

--- a/src/AdminUI/Pages/SendNotification.razor.css
+++ b/src/AdminUI/Pages/SendNotification.razor.css
@@ -16,12 +16,19 @@
     margin-top: 0 !important;
 }
 
-/* Container for Date/Time/Timezone fields to allow flex layout and offset */
+/* Container for Date/Time/Timezone fields - stacked layout with Timezone below */
 .schedule-controls-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-left: 38px; /* Offset to align with 'Schedule' radio button on desktop */
+}
+
+/* Row for Date and Time fields side by side */
+.schedule-date-time-row {
     display: flex;
     flex-direction: row;
     gap: 24px;
-    margin-left: 108px; /* Offset to align with 'Schedule' radio button on desktop */
 }
 
 .target-autocomplete {
@@ -41,17 +48,21 @@
 }
 
 .schedule-timezone-select {
-    flex: 1.5; /* Timezone takes more width space than Date and Time */
+    width: 100%; /* Timezone takes full width on its own row */
+    margin-left: 0 !important; /* Ensure alignment with date/time row above */
 }
 
 /* Remove offset and stack vertically on mobile */
 @media (max-width: 1400px) {
     .schedule-controls-container {
         margin-left: 0;
+    }
+
+    .schedule-date-time-row {
         flex-direction: column;
         gap: 16px;
     }
-    
+
     .schedule-date-picker,
     .schedule-time-picker,
     .schedule-timezone-select {
@@ -103,6 +114,26 @@
 /* Section headers */
 .section-header {
     font-weight: 500;
+}
+
+/* Notification field labels (Title, Body) - same style as radio labels */
+.notification-field-label {
+    font-size: 1rem;
+    margin-bottom: 8px;
+    color: white !important;
+}
+
+/* Outlined input styling for notification fields */
+::deep .notification-input-outlined .mud-input-outlined-border {
+    border-color: rgba(255, 255, 255, 0.23) !important;
+}
+
+::deep .notification-input-outlined:hover .mud-input-outlined-border {
+    border-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+::deep .notification-input-outlined.mud-input-error .mud-input-outlined-border {
+    border-color: var(--mud-palette-error) !important;
 }
 
 /* Required field indicator - red asterisk */


### PR DESCRIPTION
…ion fields and date/time controls

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #1392 - Additional feedback from Adam

> 2. What was changed?

✏️ Moved UI elements, changed how labels behave and added border to input text.

<img width="1682" height="925" alt="image" src="https://github.com/user-attachments/assets/cfb75e09-1c08-4eeb-b86f-e12f26ceae24" />

**Figure: Date and timezones are now aligned with target dropdowns.**

<img width="1682" height="925" alt="image" src="https://github.com/user-attachments/assets/7ebee9b4-396c-4e1b-aa67-f9a7c739bde7" />

**Figure: Input text labels are now outside the text box and text box has border.**

<img width="1682" height="925" alt="image" src="https://github.com/user-attachments/assets/1d0ab8b6-b274-49c8-a8ee-1407b7a161ec" />

**Figure: When selecting a text box, the background goes white.**

<img width="1682" height="925" alt="image" src="https://github.com/user-attachments/assets/ef39e33f-f791-4c9c-b5ea-6bc94af4a14a" />

**Figure: Error validation will no longer make label red.**

> 3. Did you do pair or mob programming?

✏️ No.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->