### PR TITLE
Docs - Clarify mobile signing and testing tracks

### DIFF
--- a/_docs/Instructions-Beta-Testing.md
+++ b/_docs/Instructions-Beta-Testing.md
@@ -8,22 +8,22 @@ Give developers, QA, Product Owner, and other stakeholders access to pre‑relea
 
 1. Developer merges PR into `main`.
 2. CI pipeline builds Android (AAB) + iOS (IPA) artifacts.
-3. A manual approval gate (SSW Rewards Maintainers) in the CD pipeline is evaluated.
+3. A manual approval gate from the project maintainers in the CD pipeline is evaluated.
 4. On approval the pipeline automatically:
-   - Uploads Android AAB to Google Play (Beta / Internal Testing).
-   - Uploads iOS build to App Store Connect and enables it for designated TestFlight groups.
+   - Uploads Android AAB to the configured Google Play testing track (`internal` in the current workflow).
+   - Uploads iOS build to App Store Connect / TestFlight.
 5. Testers on those beta tracks receive updates automatically (Play Store auto-update / TestFlight notification depending on their settings).
 6. Sanity / regression tests executed (see "Sanity / Smoke Test Checklist").
-7. When criteria met, the same (or a subsequent) build is promoted to Production (separate approval gate – see `Instructions-Deployment.md`).
+7. When criteria are met, promote the same build to open testing or production in the store console, or use a dedicated release workflow if one exists.
 
 ## CI/CD Pipeline Overview
 
 | Stage                 | Trigger            | Action                                            | Manual Gate            | Outputs                    |
 | --------------------- | ------------------ | ------------------------------------------------- | ---------------------- | -------------------------- |
 | Build                 | Push to `main`     | Compile, run unit tests, produce AAB + IPA        | No                     | Build artifacts            |
-| Beta Deploy (Android) | Post-build success | (Pending until gate) Upload AAB to Play track     | Yes (Approve)          | Play Store beta available  |
-| Beta Deploy (iOS)     | Post-build success | (Pending until gate) Upload to App Store Connect  | Yes (Approve)          | TestFlight build available |
-| Prod Release          | Manual trigger     | Promotes approved beta build to Production stores | Yes (Release approval) | Public store release       |
+| Beta Deploy (Android) | Post-build success | (Pending until gate) Upload AAB to configured Play track | Yes (Approve)          | Play Store testing release |
+| Beta Deploy (iOS)     | Post-build success | (Pending until gate) Upload to App Store Connect / TestFlight | Yes (Approve)          | TestFlight build available |
+| Public Release        | Manual store action or dedicated workflow | Promote approved build to open testing or production | Store-dependent | Public tester or store release |
 
 ## Requesting Beta Access (New Users)
 
@@ -31,7 +31,7 @@ If you are not yet a tester but need beta access:
 
 1. Confirm you actually need pre-release features (otherwise use Production store build).
 2. Email the Product Owner (PO) or post in the Teams channel with:
-   - Subject: "Beta Access Request – SSW Rewards (Android/iOS)"
+   - Subject: "Beta Access Request – <App Name> (Android/iOS)"
    - Platforms required (Android, iOS, or both)
    - Relevant account email (Google, Apple, etc.)
 3. PO approves and adds you to the relevant tester lists (see Adding a New Tester) and confirms back.
@@ -45,17 +45,26 @@ If you are not yet a tester but need beta access:
 - Platform(s) required (Android, iOS, or both)
 - Email address
 
-### 2. Android – Add to Play Beta
+### 2. Android – Add to Play Testing
 
-1. Google Play Console > `SSW Rewards` > Testing > Internal testing.
-2. Add tester email to the Testers list.
-3. Provide tester the opt‑in link if first time.
+1. Google Play Console > your app > **Testing**.
+2. Choose the track used by your workflow or release plan:
+   - **Internal testing**: small, invite-only group; the current workflow uploads here.
+   - **Closed testing**: controlled named groups or lists.
+   - **Open testing**: public opt-in testers from the Play Store listing.
+3. Add tester emails or groups where the track requires them.
+4. Provide the opt-in link if the tester has not joined that track before.
+
+The current Android workflow uploads to `internal`. Publishing the same build to open testing or
+production requires a Play Console promotion/release step unless the workflow is changed to target
+that track.
 
 ### 3. iOS – Add to TestFlight Group
 
 1. App Store Connect > Users and Access: add internal user if needed.
-2. TestFlight tab > Add tester to internal testing group.
-3. After build processing finishes the tester automatically gets access.
+2. TestFlight tab > add the tester to the relevant internal or external testing group.
+3. External TestFlight testing may require Apple beta app review before testers can install the build.
+4. After build processing and any required review finishes, testers receive access based on their group.
 
 ## Promotion Steps (Automated)
 
@@ -64,14 +73,18 @@ If you are not yet a tester but need beta access:
 1. Merge -> build pipeline runs.
 2. Approver reviews change summary & test results at the approval gate.
 3. On approval pipeline uploads AAB to configured track and starts rollout (usually 100% instantly for test tracks).
-4. Monitor Play Console release for status / crashes (supplement with Firebase Crashlytics).
+4. If you need broader public testers, promote the release from internal testing to open testing in
+   Play Console and complete any required review.
+5. Monitor Play Console release for status / crashes (supplement with Firebase Crashlytics).
 
 ### iOS
 
 1. Merge -> build pipeline runs.
 2. Approver grants beta deployment stage.
 3. Pipeline uploads build to App Store Connect (processing may take several minutes).
-4. Monitor TestFlight metrics & Firebase Crashlytics for issues.
+4. Add the processed build to the intended TestFlight group if the workflow or App Store Connect
+   settings do not do that automatically.
+5. Monitor TestFlight metrics & Firebase Crashlytics for issues.
 
 ## Release Notes Template (Keep concise)
 
@@ -123,5 +136,6 @@ Gold plating:
 - [Deployment Steps](Instructions-Deployment.md)
 - Apple TestFlight docs: https://developer.apple.com/testflight/
 - Google Play testing tracks: https://support.google.com/googleplay/android-developer/answer/9845334
+- Google Play release rollout docs: https://support.google.com/googleplay/android-developer/answer/9859348
 - Firebase Analytics: https://firebase.google.com/docs/analytics
 - Firebase Crashlytics: https://firebase.google.com/docs/crashlytics

--- a/_docs/Instructions-Beta-Testing.md
+++ b/_docs/Instructions-Beta-Testing.md
@@ -8,7 +8,7 @@ Give developers, QA, Product Owner, and other stakeholders access to pre‑relea
 
 1. Developer merges PR into `main`.
 2. CI pipeline builds Android (AAB) + iOS (IPA) artifacts.
-3. A manual approval gate from the project maintainers in the CD pipeline is evaluated.
+3. A manual approval gate in the CD pipeline is evaluated by the project maintainers.
 4. On approval the pipeline automatically:
    - Uploads Android AAB to the configured Google Play testing track (`internal` in the current workflow).
    - Uploads iOS build to App Store Connect / TestFlight.

--- a/_docs/Instructions-Deployment-Troubleshooting.md
+++ b/_docs/Instructions-Deployment-Troubleshooting.md
@@ -125,7 +125,7 @@ GitHub secrets are write-only, so verify the local files before uploading them.
 ```bash
 repo="<owner>/<repo>"
 
-base64 -i apple-distribution.p12 | tr -d '\n' |
+base64 < apple-distribution.p12 | tr -d '\n' |
   gh secret set APPLE_CERT -R "$repo"
 
 read -rsp "p12 export password: " APPLE_CERT_PASSWORD
@@ -137,7 +137,7 @@ unset APPLE_CERT_PASSWORD
 printf '%s' "Apple Distribution: <Company Name> (<Team ID>)" |
   gh secret set APPLE_CERT_NAME -R "$repo"
 
-base64 -i "<App Store Profile>.mobileprovision" | tr -d '\n' |
+base64 < "<App Store Profile>.mobileprovision" | tr -d '\n' |
   gh secret set APPLE_PROFILE -R "$repo"
 
 printf '%s' "<profile-name>" |

--- a/_docs/Instructions-Deployment-Troubleshooting.md
+++ b/_docs/Instructions-Deployment-Troubleshooting.md
@@ -15,7 +15,13 @@ iOS code signing key '***' not found in keychain
 GitHub uses two different Apple files:
 
 - `APPLE_CERT` - base64 of a `.p12` file containing the Apple Distribution certificate and its private key.
-- `APPLE_PROFILE` - base64 of the `SSWRewards.mobileprovision` App Store provisioning profile.
+- `APPLE_PROFILE` - base64 of the App Store provisioning profile (`.mobileprovision`).
+
+The workflow also expects:
+
+- `APPLE_CERT_PASSWORD` - the export password for the `.p12`.
+- `APPLE_CERT_NAME` - the certificate identity used by the build, for example `Apple Distribution: <Company Name> (<Team ID>)`.
+- `APPLE_PROFILE_NAME` - the profile name embedded in the provisioning profile.
 
 A `.cer` file downloaded from Apple is not enough for `APPLE_CERT`; it does not include the
 private key. If the certificate was created by another developer, only that developer's Mac
@@ -26,7 +32,7 @@ private key. If the certificate was created by another developer, only that deve
 Create the CSR and private key outside the repository:
 
 ```bash
-workdir="$HOME/Developer/clients/ssw/work/rewards-mobile-signing-rotation/$(date +%Y%m%d-%H%M%S)"
+workdir="$HOME/work/mobile-signing-rotation/$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$workdir"
 chmod 700 "$workdir"
 
@@ -36,7 +42,7 @@ chmod 600 "$workdir/apple-distribution-private.key"
 openssl req -new \
   -key "$workdir/apple-distribution-private.key" \
   -out "$workdir/apple-distribution.csr" \
-  -subj "/emailAddress=<your-ssw-email>/CN=<your-name> Apple Distribution/O=Superior Software for Windows Pty Ltd/C=AU"
+  -subj "/emailAddress=<your-email>/CN=<your-name> Apple Distribution/O=<organization-name>/C=<country-code>"
 
 openssl req -in "$workdir/apple-distribution.csr" -noout -subject
 ```
@@ -65,37 +71,41 @@ openssl pkcs12 -export \
   -inkey apple-distribution-private.key \
   -in apple-distribution.cer.pem \
   -out apple-distribution.p12 \
-  -name "Apple Distribution: Superior Software for Windows Pty Ltd (B5652JTA7Q)"
+  -name "Apple Distribution: <Company Name> (<Team ID>)"
 ```
 
 Use a strong export password for the `.p12`; this password becomes `APPLE_CERT_PASSWORD`.
+
+For the CSR pattern, see SSW Rules: [Do you Code-Sign and Notarize your Apple applications?](https://www.ssw.com.au/rules/code-sign-and-notarize-apple-application/).
+That rule targets macOS Developer ID signing, so use Apple Developer's docs for the iOS-specific
+certificate and App Store profile types.
 
 ### Regenerate the App Store Provisioning Profile
 
 In Apple Developer:
 
 1. Go to **Profiles**.
-2. Open `SSWRewards` (not `SSWRewards_Dev`).
+2. Open the App Store provisioning profile used by CI, not a Development profile.
 3. Confirm it is:
    - Platform: `iOS`
    - Type: `App Store`
-   - App ID: `SSW Mobile App (com.SSW.SSW.Consulting)`
+   - App ID: the app's production bundle identifier
 4. Click **Edit**.
 5. Select the new Apple Distribution certificate.
-6. Save and download the regenerated `SSW Rewards.mobileprovision`.
+6. Save and download the regenerated `.mobileprovision` file.
 
 Verify the profile and certificate match:
 
 ```bash
 security cms -D \
-  -i "SSW Rewards.mobileprovision" \
-  > SSWRewards.plist
+  -i "<App Store Profile>.mobileprovision" \
+  > AppStoreProfile.plist
 
-/usr/libexec/PlistBuddy -c 'Print :Name' SSWRewards.plist
-/usr/libexec/PlistBuddy -c 'Print :ExpirationDate' SSWRewards.plist
-/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' SSWRewards.plist
+/usr/libexec/PlistBuddy -c 'Print :Name' AppStoreProfile.plist
+/usr/libexec/PlistBuddy -c 'Print :ExpirationDate' AppStoreProfile.plist
+/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' AppStoreProfile.plist
 
-/usr/libexec/PlistBuddy -c 'Print :DeveloperCertificates:0' SSWRewards.plist > profile-cert0.der
+/usr/libexec/PlistBuddy -c 'Print :DeveloperCertificates:0' AppStoreProfile.plist > profile-cert0.der
 
 openssl x509 -inform DER \
   -in profile-cert0.der \
@@ -113,7 +123,7 @@ The two fingerprints must match.
 GitHub secrets are write-only, so verify the local files before uploading them.
 
 ```bash
-repo="SSWConsulting/SSW.Rewards.Mobile"
+repo="<owner>/<repo>"
 
 base64 -i apple-distribution.p12 | tr -d '\n' |
   gh secret set APPLE_CERT -R "$repo"
@@ -124,13 +134,13 @@ printf '%s' "$APPLE_CERT_PASSWORD" |
   gh secret set APPLE_CERT_PASSWORD -R "$repo"
 unset APPLE_CERT_PASSWORD
 
-printf '%s' "Apple Distribution: Superior Software for Windows Pty Ltd (B5652JTA7Q)" |
+printf '%s' "Apple Distribution: <Company Name> (<Team ID>)" |
   gh secret set APPLE_CERT_NAME -R "$repo"
 
-base64 -i "SSW Rewards.mobileprovision" | tr -d '\n' |
+base64 -i "<App Store Profile>.mobileprovision" | tr -d '\n' |
   gh secret set APPLE_PROFILE -R "$repo"
 
-printf '%s' "SSWRewards" |
+printf '%s' "<profile-name>" |
   gh secret set APPLE_PROFILE_NAME -R "$repo"
 
 gh secret list -R "$repo" | grep APPLE_
@@ -139,16 +149,82 @@ gh secret list -R "$repo" | grep APPLE_
 ### Rerun the Mobile Workflow
 
 ```bash
-gh workflow run mobile-main.yml -R SSWConsulting/SSW.Rewards.Mobile --ref main
+gh workflow run mobile-main.yml -R <owner>/<repo> --ref main
 
 gh run list \
-  -R SSWConsulting/SSW.Rewards.Mobile \
+  -R <owner>/<repo> \
   --workflow mobile-main.yml \
   --limit 3
 ```
 
 The workflow uses the `prod` GitHub environment, so build jobs may wait for environment approval
 before the iOS signing step runs.
+
+References:
+
+- [Apple - Create a certificate signing request](https://developer.apple.com/help/account/certificates/create-a-certificate-signing-request/)
+- [Apple - Certificates overview](https://developer.apple.com/help/account/certificates/certificates-overview/)
+- [Apple - Create an App Store Connect provisioning profile](https://developer.apple.com/help/account/provisioning-profiles/create-an-app-store-provisioning-profile/)
+
+## Mobile Android Signing Keystore
+
+The Android build signs the release AAB before uploading it to Google Play. In this repo the build
+expects these secrets:
+
+- `ANDROID_KEYSTORE` - base64 of the release/upload keystore file.
+- `ANDROID_KEYPASSWORD` - password for the key alias.
+- `ANDROID_KEYSTOREALIAS` - alias inside the keystore.
+- `ANDROID_KEYSTOREPASSWORD` - password for the keystore.
+
+The deploy workflow then uploads the signed AAB to Google Play using:
+
+- `GCP_SERVICE_ACCOUNT` - service account JSON for the Google Play Developer API.
+
+The current workflow uploads Android builds to the `internal` Google Play track. Moving the same
+build to open testing or production is a separate Play Console release/promotion step unless a
+dedicated workflow is added for that track.
+
+### Verify the Keystore Metadata
+
+Use metadata checks only; do not print passwords or commit the keystore.
+
+```bash
+workdir="$HOME/work/mobile-android-signing-check"
+mkdir -p "$workdir"
+chmod 700 "$workdir"
+
+# macOS:
+base64 -D -i android-keystore.base64 -o "$workdir/upload.keystore"
+# Linux:
+# base64 --decode < android-keystore.base64 > "$workdir/upload.keystore"
+chmod 600 "$workdir/upload.keystore"
+
+keytool -list -v \
+  -keystore "$workdir/upload.keystore" \
+  -alias "<key-alias>"
+```
+
+Confirm:
+
+- the alias matches `ANDROID_KEYSTOREALIAS`;
+- the certificate SHA-1/SHA-256 matches the upload certificate expected in Google Play Console;
+- the certificate validity has not expired.
+
+### Rotate or Recover Android Signing
+
+Android signing differs from iOS signing:
+
+- Google Play App Signing stores the app signing key for Play-distributed apps.
+- CI normally signs uploads with an upload key/keystore.
+- If the upload key is lost or compromised, use Google Play Console's upload key reset flow rather
+  than inventing a new key and expecting existing app updates to accept it.
+
+References:
+
+- [Android Developers - Sign your app](https://developer.android.com/studio/publish/app-signing)
+- [Google Play Help - Use Play App Signing](https://support.google.com/googleplay/android-developer/answer/9842756)
+- [Google Play Help - Set up an open, closed, or internal test](https://support.google.com/googleplay/android-developer/answer/9845334)
+- [Google Play Help - Prepare and roll out a release](https://support.google.com/googleplay/android-developer/answer/9859348)
 
 ## Admin Portal CDN Cache
 

--- a/_docs/Instructions-Deployment-Troubleshooting.md
+++ b/_docs/Instructions-Deployment-Troubleshooting.md
@@ -1,5 +1,155 @@
 # Deployment Troubleshooting
 
+## Mobile iOS Signing Certificate Expired
+
+The iOS build fails during `Build and sign` when the Apple Distribution certificate in GitHub
+Actions has expired or does not match the provisioning profile.
+
+Typical log lines:
+
+```text
+The certificate '***' has expired
+iOS code signing key '***' not found in keychain
+```
+
+GitHub uses two different Apple files:
+
+- `APPLE_CERT` - base64 of a `.p12` file containing the Apple Distribution certificate and its private key.
+- `APPLE_PROFILE` - base64 of the `SSWRewards.mobileprovision` App Store provisioning profile.
+
+A `.cer` file downloaded from Apple is not enough for `APPLE_CERT`; it does not include the
+private key. If the certificate was created by another developer, only that developer's Mac
+(or a secure backup) normally has the private key needed to export the `.p12`.
+
+### Create a New Apple Distribution Certificate
+
+Create the CSR and private key outside the repository:
+
+```bash
+workdir="$HOME/Developer/clients/ssw/work/rewards-mobile-signing-rotation/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$workdir"
+chmod 700 "$workdir"
+
+openssl genrsa -out "$workdir/apple-distribution-private.key" 2048
+chmod 600 "$workdir/apple-distribution-private.key"
+
+openssl req -new \
+  -key "$workdir/apple-distribution-private.key" \
+  -out "$workdir/apple-distribution.csr" \
+  -subj "/emailAddress=<your-ssw-email>/CN=<your-name> Apple Distribution/O=Superior Software for Windows Pty Ltd/C=AU"
+
+openssl req -in "$workdir/apple-distribution.csr" -noout -subject
+```
+
+In Apple Developer:
+
+1. Open **Certificates, Identifiers & Profiles**.
+2. Go to **Certificates** and click `+`.
+3. Select **Apple Distribution**.
+4. Upload `apple-distribution.csr`.
+5. Download the generated `.cer` file into the same `workdir`.
+
+Convert the downloaded `.cer` and private key into the `.p12` that GitHub Actions expects:
+
+```bash
+cd "$workdir"
+
+openssl x509 -inform DER \
+  -in "Apple Developer Distribution Certificate.cer" \
+  -out apple-distribution.cer.pem
+
+openssl x509 -in apple-distribution.cer.pem \
+  -noout -subject -serial -enddate -fingerprint -sha1
+
+openssl pkcs12 -export \
+  -inkey apple-distribution-private.key \
+  -in apple-distribution.cer.pem \
+  -out apple-distribution.p12 \
+  -name "Apple Distribution: Superior Software for Windows Pty Ltd (B5652JTA7Q)"
+```
+
+Use a strong export password for the `.p12`; this password becomes `APPLE_CERT_PASSWORD`.
+
+### Regenerate the App Store Provisioning Profile
+
+In Apple Developer:
+
+1. Go to **Profiles**.
+2. Open `SSWRewards` (not `SSWRewards_Dev`).
+3. Confirm it is:
+   - Platform: `iOS`
+   - Type: `App Store`
+   - App ID: `SSW Mobile App (com.SSW.SSW.Consulting)`
+4. Click **Edit**.
+5. Select the new Apple Distribution certificate.
+6. Save and download the regenerated `SSW Rewards.mobileprovision`.
+
+Verify the profile and certificate match:
+
+```bash
+security cms -D \
+  -i "SSW Rewards.mobileprovision" \
+  > SSWRewards.plist
+
+/usr/libexec/PlistBuddy -c 'Print :Name' SSWRewards.plist
+/usr/libexec/PlistBuddy -c 'Print :ExpirationDate' SSWRewards.plist
+/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' SSWRewards.plist
+
+/usr/libexec/PlistBuddy -c 'Print :DeveloperCertificates:0' SSWRewards.plist > profile-cert0.der
+
+openssl x509 -inform DER \
+  -in profile-cert0.der \
+  -noout -subject -serial -enddate -fingerprint -sha1
+
+openssl x509 \
+  -in apple-distribution.cer.pem \
+  -noout -subject -serial -enddate -fingerprint -sha1
+```
+
+The two fingerprints must match.
+
+### Update GitHub Actions Secrets
+
+GitHub secrets are write-only, so verify the local files before uploading them.
+
+```bash
+repo="SSWConsulting/SSW.Rewards.Mobile"
+
+base64 -i apple-distribution.p12 | tr -d '\n' |
+  gh secret set APPLE_CERT -R "$repo"
+
+read -rsp "p12 export password: " APPLE_CERT_PASSWORD
+printf '\n'
+printf '%s' "$APPLE_CERT_PASSWORD" |
+  gh secret set APPLE_CERT_PASSWORD -R "$repo"
+unset APPLE_CERT_PASSWORD
+
+printf '%s' "Apple Distribution: Superior Software for Windows Pty Ltd (B5652JTA7Q)" |
+  gh secret set APPLE_CERT_NAME -R "$repo"
+
+base64 -i "SSW Rewards.mobileprovision" | tr -d '\n' |
+  gh secret set APPLE_PROFILE -R "$repo"
+
+printf '%s' "SSWRewards" |
+  gh secret set APPLE_PROFILE_NAME -R "$repo"
+
+gh secret list -R "$repo" | grep APPLE_
+```
+
+### Rerun the Mobile Workflow
+
+```bash
+gh workflow run mobile-main.yml -R SSWConsulting/SSW.Rewards.Mobile --ref main
+
+gh run list \
+  -R SSWConsulting/SSW.Rewards.Mobile \
+  --workflow mobile-main.yml \
+  --limit 3
+```
+
+The workflow uses the `prod` GitHub environment, so build jobs may wait for environment approval
+before the iOS signing step runs.
+
 ## Admin Portal CDN Cache
 
 - **Manual Purge Access**: When requesting Azure staging resources access via My Access from SysAdmin, CDN purge permissions are now included.

--- a/_docs/Instructions-Deployment.md
+++ b/_docs/Instructions-Deployment.md
@@ -97,7 +97,7 @@ For manual purge steps and access notes, see Deployment Troubleshooting → [Adm
 - YAML: `.github/workflows/mobile-main.yml`
 - Trigger: Automatic on changes to the mobile app in `main`
 
-2. Pipeline builds Android & iOS artifacts. After the approval gate is granted it automatically uploads:
+2. Pipeline builds Android & iOS artifacts. After the approval gate is granted, it automatically uploads:
    - Android build to the configured Google Play testing track. Today this workflow targets `internal`.
    - iOS build to TestFlight.
 3. Testers on those tracks receive the update automatically (no manual upload required).

--- a/_docs/Instructions-Deployment.md
+++ b/_docs/Instructions-Deployment.md
@@ -12,7 +12,7 @@ workflows that call them.
 | --- | --- | --- |
 | **API - Main (Build & deploy)** | 👤 You (Run workflow) | Deploy Web API + infrastructure → staging, then approve → production |
 | **Admin - Main (Build & Deploy)** | 👤 You (Run workflow) | Deploy Admin Portal → staging, then approve → production |
-| **Mobile - Main (Build & Deploy)** | 🤖 Auto on mobile changes to `main` (or manually) | Build + ship the mobile app to Google Play / TestFlight |
+| **Mobile - Main (Build & Deploy)** | 🤖 Auto on mobile changes to `main` (or manually) | Build + ship the mobile app to Google Play / TestFlight; for iOS certificate/signing failures see [Deployment Troubleshooting](Instructions-Deployment-Troubleshooting.md#mobile-ios-signing-certificate-expired) |
 | Build and Test (Automation) | 🤖 Auto on every PR to `main` | PR quality gate — build + tests |
 | Everything else "(Automation)" | 🤖 Never run directly | Build/deploy steps invoked by the workflows above |
 
@@ -102,7 +102,8 @@ For manual purge steps and access notes, see Deployment Troubleshooting → [Adm
    - iOS build to TestFlight.
 3. Testers on those tracks receive the update automatically (no manual upload required).
 4. After beta validation passes, a separate Production approval gate promotes the build to the public stores.
-5. For tester management and promotion specifics see [Beta Testing Guide](Instructions-Beta-Testing.md)
+5. If the iOS build fails in `Build and sign` with certificate, provisioning profile, or keychain errors, see Deployment Troubleshooting → [Mobile iOS Signing Certificate Expired](Instructions-Deployment-Troubleshooting.md#mobile-ios-signing-certificate-expired).
+6. For tester management and promotion specifics see [Beta Testing Guide](Instructions-Beta-Testing.md)
 
 ### Build & Test (no deployment)
 

--- a/_docs/Instructions-Deployment.md
+++ b/_docs/Instructions-Deployment.md
@@ -97,13 +97,15 @@ For manual purge steps and access notes, see Deployment Troubleshooting → [Adm
 - YAML: `.github/workflows/mobile-main.yml`
 - Trigger: Automatic on changes to the mobile app in `main`
 
-2. Pipeline builds Android & iOS artifacts. After the beta approval gate is granted it automatically uploads:
-   - Android build to the configured Google Play beta/internal track.
+2. Pipeline builds Android & iOS artifacts. After the approval gate is granted it automatically uploads:
+   - Android build to the configured Google Play testing track. Today this workflow targets `internal`.
    - iOS build to TestFlight.
 3. Testers on those tracks receive the update automatically (no manual upload required).
-4. After beta validation passes, a separate Production approval gate promotes the build to the public stores.
+4. After beta validation passes, promote the build to open testing or production in the relevant store
+   console, or add a dedicated workflow for that target track.
 5. If the iOS build fails in `Build and sign` with certificate, provisioning profile, or keychain errors, see Deployment Troubleshooting → [Mobile iOS Signing Certificate Expired](Instructions-Deployment-Troubleshooting.md#mobile-ios-signing-certificate-expired).
-6. For tester management and promotion specifics see [Beta Testing Guide](Instructions-Beta-Testing.md)
+6. If the Android build fails around keystore signing or Play upload, see Deployment Troubleshooting → [Mobile Android Signing Keystore](Instructions-Deployment-Troubleshooting.md#mobile-android-signing-keystore).
+7. For tester management and promotion specifics see [Beta Testing Guide](Instructions-Beta-Testing.md).
 
 ### Build & Test (no deployment)
 


### PR DESCRIPTION
## Summary

- Generalises the iOS signing troubleshooting runbook so it is usable by forks and not tied to one organisation.
- Links the deployment guide to both iOS certificate/profile issues and Android keystore/Play upload issues.
- Adds Android signing guidance for keystore metadata checks, Play App Signing, upload-key recovery, and the difference between internal/open/production tracks.
- Clarifies that the current Android workflow uploads to the Google Play `internal` track and that broader public testing or production needs a Play Console promotion or dedicated workflow.

## References

- SSW Rules: https://www.ssw.com.au/rules/code-sign-and-notarize-apple-application/
- Apple CSR docs: https://developer.apple.com/help/account/certificates/create-a-certificate-signing-request/
- Android signing docs: https://developer.android.com/studio/publish/app-signing
- Google Play testing tracks: https://support.google.com/googleplay/android-developer/answer/9845334

## Checks

- `git diff --check`
- Verified remaining SSW-specific hits are the requested SSW Rules reference or unrelated existing deployment sections.
