### PR TITLE
📝 Document sync-mobile bootstrap for fresh git worktrees

### DIFF
--- a/.agents/skills/setup-mobile/SKILL.md
+++ b/.agents/skills/setup-mobile/SKILL.md
@@ -50,10 +50,10 @@ placeholder. Get the real files from Keeper, or use the **Sync mobile secrets (i
 the dashboard `mobile-app` resource.
 
 > **Fresh git worktree?** These files are materialized *into the working tree*, so each new worktree
-> needs them even if another worktree on the machine already has them. Run `rewards-dev secrets
-> sync-mobile` once in the new worktree (idempotent). See the **New worktree bootstrap** note in
-> [Aspire-Local-Dev.md](../../../_docs/Aspire-Local-Dev.md) so you don't chase a build that fails only
-> on Firebase.
+> needs them even if another worktree on the machine already has them. Run
+> `rewards-dev secrets sync-mobile` once in the new worktree (idempotent). See the **New worktree
+> bootstrap** note in [Aspire-Local-Dev.md](../../../_docs/Aspire-Local-Dev.md) so you don't chase a
+> build that fails only on Firebase.
 
 ## Step 4 — build & deploy (Android emulator or iOS simulator)
 

--- a/.agents/skills/setup-mobile/SKILL.md
+++ b/.agents/skills/setup-mobile/SKILL.md
@@ -49,6 +49,12 @@ On a system-wide .NET install this needs `sudo`.
 placeholder. Get the real files from Keeper, or use the **Sync mobile secrets (isolated)** command on
 the dashboard `mobile-app` resource.
 
+> **Fresh git worktree?** These files are materialized *into the working tree*, so each new worktree
+> needs them even if another worktree on the machine already has them. Run `rewards-dev secrets
+> sync-mobile` once in the new worktree (idempotent). See the **New worktree bootstrap** note in
+> [Aspire-Local-Dev.md](../../../_docs/Aspire-Local-Dev.md) so you don't chase a build that fails only
+> on Firebase.
+
 ## Step 4 — build & deploy (Android emulator or iOS simulator)
 
 The app builds for both platforms. Build one platform at a time — only that platform's workload is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Gamified engagement platform: .NET MAUI mobile app + Blazor WASM admin + ASP.NET
 - **Framework**: .NET 10 | **Architecture**: Clean Architecture with CQRS (MediatR)
 - **Build**: `dotnet build SSW.Rewards.sln` | **Test**: `dotnet test`
 - **Setup**: `aspire run` (from the repo root — `.aspire/settings.json` targets `src/AppHost`; .NET Aspire orchestrates SQL + Azurite + WebAPI + AdminUI). Secrets come from **one** Keeper record into the AppHost user-secrets — paste once with `rewards-dev secrets edit`, verify with `rewards-dev secrets check`. See [Aspire-Local-Dev.md](_docs/Aspire-Local-Dev.md).
+- **New git worktree?** Before building, read the **New worktree bootstrap** note in [Aspire-Local-Dev.md](_docs/Aspire-Local-Dev.md) and run `rewards-dev secrets sync-mobile` in the new worktree — the git-ignored Firebase files are per-worktree, so a full `SSW.Rewards.sln` build otherwise fails on MobileUI even though the backend builds/tests fine. Don't chase that as a code bug.
 
 ## Critical Rules
 

--- a/_docs/Aspire-Local-Dev.md
+++ b/_docs/Aspire-Local-Dev.md
@@ -251,3 +251,15 @@ No more per-session URL churn in `Constants.cs`.
   **one** clone at a time. Symptom if you ever see a second container fighting for the volume: SQL
   logs `Setup FAILED copying system data file … Access is denied` and exits 255 — stop the other
   `ssw-rewards-sql*` container (`docker stop ssw-rewards-sql`) and re-run.
+- **New worktree bootstrap** — machine-global state (MAUI workloads, the AppHost + isolated mobile
+  user-secrets stores) is shared across worktrees, but the **git-ignored Firebase files**
+  (`src/MobileUI/Platforms/{Android/google-services.json, iOS/GoogleService-Info.plist}`) are
+  materialized *into the working tree*, so a fresh worktree doesn't have them even if another worktree
+  on the machine does. In every new worktree, run once:
+  ```bash
+  rewards-dev secrets sync-mobile   # writes the two Firebase files into THIS worktree
+  ```
+  That's the whole mobile fix (idempotent; safe to re-run). Prereq: the machine's AppHost store must
+  already hold the Keeper record — a one-time-per-machine `rewards-dev secrets edit`, not per-worktree.
+  Building the full `SSW.Rewards.sln` compiles MobileUI, so skipping this makes the *solution* build
+  fail on Firebase even though the backend projects build and test fine.


### PR DESCRIPTION
## Problem

Building the full `SSW.Rewards.sln` in a **fresh git worktree** fails on MobileUI (missing Firebase config) even though the backend projects build and test fine — which reads like a regression but isn't. The git-ignored Firebase files (`google-services.json` / `GoogleService-Info.plist`) are **materialized into the working tree**, so a new worktree doesn't have them even when another worktree on the same machine does. Machine-global state (MAUI workloads, the AppHost + isolated mobile user-secrets stores) *is* shared, which is why the failure looks mysterious.

An agent (or human) with no note about this chases a phantom build/code bug instead of running one command.

## Fix

Document the one-time-per-worktree bootstrap so it's caught at the point of confusion:

```bash
rewards-dev secrets sync-mobile   # writes the two Firebase files into THIS worktree
```

Idempotent and safe to re-run. Prereq is the one-time-per-machine `rewards-dev secrets edit` (Keeper record), not per-worktree.

## Changes (docs only)

- **`_docs/Aspire-Local-Dev.md`** — new **New worktree bootstrap** note in Notes/gotchas (source of truth), beside the existing shared-volume worktree gotcha.
- **`AGENTS.md`** — "New git worktree?" bullet in Essentials naming the exact symptom so agents recognize it as setup, not a code bug, and don't chase their tail.
- **`.agents/skills/setup-mobile/SKILL.md`** — callout in the Firebase-config step linking back to the Aspire doc.

All three converge on the same command and the same source-of-truth doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)