### PR TITLE
Release mobile version 3.1.5

### DIFF
--- a/src/MobileUI/MobileUI.csproj
+++ b/src/MobileUI/MobileUI.csproj
@@ -30,7 +30,7 @@
 		<ApplicationIdGuid>fb3c30ce-ab0c-4155-b244-e49513e45a94</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>3.1.4</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>3.1.5</ApplicationDisplayVersion>
 		<ApplicationVersion>2</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
## Summary
- Bumps the MAUI mobile marketing version from 3.1.4 to 3.1.5.
- Applies to both Android and iOS through the shared `ApplicationDisplayVersion` in `src/MobileUI/MobileUI.csproj`.

## Validation
- `dotnet restore src/MobileUI/MobileUI.csproj -p:MobileTargetFrameworks=net10.0-android`
- `dotnet restore src/MobileUI/MobileUI.csproj -p:MobileTargetFrameworks=net10.0-ios`
- `dotnet msbuild src/MobileUI/MobileUI.csproj -p:TargetFramework=net10.0-android -p:MobileTargetFrameworks=net10.0-android -getProperty:ApplicationDisplayVersion` -> `3.1.5`
- `dotnet msbuild src/MobileUI/MobileUI.csproj -p:TargetFramework=net10.0-ios -p:MobileTargetFrameworks=net10.0-ios -getProperty:ApplicationDisplayVersion` -> `3.1.5`

## Notes
- Local signed mobile builds were not run because this worktree does not contain the gitignored Firebase client config files. The release workflows inject those files from GitHub environment variables during CI.
- Restore currently reports existing warnings for `SixLabors.ImageSharp` advisories and an AndroidX dependency constraint; this PR does not change those dependencies.