### PR TITLE
📝 Mark internal workflows as (Automation) and document the human-run pipelines

### DIFF
--- a/.github/workflows/admin-build.yml
+++ b/.github/workflows/admin-build.yml
@@ -1,3 +1,5 @@
+name: Admin - Build (Automation)
+
 on:
     workflow_call:
 

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -1,3 +1,5 @@
+name: Admin - Deploy (Automation)
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,4 +1,4 @@
-name: Build Android app
+name: Build Android app (Automation)
 
 on:
   workflow_call:

--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Android to Google Play
+name: Deploy Android to Google Play (Automation)
 
 on:
   workflow_call:

--- a/.github/workflows/api-az-deploy.yml
+++ b/.github/workflows/api-az-deploy.yml
@@ -1,4 +1,4 @@
-name: API - Deploy
+name: API - Deploy (Automation)
 
 on:
   workflow_call:

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -1,3 +1,5 @@
+name: API - Build (Automation)
+
 on:
   workflow_call:
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build and Test (Automation)
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (Automation)
 
 on:
   workflow_call:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,4 +1,4 @@
-name: Build iOS app
+name: Build iOS app (Automation)
 
 on:
   workflow_call:

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy iOS build to TestFlight
+name: Deploy iOS build to TestFlight (Automation)
 
 on:
   workflow_call:

--- a/_docs/Instructions-Deployment.md
+++ b/_docs/Instructions-Deployment.md
@@ -4,14 +4,16 @@
 
 Only three workflows are run by humans — the ones pinned in the Actions tab. Everything named
 "(Automation)" is internal machinery (reusable workflows the pinned ones call, or CI that
-triggers itself) and should never be run directly.
+triggers itself) and doesn't need to be run directly. Some automations — "Build and Test" and
+"CI" — can be run manually for debugging purposes; the rest can only be invoked by the
+workflows that call them.
 
 | Workflow | Who runs it | Purpose |
 | --- | --- | --- |
 | **API - Main (Build & deploy)** | 👤 You (Run workflow) | Deploy Web API + infrastructure → staging, then approve → production |
 | **Admin - Main (Build & Deploy)** | 👤 You (Run workflow) | Deploy Admin Portal → staging, then approve → production |
 | **Mobile - Main (Build & Deploy)** | 🤖 Auto on mobile changes to `main` (or manually) | Build + ship the mobile app to Google Play / TestFlight |
-| Build and Test (Automation) | 🤖 Auto on every PR | PR quality gate — build + tests |
+| Build and Test (Automation) | 🤖 Auto on every PR to `main` | PR quality gate — build + tests |
 | Everything else "(Automation)" | 🤖 Never run directly | Build/deploy steps invoked by the workflows above |
 
 ### Web API / Infrastructure
@@ -106,7 +108,7 @@ For manual purge steps and access notes, see Deployment Troubleshooting → [Adm
 
 - Workflow: "Build and Test (Automation)"
 - YAML: `.github/workflows/build-and-test.yml`
-- Trigger: Automatic on PRs and pushes
+- Trigger: Automatic on PRs targeting `main` (manual `workflow_dispatch` available for debugging)
 - Purpose: Builds Mobile, Admin, and Web API; runs tests; does not deploy
 
 # High-level production dependencies
@@ -205,7 +207,7 @@ Use these from GitHub → Actions tab. Where noted, Production requires manual a
 - Build & Test (no deployment)
   - Workflow: "Build and Test (Automation)"
   - File: `.github/workflows/build-and-test.yml`
-  - Trigger: Automatic (PRs and pushes)
+  - Trigger: Automatic (PRs targeting `main`)
 
 How to run (manual workflows):
 

--- a/_docs/Instructions-Deployment.md
+++ b/_docs/Instructions-Deployment.md
@@ -1,5 +1,19 @@
 # Deployment
 
+## Which workflow do I use?
+
+Only three workflows are run by humans — the ones pinned in the Actions tab. Everything named
+"(Automation)" is internal machinery (reusable workflows the pinned ones call, or CI that
+triggers itself) and should never be run directly.
+
+| Workflow | Who runs it | Purpose |
+| --- | --- | --- |
+| **API - Main (Build & deploy)** | 👤 You (Run workflow) | Deploy Web API + infrastructure → staging, then approve → production |
+| **Admin - Main (Build & Deploy)** | 👤 You (Run workflow) | Deploy Admin Portal → staging, then approve → production |
+| **Mobile - Main (Build & Deploy)** | 🤖 Auto on mobile changes to `main` (or manually) | Build + ship the mobile app to Google Play / TestFlight |
+| Build and Test (Automation) | 🤖 Auto on every PR | PR quality gate — build + tests |
+| Everything else "(Automation)" | 🤖 Never run directly | Build/deploy steps invoked by the workflows above |
+
 ### Web API / Infrastructure
 
 1. Merge PR into main
@@ -90,7 +104,7 @@ For manual purge steps and access notes, see Deployment Troubleshooting → [Adm
 
 ### Build & Test (no deployment)
 
-- Workflow: "Build and Test"
+- Workflow: "Build and Test (Automation)"
 - YAML: `.github/workflows/build-and-test.yml`
 - Trigger: Automatic on PRs and pushes
 - Purpose: Builds Mobile, Admin, and Web API; runs tests; does not deploy
@@ -189,7 +203,7 @@ Use these from GitHub → Actions tab. Where noted, Production requires manual a
   - Trigger: Automatic (on `main` when mobile app changes)
 
 - Build & Test (no deployment)
-  - Workflow: "Build and Test"
+  - Workflow: "Build and Test (Automation)"
   - File: `.github/workflows/build-and-test.yml`
   - Trigger: Automatic (PRs and pushes)
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Follow-up to #1565 — the Actions sidebar lists every workflow (GitHub can't hide reusable ones), making it unclear which of the 13 workflows humans actually run.

> 2. What was changed?

✏️
1. Added an "(Automation)" suffix to the name of every workflow that is never run directly by a human — the reusable `workflow_call` workflows (admin/api/android/ios build & deploy, `ci.yml`) and the self-triggering PR gate (`build-and-test.yml`). The three human-run pipelines (Admin/API/Mobile - Main) keep their clean names.
2. Added a `name:` to `admin-build.yml`, `admin-deploy.yml`, and `api-build.yml`, which previously displayed as raw file paths in the Actions tab.
3. Added a "Which workflow do I use?" table at the top of `_docs/Instructions-Deployment.md` — who runs what, and that "(Automation)" workflows are internal machinery.

No triggers, jobs, or behaviour changed — names and docs only. (Branch protection pins no status-check names, so renames are safe.)

> 3. Did you do pair or mob programming?

✏️ Yes - JK pairing with Claude (Fable 5)
