### PR TITLE
Fix cached reward affordability refresh

### DIFF
--- a/src/MobileUI/Features/Redeem/RedeemViewModel.cs
+++ b/src/MobileUI/Features/Redeem/RedeemViewModel.cs
@@ -131,6 +131,9 @@ public partial class RedeemViewModel : BaseViewModel
         _timer.Stop();
         CarouselPosition = 0;
 
+        // Ensure reward affordability is calculated against the user's latest credit balance.
+        await _userService.UpdateMyDetailsAsync();
+
         await Rewards.LoadAsync(async ct => await FetchRewardsData(ct), reload: true);
     }
 
@@ -167,6 +170,7 @@ public partial class RedeemViewModel : BaseViewModel
             _timer.Start();
 
             CarouselRewards.ReplaceRange(Rewards.Collection.Where(r => r.IsCarousel));
+            UpdateRewardsAffordability();
         });
     }
 
@@ -267,7 +271,6 @@ public partial class RedeemViewModel : BaseViewModel
             {
                 popup.CallbackEvent -= handler;
                 await LoadData();
-                await _userService.UpdateMyDetailsAsync();
             };
             popup.CallbackEvent += handler;
             await MopupService.Instance.PushAsync(popup);


### PR DESCRIPTION
## Summary
- Fixes #1563
- Refresh current user details before loading rewards so credits/user id are current before affordability and pending-redemption checks run
- Recompute reward affordability after cached or fresh reward data updates the redeem list
- Prevent stale cached reward UI state from leaving GET buttons disabled after the current balance is already known

## Investigation
- Issue #1563 identifies Marina and Hawk as affected, with sufficient points but disabled reward buttons
- Production App Insights showed their Reward/List, User/Get, and GetUserPendingRedemptions calls returned 200 during the report window
- Some early GetUserPendingRedemptions requests used userId=0 before the real user id arrived, which matches a timing issue in the Redeem load path
- No Reward/Claim or CreatePendingRedemption requests were recorded for the affected accounts in the last 24h, matching a client-side disabled-button issue before the redeem popup/API call

## Verification
- PASS: dotnet build src/MobileUI/MobileUI.csproj -f net10.0-android --no-restore
- BLOCKED locally: dotnet build SSW.Rewards.sln fails on iOS provisioning profile availability for MobileUI