### PR TITLE
✨ Web API | Use pooled DbContext

### DIFF
--- a/src/Infrastructure/ConfigureServices.cs
+++ b/src/Infrastructure/ConfigureServices.cs
@@ -29,8 +29,8 @@ public static class ConfigureServices
         services.AddMemoryCache();
         services.AddScoped<ICacheService, CacheService>();
 
-        services.AddScoped<AuditableEntitySaveChangesInterceptor>();
-        services.AddScoped<AchievementIntegrationIdInterceptor>();
+        services.AddSingleton<AuditableEntitySaveChangesInterceptor>();
+        services.AddSingleton<AchievementIntegrationIdInterceptor>();
 
         // ChatGPT config
         services.AddOptions<GPTServiceOptions>()
@@ -58,13 +58,17 @@ public static class ConfigureServices
 
         services.AddHangfireServer();
 
-        services.AddDbContext<ApplicationDbContext>(options =>
+        services.AddDbContextPool<ApplicationDbContext>((provider, options) =>
         {
 #if DEBUG
             options.EnableSensitiveDataLogging();
 #endif
             options.UseSqlServer(configuration.GetConnectionString("DefaultConnection"),
                 builder => builder.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName));
+
+            options.AddInterceptors(
+                provider.GetRequiredService<AuditableEntitySaveChangesInterceptor>(),
+                provider.GetRequiredService<AchievementIntegrationIdInterceptor>());
         });
 
         services.AddScoped<IApplicationDbContext>(provider => provider.GetRequiredService<ApplicationDbContext>());

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -2,25 +2,15 @@
 using Microsoft.EntityFrameworkCore;
 using SSW.Rewards.Application.Common.Interfaces;
 using SSW.Rewards.Domain.Entities;
-using SSW.Rewards.Infrastructure.Persistence.Interceptors;
 
 namespace SSW.Rewards.Infrastructure.Persistence;
 
 public class ApplicationDbContext : DbContext, IApplicationDbContext
 {
     //private readonly IMediator _mediator;
-    private readonly AuditableEntitySaveChangesInterceptor _auditableEntitySaveChangesInterceptor;
-    private readonly AchievementIntegrationIdInterceptor _achievementIntegrationIdInterceptor;
-
-    public ApplicationDbContext(
-        DbContextOptions<ApplicationDbContext> options,
-        AuditableEntitySaveChangesInterceptor auditableEntitySaveChangesInterceptor,
-        AchievementIntegrationIdInterceptor achievementIntegrationIdInterceptor
-        )
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
     {
-        _auditableEntitySaveChangesInterceptor = auditableEntitySaveChangesInterceptor;
-        _achievementIntegrationIdInterceptor = achievementIntegrationIdInterceptor;
     }
 
     public DbSet<StaffMember> StaffMembers { get; set; }
@@ -55,12 +45,5 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
         modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
         base.OnModelCreating(modelBuilder);
-    }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder.AddInterceptors(
-            _auditableEntitySaveChangesInterceptor,
-            _achievementIntegrationIdInterceptor);
     }
 }

--- a/tests/Application.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/Application.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,11 +1,13 @@
-﻿using SSW.Rewards.Application.Common.Interfaces;
-using SSW.Rewards.Infrastructure.Persistence;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
+using SSW.Rewards.Application.Common.Interfaces;
+using SSW.Rewards.Infrastructure.Persistence;
+using SSW.Rewards.Infrastructure.Persistence.Interceptors;
 
 namespace SSW.Rewards.Application.IntegrationTests;
 
@@ -27,16 +29,27 @@ internal class CustomWebApplicationFactory : WebApplicationFactory<Program>
 
         builder.ConfigureServices((builder, services) =>
         {
-            services
-                .Remove<ICurrentUserService>()
-                .AddTransient(provider => Mock.Of<ICurrentUserService>(s =>
-                    s.GetUserId() == GetCurrentUserId()));
+            var currentUserServiceMock = new Mock<ICurrentUserService>();
+            currentUserServiceMock
+                .Setup(s => s.GetUserId())
+                .Returns(() => GetCurrentUserId() ?? string.Empty);
 
             services
-                .Remove<DbContextOptions<ApplicationDbContext>>()
-                .AddDbContext<ApplicationDbContext>((sp, options) =>
-                    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"),
-                        builder => builder.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName)));
+                .Remove<ICurrentUserService>()
+                .AddSingleton(currentUserServiceMock.Object);
+
+            services.RemoveAll<DbContextOptions<ApplicationDbContext>>();
+            services.RemoveAll<ApplicationDbContext>();
+
+            services.AddDbContextPool<ApplicationDbContext>((provider, options) =>
+            {
+                options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"),
+                    builder => builder.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName));
+
+                options.AddInterceptors(
+                    provider.GetRequiredService<AuditableEntitySaveChangesInterceptor>(),
+                    provider.GetRequiredService<AchievementIntegrationIdInterceptor>());
+            });
         });
     }
 }

--- a/tests/Application.IntegrationTests/DbContextPoolingTests.cs
+++ b/tests/Application.IntegrationTests/DbContextPoolingTests.cs
@@ -1,0 +1,110 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using SSW.Rewards.Application.Common.Interfaces;
+using SSW.Rewards.Domain.Entities;
+using SSW.Rewards.Infrastructure.Persistence;
+using SSW.Rewards.Infrastructure.Persistence.Interceptors;
+
+namespace SSW.Rewards.Infrastructure.IntegrationTests;
+
+public class DbContextPoolingTests
+{
+    [Test]
+    public async Task PooledContextShouldUseCurrentUserForEachScope()
+    {
+        var (provider, currentUserService) = BuildServiceProvider();
+        using (provider)
+        {
+            currentUserService.UserId = "user-1";
+            var firstSkillId = await AddSkillAsync(provider, "Pooling test 1");
+
+            currentUserService.UserId = "user-2";
+            var secondSkillId = await AddSkillAsync(provider, "Pooling test 2");
+
+            using var assertionScope = provider.CreateScope();
+            var context = assertionScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var firstSavedSkill = await context.Skills.SingleAsync(s => s.Id == firstSkillId);
+            var secondSavedSkill = await context.Skills.SingleAsync(s => s.Id == secondSkillId);
+
+            firstSavedSkill.CreatedBy.Should().Be("user-1");
+            secondSavedSkill.CreatedBy.Should().Be("user-2");
+        }
+    }
+
+    [Test]
+    public async Task PooledContextShouldRunAchievementIntegrationIdInterceptor()
+    {
+        var (provider, _) = BuildServiceProvider();
+        using (provider)
+        {
+            using var scope = provider.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var firstAchievement = new Achievement { Name = "Pooling achievement 1", IntegrationId = "duplicate" };
+            var secondAchievement = new Achievement { Name = "Pooling achievement 2", IntegrationId = "duplicate" };
+
+            context.Achievements.AddRange(firstAchievement, secondAchievement);
+            await context.SaveChangesAsync();
+
+            firstAchievement.IntegrationId.Should().NotBeNullOrWhiteSpace();
+            secondAchievement.IntegrationId.Should().NotBeNullOrWhiteSpace();
+            firstAchievement.IntegrationId.Should().NotBe(secondAchievement.IntegrationId);
+        }
+    }
+
+    private static async Task<int> AddSkillAsync(IServiceProvider provider, string name)
+    {
+        using var scope = provider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var skill = new Skill { Name = name };
+
+        context.Skills.Add(skill);
+        await context.SaveChangesAsync();
+
+        return skill.Id;
+    }
+
+    private static (ServiceProvider Provider, TestCurrentUserService CurrentUserService) BuildServiceProvider()
+    {
+        var currentUserService = new TestCurrentUserService();
+        var services = new ServiceCollection();
+
+        services.AddSingleton<ICurrentUserService>(currentUserService);
+        services.AddSingleton<IDateTime>(new TestDateTime());
+        services.AddSingleton<AuditableEntitySaveChangesInterceptor>();
+        services.AddSingleton<AchievementIntegrationIdInterceptor>();
+        services.AddDbContextPool<ApplicationDbContext>((provider, options) =>
+        {
+            options.UseInMemoryDatabase(Guid.NewGuid().ToString());
+            options.AddInterceptors(
+                provider.GetRequiredService<AuditableEntitySaveChangesInterceptor>(),
+                provider.GetRequiredService<AchievementIntegrationIdInterceptor>());
+        });
+
+        return (services.BuildServiceProvider(), currentUserService);
+    }
+
+    private sealed class TestCurrentUserService : ICurrentUserService
+    {
+        public string UserId { get; set; } = string.Empty;
+
+        public string GetUserId() => UserId;
+
+        public string GetUserEmail() => string.Empty;
+
+        public string GetUserFullName() => string.Empty;
+
+        public string? GetUserProfilePic() => null;
+
+        public bool IsInRole(string role) => false;
+    }
+
+    private sealed class TestDateTime : IDateTime
+    {
+        public DateTime Now => new(2026, 7, 9, 0, 0, 0, DateTimeKind.Local);
+
+        public DateTime UtcNow => new(2026, 7, 9, 0, 0, 0, DateTimeKind.Utc);
+    }
+}

--- a/tests/Application.IntegrationTests/DbContextPoolingTests.cs
+++ b/tests/Application.IntegrationTests/DbContextPoolingTests.cs
@@ -35,6 +35,34 @@ public class DbContextPoolingTests
     }
 
     [Test]
+    public async Task PooledContextShouldUseCurrentUserForConcurrentScopes()
+    {
+        var (provider, currentUserService) = BuildServiceProvider();
+        using (provider)
+        {
+            var savedSkills = await Task.WhenAll(Enumerable.Range(1, 20).Select(index => Task.Run(async () =>
+            {
+                var userId = $"concurrent-user-{index}";
+                currentUserService.UserId = userId;
+
+                var skillId = await AddSkillAsync(provider, $"Concurrent pooling test {index}");
+
+                return new { skillId, userId };
+            })));
+
+            using var assertionScope = provider.CreateScope();
+            var context = assertionScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            foreach (var savedSkill in savedSkills)
+            {
+                var skill = await context.Skills.SingleAsync(s => s.Id == savedSkill.skillId);
+
+                skill.CreatedBy.Should().Be(savedSkill.userId);
+            }
+        }
+    }
+
+    [Test]
     public async Task PooledContextShouldRunAchievementIntegrationIdInterceptor()
     {
         var (provider, _) = BuildServiceProvider();
@@ -88,7 +116,13 @@ public class DbContextPoolingTests
 
     private sealed class TestCurrentUserService : ICurrentUserService
     {
-        public string UserId { get; set; } = string.Empty;
+        private readonly AsyncLocal<string?> _userId = new();
+
+        public string UserId
+        {
+            get => _userId.Value ?? string.Empty;
+            set => _userId.Value = value;
+        }
 
         public string GetUserId() => UserId;
 

--- a/tests/Application.IntegrationTests/Testing.cs
+++ b/tests/Application.IntegrationTests/Testing.cs
@@ -24,7 +24,7 @@ public partial class Testing
     private static string? _currentUserId;
 
     [OneTimeSetUp]
-    public async void RunBeforeAnyTests()
+    public async Task RunBeforeAnyTests()
     {
         _factory = new CustomWebApplicationFactory();
         _scopeFactory = _factory.Services.GetRequiredService<IServiceScopeFactory>();


### PR DESCRIPTION
## What
- Switches `ApplicationDbContext` registration to EF Core `AddDbContextPool`.
- Moves save-change interceptors out of the pooled `DbContext` instance and into the DI-built options.
- Updates the integration-test factory to use pooled registration and lazy current-user lookup.
- Adds pooled-context regression coverage for audit user isolation, concurrent current-user isolation, and achievement integration-id interception.

## Why
Issue #1161 asks for DbContext pooling to reduce per-request DbContext setup pressure under load. The previous context constructor captured interceptor instances, which is not the right shape for a pooled context because pooled instances are reused between scopes.

## Validation
- `dotnet build src/WebAPI/WebAPI.csproj`
- `dotnet build src/AdminUI/AdminUI.csproj`
- `dotnet test tests/Application.UnitTests/Application.UnitTests.csproj --logger "console;verbosity=minimal"` — 59 passed
- `dotnet test tests/Domain.UnitTests/Domain.UnitTests.csproj --logger "console;verbosity=minimal"` — 5 passed
- `dotnet test tests/Application.IntegrationTests/Application.IntegrationTests.csproj --no-restore --filter FullyQualifiedName~DbContextPoolingTests --logger "console;verbosity=normal"` — 3 passed
- Aspire foreground run: `rewards-webapi` and `rewards-adminui` healthy at `https://localhost:5001` and `https://localhost:7137`
- `curl -kfsS https://localhost:5001/health` — Healthy
- Playwright concurrent smoke from existing harness: `npm test -- --project=chromium tests/auth.verify.spec.ts --workers=4 --repeat-each=4 --reporter=list` — 8 passed
- Aspire log scan after smoke found no DbContext/pooling/second-operation/disposed-context errors
- Opus review: no blocking findings; follow-up review confirmed the deterministic concurrency test is sound

## Notes
- `dotnet build SSW.Rewards.sln` is still blocked locally by existing mobile prerequisites: missing Android `google-services.json` and no iOS signing key. Backend/Admin builds pass.
- One self-inflicted parallel verification run hit an MSBuild file lock while building and testing the same project graph concurrently; rerunning the pooling tests alone passed.

Fixes #1161
