### PR TITLE
CI - Use newer Xcode for iOS build

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -42,8 +42,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          sudo xcode-select -s "/Applications/Xcode_26.2.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_26.2.app" >> $GITHUB_ENV
+          sudo xcode-select -s "/Applications/Xcode_26.6.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_26.6.app" >> $GITHUB_ENV
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2


### PR DESCRIPTION
## Summary
- Updates the iOS build workflow to select Xcode 26.6 instead of Xcode 26.2.

## Why
- The fresh mobile release run imported the new signing certificate and provisioning profile successfully.
- The iOS build then failed in `Build and sign` with `MT4162` because Xcode 26.2 only provides iOS SDK 26.2, while the current .NET iOS workload references APIs introduced in iOS 26.4+.
- The `macos-26-arm64` runner image includes Xcode 26.6 with iOS SDK 26.5.

## Verification
- Not run locally; this is a GitHub-hosted macOS runner configuration change.
- Expected verification is the next Mobile - Main iOS build.