### PR TITLE
🐛 Mobile | Re-enable Firebase Analytics on iOS

### DIFF
--- a/src/MobileUI/MauiProgram.cs
+++ b/src/MobileUI/MauiProgram.cs
@@ -4,6 +4,7 @@ using FFImageLoading.Maui;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.LifecycleEvents;
 using Mopups.Hosting;
+using Plugin.Firebase.Analytics;
 using Plugin.Firebase.Crashlytics;
 using SkiaSharp.Views.Maui.Controls.Hosting;
 using SSW.Rewards.Mobile.Renderers;
@@ -14,7 +15,6 @@ using Plugin.Firebase.CloudMessaging;
 using Foundation;
 #elif ANDROID
 using Microsoft.Maui.Platform;
-using Plugin.Firebase.Analytics;
 using Plugin.Firebase.Core.Platforms.Android;
 #endif
 
@@ -107,6 +107,8 @@ public static class MauiProgram
                 CrossFirebase.Initialize();
                 FirebaseCloudMessagingImplementation.Initialize();
                 CrossFirebaseCrashlytics.Current.SetCrashlyticsCollectionEnabled(true);
+                // Override IS_ANALYTICS_ENABLED=false that ships in the prod plist.
+                CrossFirebaseAnalytics.Current.IsAnalyticsCollectionEnabled = true;
                 return false;
             }));
 #elif ANDROID


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Today's production pulse report showed that iOS users are invisible to Firebase Analytics / GA4 — every `LogEvent()` call from iOS has been a silent no-op since PR #1212 (Mar 2025). The iOS branch of `RegisterFirebase()` never initialised analytics, and the prod `GoogleService-Info.plist` ships with `IS_ANALYTICS_ENABLED=false`. Android has been fine throughout.

Pulse report: https://ssw-rewards-prod-today-report-20260423.surge.sh

Verified empirically:
- `firebase apps:sdkconfig IOS ... --project ssw-rewards-52a58` → `IS_ANALYTICS_ENABLED=false`
- `src/MobileUI/MauiProgram.cs` (current `main`) only calls `FirebaseAnalyticsImplementation.Initialize(activity)` under `#elif ANDROID`. The `#if IOS` block has no analytics init.
- No programmatic overrides anywhere in the codebase (no `SetAnalyticsCollectionEnabled`, no `FIREBASE_ANALYTICS_COLLECTION_ENABLED` in `Info.plist`).

> 2. What was changed?

✏️ Single-file change in `src/MobileUI/MauiProgram.cs`:

- Moved `using Plugin.Firebase.Analytics;` out of the `#elif ANDROID` block so iOS can use it too.
- Added one line inside the iOS `WillFinishLaunching` lifecycle event:
  ```csharp
  // Override IS_ANALYTICS_ENABLED=false that ships in the prod plist.
  CrossFirebaseAnalytics.Current.IsAnalyticsCollectionEnabled = true;
  ```

That property setter delegates to `FirebaseAnalytics.SetAnalyticsCollectionEnabled(true)` under the hood (confirmed from [Plugin.Firebase iOS source](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Analytics/Platforms/iOS/FirebaseAnalyticsImplementation.cs)), which takes precedence over the plist flag at runtime. No need to regenerate the production `GoogleService-Info.plist` — though it would still be good hygiene to do so separately so the plist reflects intent.

Android is untouched — it already works via `FirebaseAnalyticsImplementation.Initialize(activity)` + manifest flag.

**Validation plan**
- [ ] TestFlight build, open the app on iOS, trigger `quiz_start` + `reward_view`
- [ ] Confirm events appear in Firebase Console → Analytics → DebugView (or Realtime) within ~1 minute
- [ ] Confirm Android still flows events as before
- [ ] (Follow-up, not this PR) regenerate prod iOS `GoogleService-Info.plist` from Firebase Console with analytics enabled, update the GitHub secret that release workflows inject from

> 3. Did you do pair or mob programming?

✏️ Paired with Claude Opus 4.7 (1M context) — investigation (git archaeology on PR #1212), Plugin.Firebase source reading, and the fix itself.