### PR TITLE
🐛 Fix monthly leaderboard and sorting users

### DIFF
--- a/src/Application/Leaderboard/LeaderboardService.cs
+++ b/src/Application/Leaderboard/LeaderboardService.cs
@@ -40,6 +40,8 @@ public class LeaderboardService : ILeaderboardService
     private async Task<List<LeaderboardUserDto>> GenerateLeaderboard(CancellationToken cancellationToken)
     {
         DateTime utcNow = _dateTime.UtcNow;
+        DateTime lastSevenDaysUtc = utcNow.AddDays(-7);
+        DateTime lastThirtyDaysUtc = utcNow.AddDays(-30);
 
         var users = await _context.Users
             .AsNoTracking()
@@ -61,10 +63,10 @@ public class LeaderboardService : ILeaderboardService
                         ua.AwardedAt.Day == utcNow.Day)
                     .Sum(ua => ua.Achievement.Value),
                 PointsThisWeek = x.UserAchievements
-                    .Where(ua => utcNow.AddDays(-7) <= ua.AwardedAt && ua.AwardedAt <= utcNow)
+                    .Where(ua => lastSevenDaysUtc <= ua.AwardedAt && ua.AwardedAt <= utcNow)
                     .Sum(ua => ua.Achievement.Value),
                 PointsThisMonth = x.UserAchievements
-                    .Where(ua => ua.AwardedAt.Year == utcNow.Year && ua.AwardedAt.Month == utcNow.Month)
+                    .Where(ua => lastThirtyDaysUtc <= ua.AwardedAt && ua.AwardedAt <= utcNow)
                     .Sum(ua => ua.Achievement.Value),
                 PointsThisYear = x.UserAchievements
                     .Where(ua => ua.AwardedAt.Year == utcNow.Year)

--- a/src/Application/Leaderboard/LeaderboardService.cs
+++ b/src/Application/Leaderboard/LeaderboardService.cs
@@ -34,7 +34,7 @@ public class LeaderboardService : ILeaderboardService
     {
         var users = await _cacheService.GetOrAddAsync(CacheKeys.Leaderboard, () => GenerateLeaderboard(cancellationToken));
 
-        return users;
+        return OrderByAllTimeRank(users).ToList();
     }
 
     private async Task<List<LeaderboardUserDto>> GenerateLeaderboard(CancellationToken cancellationToken)
@@ -88,7 +88,10 @@ public class LeaderboardService : ILeaderboardService
 
         // Post-processing
         int rank = 0;
-        foreach (LeaderboardUserDto? user in users.OrderByDescending(lud => lud.TotalPoints))
+        foreach (LeaderboardUserDto? user in users
+            .OrderByDescending(lud => lud.TotalPoints)
+            .ThenBy(lud => lud.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(lud => lud.UserId))
         {
             user.Rank = ++rank;
             user.Title = user.Title switch
@@ -105,8 +108,14 @@ public class LeaderboardService : ILeaderboardService
             }
         }
 
-        return users;
+        return OrderByAllTimeRank(users).ToList();
     }
+
+    private static IOrderedEnumerable<LeaderboardUserDto> OrderByAllTimeRank(IEnumerable<LeaderboardUserDto> users)
+        => users
+            .OrderBy(user => user.Rank)
+            .ThenBy(user => user.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(user => user.UserId);
 
     private static string ParseXHandle(string? value)
     {

--- a/src/Application/Leaderboard/LeaderboardService.cs
+++ b/src/Application/Leaderboard/LeaderboardService.cs
@@ -90,8 +90,7 @@ public class LeaderboardService : ILeaderboardService
         int rank = 0;
         foreach (LeaderboardUserDto? user in users
             .OrderByDescending(lud => lud.TotalPoints)
-            .ThenBy(lud => lud.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(lud => lud.UserId))
+            .ThenBy(lud => lud.Name))
         {
             user.Rank = ++rank;
             user.Title = user.Title switch
@@ -114,8 +113,7 @@ public class LeaderboardService : ILeaderboardService
     private static IOrderedEnumerable<LeaderboardUserDto> OrderByAllTimeRank(IEnumerable<LeaderboardUserDto> users)
         => users
             .OrderBy(user => user.Rank)
-            .ThenBy(user => user.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(user => user.UserId);
+            .ThenBy(user => user.Name);
 
     private static string ParseXHandle(string? value)
     {

--- a/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
@@ -21,15 +21,7 @@ internal class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, Leade
     public async Task<LeaderboardViewModel> Handle(GetLeaderboardPaginatedListQuery request, CancellationToken cancellationToken)
     {
         List<LeaderboardUserDto> users = await _leaderboardService.GetFullLeaderboard(cancellationToken);
-        var query = users.AsQueryable();
-        query = request.CurrentPeriod switch
-        {
-            LeaderboardFilter.ThisMonth => query.OrderByDescending(x => x.PointsThisMonth),
-            LeaderboardFilter.ThisYear => query.OrderByDescending(x => x.PointsThisYear),
-            LeaderboardFilter.Forever => query.OrderByDescending(x => x.TotalPoints),
-            LeaderboardFilter.ThisWeek => query.OrderByDescending(x => x.PointsThisWeek),
-            _ => query.OrderByDescending(x => x.TotalPoints),
-        };
+        var query = OrderByLeaderboardPeriod(users, request.CurrentPeriod);
 
         return new LeaderboardViewModel
         {
@@ -39,4 +31,26 @@ internal class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, Leade
                 .ToArray()
         };
     }
+
+    private static IOrderedEnumerable<LeaderboardUserDto> OrderByLeaderboardPeriod(IEnumerable<LeaderboardUserDto> users, LeaderboardFilter currentPeriod)
+        => currentPeriod switch
+        {
+            LeaderboardFilter.ThisMonth => OrderByPeriodPoints(users, user => user.PointsThisMonth),
+            LeaderboardFilter.ThisYear => OrderByPeriodPoints(users, user => user.PointsThisYear),
+            LeaderboardFilter.ThisWeek => OrderByPeriodPoints(users, user => user.PointsThisWeek),
+            _ => OrderByAllTimeRank(users),
+        };
+
+    private static IOrderedEnumerable<LeaderboardUserDto> OrderByPeriodPoints(IEnumerable<LeaderboardUserDto> users, Func<LeaderboardUserDto, int> periodPoints)
+        => users
+            .OrderByDescending(periodPoints)
+            .ThenBy(user => user.Rank)
+            .ThenBy(user => user.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(user => user.UserId);
+
+    private static IOrderedEnumerable<LeaderboardUserDto> OrderByAllTimeRank(IEnumerable<LeaderboardUserDto> users)
+        => users
+            .OrderBy(user => user.Rank)
+            .ThenBy(user => user.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(user => user.UserId);
 }

--- a/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
+++ b/src/Application/Leaderboard/Queries/GetLeaderboardPaginatedList/GetLeaderboardPaginatedListQuery.cs
@@ -21,7 +21,15 @@ internal class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, Leade
     public async Task<LeaderboardViewModel> Handle(GetLeaderboardPaginatedListQuery request, CancellationToken cancellationToken)
     {
         List<LeaderboardUserDto> users = await _leaderboardService.GetFullLeaderboard(cancellationToken);
-        var query = OrderByLeaderboardPeriod(users, request.CurrentPeriod);
+        var query = users.AsQueryable();
+        query = (request.CurrentPeriod switch
+        {
+            LeaderboardFilter.ThisMonth => query.OrderByDescending(x => x.PointsThisMonth),
+            LeaderboardFilter.ThisYear => query.OrderByDescending(x => x.PointsThisYear),
+            LeaderboardFilter.Forever => query.OrderByDescending(x => x.TotalPoints),
+            LeaderboardFilter.ThisWeek => query.OrderByDescending(x => x.PointsThisWeek),
+            _ => query.OrderByDescending(x => x.TotalPoints),
+        }).ThenBy(x => x.Name);
 
         return new LeaderboardViewModel
         {
@@ -31,26 +39,4 @@ internal class Handler : IRequestHandler<GetLeaderboardPaginatedListQuery, Leade
                 .ToArray()
         };
     }
-
-    private static IOrderedEnumerable<LeaderboardUserDto> OrderByLeaderboardPeriod(IEnumerable<LeaderboardUserDto> users, LeaderboardFilter currentPeriod)
-        => currentPeriod switch
-        {
-            LeaderboardFilter.ThisMonth => OrderByPeriodPoints(users, user => user.PointsThisMonth),
-            LeaderboardFilter.ThisYear => OrderByPeriodPoints(users, user => user.PointsThisYear),
-            LeaderboardFilter.ThisWeek => OrderByPeriodPoints(users, user => user.PointsThisWeek),
-            _ => OrderByAllTimeRank(users),
-        };
-
-    private static IOrderedEnumerable<LeaderboardUserDto> OrderByPeriodPoints(IEnumerable<LeaderboardUserDto> users, Func<LeaderboardUserDto, int> periodPoints)
-        => users
-            .OrderByDescending(periodPoints)
-            .ThenBy(user => user.Rank)
-            .ThenBy(user => user.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(user => user.UserId);
-
-    private static IOrderedEnumerable<LeaderboardUserDto> OrderByAllTimeRank(IEnumerable<LeaderboardUserDto> users)
-        => users
-            .OrderBy(user => user.Rank)
-            .ThenBy(user => user.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(user => user.UserId);
 }

--- a/src/Application/Leaderboard/Queries/GetMobileLeaderbaoard/GetMobileLeaderboard.cs
+++ b/src/Application/Leaderboard/Queries/GetMobileLeaderbaoard/GetMobileLeaderboard.cs
@@ -29,9 +29,7 @@ internal class GetMobileLeaderboardQueryHandler(ILeaderboardService leaderboardS
         // Sort and recalculate the rank based on the current period.
         query = query
             .OrderByDescending(x => x.Points)
-            .ThenBy(x => x.Rank)
-            .ThenBy(x => x.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(x => x.UserId)
+            .ThenBy(x => x.Name)
             .Select((x, i) =>
             {
                 x.Rank = i + 1;

--- a/src/Application/Leaderboard/Queries/GetMobileLeaderbaoard/GetMobileLeaderboard.cs
+++ b/src/Application/Leaderboard/Queries/GetMobileLeaderbaoard/GetMobileLeaderboard.cs
@@ -29,6 +29,9 @@ internal class GetMobileLeaderboardQueryHandler(ILeaderboardService leaderboardS
         // Sort and recalculate the rank based on the current period.
         query = query
             .OrderByDescending(x => x.Points)
+            .ThenBy(x => x.Rank)
+            .ThenBy(x => x.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.UserId)
             .Select((x, i) =>
             {
                 x.Rank = i + 1;

--- a/tests/Application.UnitTests/Leaderboard/LeaderboardServiceTests.cs
+++ b/tests/Application.UnitTests/Leaderboard/LeaderboardServiceTests.cs
@@ -208,4 +208,74 @@ public class LeaderboardServiceTests
         user.PointsThisMonth.Should().Be(30);
         user.PointsThisYear.Should().Be(20);
     }
+
+    [Test]
+    public async Task GetFullLeaderboard_WhenGenerating_ShouldReturnUsersOrderedByRankWithStableTieBreakers()
+    {
+        // Arrange
+        var utcNow = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc);
+        _dateTimeMock.Setup(x => x.UtcNow).Returns(utcNow);
+
+        var users = new List<User>
+        {
+            new()
+            {
+                Id = 3,
+                FullName = "Charlie",
+                Email = "charlie@example.com",
+                Activated = true,
+                UserAchievements =
+                [
+                    new UserAchievement
+                    {
+                        AwardedAt = utcNow,
+                        Achievement = new Achievement { Value = 50 }
+                    }
+                ]
+            },
+            new()
+            {
+                Id = 2,
+                FullName = "Bravo",
+                Email = "bravo@example.com",
+                Activated = true,
+                UserAchievements =
+                [
+                    new UserAchievement
+                    {
+                        AwardedAt = utcNow,
+                        Achievement = new Achievement { Value = 100 }
+                    }
+                ]
+            },
+            new()
+            {
+                Id = 1,
+                FullName = "Alpha",
+                Email = "alpha@example.com",
+                Activated = true,
+                UserAchievements =
+                [
+                    new UserAchievement
+                    {
+                        AwardedAt = utcNow,
+                        Achievement = new Achievement { Value = 100 }
+                    }
+                ]
+            }
+        };
+
+        _contextMock.Setup(x => x.Users).Returns(users.BuildMockDbSet().Object);
+        _cacheServiceMock.Setup(x => x.GetOrAddAsync(
+                CacheKeys.Leaderboard,
+                It.IsAny<Func<Task<List<LeaderboardUserDto>>>>()))
+            .Returns<string, Func<Task<List<LeaderboardUserDto>>>>((_, factory) => factory());
+
+        // Act
+        var result = await _service.GetFullLeaderboard(CancellationToken.None);
+
+        // Assert
+        result.Select(user => user.Name).Should().Equal("Alpha", "Bravo", "Charlie");
+        result.Select(user => user.Rank).Should().Equal(1, 2, 3);
+    }
 }

--- a/tests/Application.UnitTests/Leaderboard/LeaderboardServiceTests.cs
+++ b/tests/Application.UnitTests/Leaderboard/LeaderboardServiceTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
 using Moq;
 using NUnit.Framework;
+using SSW.Rewards.Application.Common.Constants;
 using SSW.Rewards.Application.Common.Interfaces;
 using SSW.Rewards.Application.Leaderboard;
 using SSW.Rewards.Domain.Entities;
@@ -155,5 +157,55 @@ public class LeaderboardServiceTests
             It.IsAny<string>(),
             It.IsAny<Func<Task<List<LeaderboardUserDto>>>>()), Times.Once);
     }
-}
 
+    [Test]
+    public async Task GetFullLeaderboard_WhenGenerating_ShouldCountThisMonthAsLastThirtyDaysAndKeepThisYear()
+    {
+        // Arrange
+        var utcNow = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc);
+        _dateTimeMock.Setup(x => x.UtcNow).Returns(utcNow);
+
+        var users = new List<User>
+        {
+            new()
+            {
+                Id = 1,
+                FullName = "Monthly User",
+                Email = "monthly@example.com",
+                Activated = true,
+                UserAchievements =
+                [
+                    new UserAchievement
+                    {
+                        AwardedAt = utcNow.AddDays(-18),
+                        Achievement = new Achievement { Value = 10 }
+                    },
+                    new UserAchievement
+                    {
+                        AwardedAt = utcNow.AddDays(-1),
+                        Achievement = new Achievement { Value = 20 }
+                    },
+                    new UserAchievement
+                    {
+                        AwardedAt = utcNow.AddDays(-33),
+                        Achievement = new Achievement { Value = 30 }
+                    }
+                ]
+            }
+        };
+
+        _contextMock.Setup(x => x.Users).Returns(users.BuildMockDbSet().Object);
+        _cacheServiceMock.Setup(x => x.GetOrAddAsync(
+                CacheKeys.Leaderboard,
+                It.IsAny<Func<Task<List<LeaderboardUserDto>>>>()))
+            .Returns<string, Func<Task<List<LeaderboardUserDto>>>>((_, factory) => factory());
+
+        // Act
+        var result = await _service.GetFullLeaderboard(CancellationToken.None);
+
+        // Assert
+        var user = result.Should().ContainSingle().Subject;
+        user.PointsThisMonth.Should().Be(30);
+        user.PointsThisYear.Should().Be(20);
+    }
+}


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Boss reported that the Monthly mobile leaderboard was effectively empty early in the month. The API treated `ThisMonth` as calendar-month-to-date, so on May 2 it only looked at roughly 2 days instead of the expected recent month of activity.

> 2. What was changed?

Changed `LeaderboardService` so `PointsThisMonth` uses a rolling 30-day UTC window. `PointsThisYear` is still calendar-year based, and the existing weekly rolling 7-day behavior is unchanged.

Also stabilized leaderboard sorting across the API paths. Period leaderboards now sort by selected period points, then name. All-time ranking is also stable by total points, then name. This avoids tied scores falling back to arbitrary cached/DB result order while keeping the query simple.

Validation:
- `MSBuildEnableWorkloadResolver=false dotnet test tests/Application.UnitTests/Application.UnitTests.csproj --no-restore` passed 61/61
- `MSBuildEnableWorkloadResolver=false dotnet build src/WebAPI/WebAPI.csproj` succeeded

The environment is missing the pinned .NET workload set `10.0.103`, so the workload resolver had to be disabled for the local run.

> 3. Did you do pair or mob programming?

Worked with Codex.