### PR TITLE
🐛 Mobile | Show reward details for unaffordable rewards

### DIFF
--- a/src/MobileUI/Constants.cs
+++ b/src/MobileUI/Constants.cs
@@ -20,6 +20,7 @@ public static class Constants
 
     public const string AuthRedirectUrl = "msauth.com.ssw.consulting://auth";
     public const string AutologinRedirectUrl = "sswrewards://autologin";
+    public const string TinaCmsStoreUrl = "";
 
 #if DEBUG
     public const string AuthorityUri = "https://identity.ssw.com.au";

--- a/src/MobileUI/Controls/CarouselItem.xaml.cs
+++ b/src/MobileUI/Controls/CarouselItem.xaml.cs
@@ -55,7 +55,7 @@ public partial class CarouselItem
     [RelayCommand]
     private async Task ButtonClicked()
     {
-        if (!IsButtonDisabled && ButtonCommand != null)
+        if (ButtonCommand != null)
         {
             await ButtonCommand.ExecuteAsync(ItemId);
         }

--- a/src/MobileUI/Controls/ListItem.xaml.cs
+++ b/src/MobileUI/Controls/ListItem.xaml.cs
@@ -46,7 +46,7 @@ public partial class ListItem : Border
     [RelayCommand]
     private async Task ButtonClicked()
     {
-        if (!IsButtonDisabled && ButtonCommand != null)
+        if (ButtonCommand != null)
         {
             await ButtonCommand.ExecuteAsync(ItemId);
         }

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml
@@ -98,6 +98,36 @@
                                        HorizontalOptions="Center"
                                        HorizontalTextAlignment="Center"
                                        Margin="0,0,0,30" />
+
+                                <Label Text="{Binding InsufficientPointsMessage}"
+                                       FontSize="18"
+                                       TextColor="{StaticResource Coin}"
+                                       HorizontalOptions="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Margin="0,0,0,10"
+                                       IsVisible="{Binding IsInsufficientPointsVisible}"
+                                       Style="{StaticResource LabelBold}" />
+
+                                <Label Text="{Binding TinaCmsStoreLinkText}"
+                                       FontSize="16"
+                                       TextColor="{StaticResource Gray300}"
+                                       HorizontalOptions="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Margin="0,0,0,30"
+                                       IsVisible="{Binding IsTinaCmsStoreTextVisible}" />
+
+                                <Label Text="{Binding TinaCmsStoreLinkText}"
+                                       FontSize="16"
+                                       TextColor="{StaticResource SSWRed}"
+                                       HorizontalOptions="Center"
+                                       HorizontalTextAlignment="Center"
+                                       TextDecorations="Underline"
+                                       Margin="0,0,0,30"
+                                       IsVisible="{Binding IsTinaCmsStoreLinkVisible}">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding OpenTinaCmsStoreCommand}" />
+                                    </Label.GestureRecognizers>
+                                </Label>
                             </VerticalStackLayout>
                             
                             <!-- Balance section -->
@@ -319,7 +349,7 @@
                             <Grid
                                 ColumnDefinitions="*,15,*"
                                 Margin="0,0,0,30"
-                                IsVisible="{Binding IsBalanceVisible}">
+                                IsVisible="{Binding IsRewardActionsVisible}">
                                 <controls:MultiLineButton
                                     Text="Redeem in-person"
                                     Command="{Binding RedeemInPersonClickedCommand}"

--- a/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml.cs
+++ b/src/MobileUI/Features/Redeem/RedeemRewardPage.xaml.cs
@@ -4,14 +4,16 @@ public partial class RedeemRewardPage
 {
     private readonly RedeemRewardViewModel _viewModel;
     private readonly Reward _reward;
+    private readonly int _userBalance;
     private readonly IFirebaseAnalyticsService _firebaseAnalyticsService;
 
-    public RedeemRewardPage(IFirebaseAnalyticsService firebaseAnalyticsService, RedeemRewardViewModel viewModel, Reward reward)
+    public RedeemRewardPage(IFirebaseAnalyticsService firebaseAnalyticsService, RedeemRewardViewModel viewModel, Reward reward, int userBalance)
     {
         _firebaseAnalyticsService = firebaseAnalyticsService;
         InitializeComponent();
         _viewModel = viewModel;
         _reward = reward;
+        _userBalance = userBalance;
         BindingContext = _viewModel;
         _viewModel.ViewPage = this;
     }
@@ -20,7 +22,7 @@ public partial class RedeemRewardPage
     {
         base.OnAppearing();
         _firebaseAnalyticsService.Log("RedeemRewardPage");
-        _viewModel.Initialise(_reward);
+        _viewModel.Initialise(_reward, _userBalance);
     }
 
     public event EventHandler<object> CallbackEvent;

--- a/src/MobileUI/Features/Redeem/RedeemRewardViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemRewardViewModel.cs
@@ -21,6 +21,7 @@ public partial class RedeemRewardViewModel(
 {
     private Reward _reward;
     private float _defaultBrightness;
+    private IDisposable _balanceSubscription;
     private const float MaxBrightness = 1.0f;
 
     [ObservableProperty]
@@ -46,6 +47,21 @@ public partial class RedeemRewardViewModel(
 
     [ObservableProperty]
     private bool _isBalanceVisible = true;
+
+    [ObservableProperty]
+    private bool _isRewardActionsVisible = true;
+
+    [ObservableProperty]
+    private bool _isInsufficientPointsVisible;
+
+    [ObservableProperty]
+    private string _insufficientPointsMessage;
+
+    [ObservableProperty]
+    private bool _isTinaCmsStoreLinkVisible;
+
+    [ObservableProperty]
+    private bool _isTinaCmsStoreTextVisible;
 
     [ObservableProperty]
     private bool _isQrCodeVisible;
@@ -77,22 +93,27 @@ public partial class RedeemRewardViewModel(
     [ObservableProperty]
     private ImageSource _qrCode;
 
+    public string TinaCmsStoreLinkText { get; } = "Purchase at the TinaCMS store";
+
     public ObservableCollection<Address> SearchResults { get; set; } = [];
     public bool ShouldCallCallback { get; set; }
 
-    public void Initialise(Reward reward)
+    public void Initialise(Reward reward, int userBalance)
     {
         _reward = reward;
         _defaultBrightness = ScreenBrightness.Default.Brightness;
+        UserBalance = userBalance;
 
         SetRewardProperties(reward);
+        UpdateInsufficientPointsState();
 
         if (reward.IsPendingRedemption)
         {
             ShowQrCode();
         }
 
-        userService.MyBalanceObservable().Subscribe(myBalance => UserBalance = myBalance);
+        _balanceSubscription?.Dispose();
+        _balanceSubscription = userService.MyBalanceObservable().Subscribe(OnBalanceChanged);
         LogEvent(Constants.AnalyticsEvents.RewardView);
     }
 
@@ -107,8 +128,47 @@ public partial class RedeemRewardViewModel(
 
     public void OnDisappearing()
     {
+        _balanceSubscription?.Dispose();
+        _balanceSubscription = null;
         ScreenBrightness.Default.Brightness = _defaultBrightness;
     }
+
+    private void OnBalanceChanged(int balance)
+    {
+        UserBalance = balance;
+        UpdateInsufficientPointsState();
+    }
+
+    private void UpdateInsufficientPointsState()
+    {
+        if (_reward is null || !IsRewardDecisionVisible())
+        {
+            return;
+        }
+
+        var pointsNeeded = Math.Max(_reward.Cost - UserBalance, 0);
+        var showTinaCmsStore = IsTinaCmsReward();
+        var hasStoreLink = showTinaCmsStore && !string.IsNullOrWhiteSpace(Constants.TinaCmsStoreUrl);
+        IsInsufficientPointsVisible = pointsNeeded > 0;
+        IsRewardActionsVisible = !IsInsufficientPointsVisible;
+        IsTinaCmsStoreLinkVisible = IsInsufficientPointsVisible && hasStoreLink;
+        IsTinaCmsStoreTextVisible = IsInsufficientPointsVisible && showTinaCmsStore && !hasStoreLink;
+        InsufficientPointsMessage = IsInsufficientPointsVisible
+            ? $"You need {pointsNeeded:n0} more points"
+            : string.Empty;
+    }
+
+    private bool IsRewardDecisionVisible()
+        => IsHeaderVisible &&
+           !IsQrCodeVisible &&
+           !IsAddressVisible &&
+           !ConfirmEnabled &&
+           !SendingClaim &&
+           !ClaimSuccess &&
+           !ClaimError;
+
+    private bool IsTinaCmsReward()
+        => _reward?.Name?.Contains("TinaCMS", StringComparison.OrdinalIgnoreCase) == true;
 
     private void ShowQrCode(string qrCode = null)
     {
@@ -116,6 +176,10 @@ public partial class RedeemRewardViewModel(
 
         IsHeaderVisible = false;
         IsBalanceVisible = false;
+        IsRewardActionsVisible = false;
+        IsInsufficientPointsVisible = false;
+        IsTinaCmsStoreLinkVisible = false;
+        IsTinaCmsStoreTextVisible = false;
         ConfirmEnabled = false;
         Heading = $"Ready to claim:{Environment.NewLine}{_reward.Name}";
         QrCode = ImageHelpers.GenerateQrCode(qrCode ?? _reward.PendingRedemptionCode);
@@ -126,6 +190,10 @@ public partial class RedeemRewardViewModel(
     private void ShowClaimingState()
     {
         IsBalanceVisible = false;
+        IsRewardActionsVisible = false;
+        IsInsufficientPointsVisible = false;
+        IsTinaCmsStoreLinkVisible = false;
+        IsTinaCmsStoreTextVisible = false;
         ConfirmEnabled = false;
         SendingClaim = true;
         Heading = "Claiming reward...";
@@ -192,9 +260,29 @@ public partial class RedeemRewardViewModel(
     }
 
     [RelayCommand]
+    private async Task OpenTinaCmsStore()
+    {
+        if (string.IsNullOrWhiteSpace(Constants.TinaCmsStoreUrl) ||
+            !Uri.TryCreate(Constants.TinaCmsStoreUrl, UriKind.Absolute, out var uri))
+        {
+            return;
+        }
+
+        try
+        {
+            await Browser.Default.OpenAsync(uri, BrowserLaunchMode.External);
+        }
+        catch
+        {
+            await alertService.DisplayAlertAsync("Error", "There was an error trying to launch the default browser.", "OK");
+        }
+    }
+
+    [RelayCommand]
     private void NextClicked()
     {
         IsBalanceVisible = false;
+        IsRewardActionsVisible = false;
         IsAddressVisible = true;
     }
 

--- a/src/MobileUI/Features/Redeem/RedeemViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemViewModel.cs
@@ -261,7 +261,8 @@ public partial class RedeemViewModel : BaseViewModel
             var popup = new RedeemRewardPage(
                 _firebaseAnalyticsService,
                 new RedeemRewardViewModel(_userService, _rewardService, _addressService, _firebaseAnalyticsService, _alertService),
-                reward);
+                reward,
+                Credits);
             EventHandler<object> handler = null;
             handler = async (_, __) =>
             {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Closes #1560

Adam Cogan reported that unaffordable reward records could be tapped but appeared to do nothing. This PR makes those taps open the reward detail view, show the large image, and explain the user's points shortfall instead of failing silently.

⚠️ TODO: Ask Tiago for TinaCMS store (#1557). Until Tiago confirms the store URL/copy, the purchase prompt is shown without an external link.

> 2. What was changed?

1. Reward list and carousel items now open the reward detail view even when the redeem action is disabled.
2. The reward detail view now receives the user's current balance and shows an unaffordable state with the points shortfall.
3. The unaffordable state shows the large reward image, hides the redeem form/actions, and includes the requested purchase prompt.

<img width="1080" height="2400" alt="before-plushie-after-tap" src="https://github.com/user-attachments/assets/1589e1b1-d9f3-4faa-a996-ebf568718239" />

**Figure: Before - tapping the unaffordable TinaCMS plushie stayed on the Redeem list.**

<img width="1080" height="2400" alt="after-plushie-detail" src="https://github.com/user-attachments/assets/000dd2b2-4444-47d0-9394-e4363487be44" />

**Figure: After - tapping the same item opens the detail view with the large image and points message.**

<img width="1080" height="2400" alt="after-redeem-list" src="https://github.com/user-attachments/assets/afe2a481-c36c-413f-8f89-67138f1b572d" />

**Figure: After - the Redeem list shows the corrected TinaCMS reward names.**

> 3. Did you do pair or mob programming?

✏️ Yes - JK pairing with Codex.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
